### PR TITLE
for basic testing with geant4 10.6

### DIFF
--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,14 +35,12 @@ fwdir   product_dir scripts
 # Add the dependent product and version
 
 product          version
-larsoft          v08_56_00
+larsoft          v08_55_00_01
 genie_xsec       v3_00_04a
 sbnd_data        v01_02_00 - optional
-sbndutil         v08_56_00 - optional
-
-# list products required ONLY for the build
-# any products here must NOT have qualifiers
-cetbuildtools    v7_15_01  -   only_for_build
+sbndutil         v08_55_00 - optional
+cetbuildtools	v7_15_01   -   only_for_build
+end_product_list
 
 # We now define allowed qualifiers and the corresponding qualifiers for the dependencies.
 # Make the table by adding columns before "notes". 

--- a/ups/setup_deps
+++ b/ups/setup_deps
@@ -59,21 +59,26 @@ set_ msg5='ERROR: setup of required products has failed'
 
 echo ----------- check this block for errors -----------------------
 set_ setup_fail="false"
-set_ cetb=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $2 }' `
-set_ cetv=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $3 }' `
+set_ exit_now="false"
+set_ cetb=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $1 }' `
+set_ cetv=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $2 }' `
 #echo Found $cetb $cetv
 setup -B $cetb $cetv
 test "$?" = 0 || set_ setup_fail="true"
-setenv UPS_OVERRIDE -B
 # now get the rest of the products
 set_ cmd="$CETBUILDTOOLS_DIR/bin/set_dev_products $CETPKG_SOURCE $CETPKG_BUILD $*"
 #echo Ready to run $cmd
 source `$cmd`
+test "$?" = 0 || set_ setup_fail="true"
 #echo "$cmd returned $setup_fail"
 test "$setup_fail" = "true" && echo "$msg5"
-test "$setup_fail" = "true" && return 1
-test -e "diag_report" && cat diag_report
+test "$setup_fail" = "true" && set_ exit_now="true"
+test -e "$CETPKG_BUILD/diag_report" && cat $CETPKG_BUILD/diag_report
 echo ----------------------------------------------------------------
+
+test "${exit_now}" = "true" && test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+test "${exit_now}" = "true" && unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail set_ setenv unsetenv_ tnotnull nullout vecho_
+test "${exit_now}" = "true" && return 1
 
 # final sanity check and report
 source $CETBUILDTOOLS_DIR/bin/set_dep_check_report

--- a/ups/setup_for_development
+++ b/ups/setup_for_development
@@ -57,26 +57,33 @@ set_ msg5='ERROR: setup of required products has failed'
 
 echo ----------- check this block for errors -----------------------
 set_ setup_fail="false"
-set_ cetb=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $2 }' `
-set_ cetv=` grep only_for_build $CETPKG_SOURCE/ups/product_deps | grep cetbuildtools | awk '{ print $3 }' `
+set_ exit_now="false"
+set_ cetb=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $1 }' `
+set_ cetv=` grep -e '^[ \t]*cetbuildtools' $CETPKG_SOURCE/ups/product_deps | grep  only_for_build| awk '{ print $2 }' `
 #echo Found $cetb $cetv
 setup -B $cetb $cetv
 test "$?" = 0 || set_ setup_fail="true"
-setenv UPS_OVERRIDE -B
 # now get the rest of the products
 set_ cmd="$CETBUILDTOOLS_DIR/bin/set_dev_products $CETPKG_SOURCE $CETPKG_BUILD $*"
 #echo Ready to run $cmd
 source `$cmd`
+test "$?" = 0 || set_ setup_fail="true"
 #echo "$cmd returned $setup_fail"
 test "$setup_fail" = "true" && echo "$msg5"
-test "$setup_fail" = "true" && return 1
+test "$setup_fail" = "true" && set_ exit_now="true"
 test -e "$CETPKG_BUILD/diag_report" && cat $CETPKG_BUILD/diag_report
 echo ----------------------------------------------------------------
+
+test "${exit_now}" = "true" && test "$ss" = csh && unalias tnotnull nullout set_ vecho_ return
+test "${exit_now}" = "true" && unset ss db me thisdir msg1 msg2 msg3 msg4 msg5 setup_fail set_ setenv unsetenv_ tnotnull nullout vecho_
+test "${exit_now}" = "true" && return 1
 
 # add lib to LD_LIBRARY_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_lib
 # add bin to path
 source $CETBUILDTOOLS_DIR/bin/set_dev_bin
+# set FHICL_FILE_PATH
+source $CETBUILDTOOLS_DIR/bin/set_dev_fhicl
 # set FW_SEARCH_PATH
 source $CETBUILDTOOLS_DIR/bin/set_dev_fwsearch
 


### PR DESCRIPTION
This PR is provided so we can run the CI for geant4 10.6.  Some changes were needed to fix old files in the ups directory.  The only other change is using larsoft v08_55_00_01.

To trigger the build manually:
kx509
setup lar_ci 
trigger --build-delay 0 --cert /tmp/x509up_u1147 --version develop --workflow sbndcodestandalone_wf --revisions "SBNSoftware/sbndcode#10"  
( SBNSoftware / sbndcode # 10 )