### PR TITLE
Create g4_with_opticalLibrary.fcl

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_with_opticalLibrary.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_with_opticalLibrary.fcl
@@ -1,0 +1,4 @@
+#include "standard_g4_sbnd.fcl"
+
+# To use Optical Library fast mode:
+services.PhotonVisibilityService: @local::sbnd_library_vuv_vis_prop_timing_photonvisibilityservice


### PR DESCRIPTION
configuration file to run the optical-library mode for the fast optical simulation