### PR TITLE
Rename lib path names to follow the convention of full path

### DIFF
--- a/sbndcode/Geometry/CMakeLists.txt
+++ b/sbndcode/Geometry/CMakeLists.txt
@@ -1,5 +1,4 @@
 art_make(
-          LIBRARY_NAME sbnd_Geometry
           LIB_LIBRARIES larcorealg_Geometry
                         ${MF_MESSAGELOGGER}
                         cetlib
@@ -8,11 +7,10 @@ art_make(
                         ${ROOT_BASIC_LIB_LIST}
                         ${ROOT_GEOM}
           SERVICE_LIBRARIES
-                        sbnd_Geometry
+                        sbndcode_Geometry
                         larcorealg_Geometry
                         art_Framework_Services_Registry
                         canvas
-                        
                         ${FHICLCPP}
                         cetlib_except
                         ${ROOT_CORE}

--- a/sbndcode/OpDetReco/OpHit/CMakeLists.txt
+++ b/sbndcode/OpDetReco/OpHit/CMakeLists.txt
@@ -1,8 +1,6 @@
 cet_enable_asserts()
 
 art_make(
-   BASENAME_ONLY
-   LIBRARY_NAME   sbndcode_OpDetReco_OpHit
    LIB_LIBRARIES
          larana_OpticalDetector_OpHitFinder
          larcore_Geometry_Geometry_service

--- a/sbndcode/OpDetSim/CMakeLists.txt
+++ b/sbndcode/OpDetSim/CMakeLists.txt
@@ -1,9 +1,5 @@
-add_subdirectory(FlashFinder)
-
-cet_enable_asserts()
 
 art_make(
-  BASENAME_ONLY
   LIB_LIBRARIES
                     larcore_Geometry_Geometry_service
                     lardataobj_Simulation
@@ -52,51 +48,8 @@ art_make(
 install_headers()
 install_fhicl()
 install_source()
+cet_enable_asserts()
+add_subdirectory(FlashFinder)
+
 # install sbnd_pds_mapping.json with mapping of the photon detectors
 install_fw(LIST sbnd_pds_mapping.json)
-
-# # install .dat files with test bench data
-# file(GLOB dat_files *.dat)
-# install_fw(LIST ${dat_files})
-
-# simple_plugin(SimPMTSBND "module"
-#                            larcore_Geometry_Geometry_service
-#                            lardataobj_Simulation
-#                            lardata_Utilities
-#                            lardataobj_RawData
-#                            lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-#                            sbndcode_Utilities_SignalShapingServiceSBND_service
-#                            nurandom_RandomUtils_NuRandomService_service
-# 			   ${ART_FRAMEWORK_CORE}
-#                            ${ART_FRAMEWORK_PRINCIPAL}
-#                            ${ART_FRAMEWORK_SERVICES_OPTIONAL_TFILESERVICE_SERVICE}
-#                            ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-#                            canvas
-#                            ${MF_MESSAGELOGGER}
-#                            ${MF_UTILITIES}
-#                            ${FHICLCPP}
-#                            cetlib cetlib_except
-#                            ${CLHEP}
-#                            ${ROOT_BASIC_LIB_LIST}
-# )
-# 
-# simple_plugin(SimArapucaSBND "module"
-#                            larcore_Geometry_Geometry_service
-#                            lardataobj_Simulation
-#                            lardata_Utilities
-#                            lardataobj_RawData
-#                            lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-#                            sbndcode_Utilities_SignalShapingServiceSBND_service
-#                            nurandom_RandomUtils_NuRandomService_service
-#                            ${ART_FRAMEWORK_CORE}
-#                            ${ART_FRAMEWORK_PRINCIPAL}
-#                            ${ART_FRAMEWORK_SERVICES_OPTIONAL_TFILESERVICE_SERVICE}
-#                            ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-#                            canvas
-#                            ${MF_MESSAGELOGGER}
-#                            ${MF_UTILITIES}
-#                            ${FHICLCPP}
-#                            cetlib cetlib_except
-#                            ${CLHEP}
-#                            ${ROOT_BASIC_LIB_LIST}
-# )

--- a/sbndcode/OpDetSim/FlashFinder/CMakeLists.txt
+++ b/sbndcode/OpDetSim/FlashFinder/CMakeLists.txt
@@ -1,7 +1,7 @@
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR} )
 art_make( 
 	  LIB_LIBRARIES
-		   sbnd_Geometry
+		   sbndcode_Geometry
 		   larcore_Geometry_Geometry_service
 		   lardataobj_RecoBase
 		   ${LARDATA_LIB}
@@ -28,7 +28,7 @@ art_make(
 		   ${ROOT_BASIC_LIB_LIST}
           MODULE_LIBRARIES
 		   sbndcode_OpDetSim_FlashFinder
-		   sbnd_Geometry
+		   sbndcode_Geometry
 		   larcore_Geometry_Geometry_service
 		   lardataobj_RecoBase
 		   ${LARDATA_LIB}

--- a/sbndcode/gallery/galleryAnalysis/CMakeLists.txt
+++ b/sbndcode/gallery/galleryAnalysis/CMakeLists.txt
@@ -81,7 +81,7 @@ set(GALLERY_LIBS MF_MessageLogger fhiclcpp canvas cetlib_except cetlib gallery)
 set(ROOT_CORELIBS Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc pthread)
 set(LARSOFTOBJ_LIBS nusimdata_SimulationBase larcoreobj_SummaryData lardataobj_RawData lardataobj_OpticalDetectorData lardataobj_RecoBase lardataobj_AnalysisBase lardataobj_MCBase lardataobj_Simulation)
 
-set(SBNDGEOMETRY_LIBS larcorealg_Geometry sbnd_Geometry)
+set(SBNDGEOMETRY_LIBS larcorealg_Geometry sbndcode_Geometry)
 set(SBNDDETINFO_LIBS lardataalg_DetectorInfo)
 
 ################################################################################

--- a/sbndcode/gallery/python/SBNDutils.py
+++ b/sbndcode/gallery/python/SBNDutils.py
@@ -27,7 +27,7 @@ def loadSBNDgeometry(config = None, registry = None):
   SourceCode = LArSoftUtils.SourceCode # alias
   
   SourceCode.loadHeaderFromUPS('sbndcode/Geometry/ChannelMapSBNDAlg.h')
-  SourceCode.loadLibrary('sbnd_Geometry')
+  SourceCode.loadLibrary('sbndcode_Geometry')
   return LArSoftUtils.loadGeometry \
     (config=config, registry=registry, mapping=ROOT.geo.ChannelMapSBNDAlg)
 # loadSBNDgeometry()

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -21,7 +21,7 @@ cet_test(geometry_sbnd_test
   SOURCES geometry_sbnd_test.cxx
   DATAFILES test_geometry_sbnd.fcl
   TEST_ARGS ./test_geometry_sbnd.fcl
-  LIBRARIES sbnd_Geometry
+  LIBRARIES sbndcode_Geometry
             larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
@@ -37,7 +37,7 @@ cet_test(geometry_sbnd_test
 # this uses BOOST for the test
 cet_test(geometry_iterator_sbnd_test
   SOURCES geometry_iterator_sbnd_test.cxx
-  LIBRARIES sbnd_Geometry
+  LIBRARIES sbndcode_Geometry
             larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
@@ -52,7 +52,7 @@ cet_test(geometry_iterator_sbnd_test
 # unit test (use the hard-coded configuration for SBND v0 geometry)
 cet_test(geometry_iterator_loop_sbnd_test
   SOURCES geometry_iterator_loop_sbnd_test.cxx
-  LIBRARIES sbnd_Geometry
+  LIBRARIES sbndcode_Geometry
             larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}


### PR DESCRIPTION
Some libraries had custom names or they just weren't using the full path in their name.

Amongst these libs are
- the ones for OpDetSim
- the new OpHit Module
- the geometry lib

This PR is only about infrastructure not about content. 