### PR TITLE
[MCP2020A] Moving SBND to 10 ms and adding calorimetry constants

### DIFF
--- a/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
@@ -6,7 +6,7 @@ sbnd_calorimetryalgdata:    @local::standard_calorimetryalgdata
 #values below aren't correct
 #sbnd_calorimetryalgdata.CalAreaConstants: [ 0.31e-2 , 0.31e-2 , 0.830e-2 ]
 sbnd_calorimetryalgmc:      @local::standard_calorimetryalgmc
-sbnd_calorimetryalgmc.CalAreaConstants:  [ 0.02354, 0.02130, 0.02354 ]
+sbnd_calorimetryalgmc.CalAreaConstants:  [ 0.0200906, 0.0200016, 0.0201293 ]
 # amplitude constants below are arbitrary and have not yet been tuned
 sbnd_calorimetryalgmc.CalAmpConstants:   	[ 0.588726e-3, 0.588726e-3, 1.18998e-3 ]
 

--- a/sbndcode/Utilities/detectorproperties_sbnd.fcl
+++ b/sbndcode/Utilities/detectorproperties_sbnd.fcl
@@ -5,7 +5,7 @@ BEGIN_PROLOG
 sbnd_detproperties:                   @local::standard_detproperties
 sbnd_detproperties.Temperature:       88.4  #(measured in ArgoNeut)
 sbnd_detproperties.Efield:           [0.5,0.666,0.8]  #reasonable values 
-sbnd_detproperties.Electronlifetime:  3.0e3  # microseconds
+sbnd_detproperties.Electronlifetime:  10.0e3  # microseconds
 sbnd_detproperties.ElectronsToADC:    6.29778e-3 
 sbnd_detproperties.NumberTimeSamples: 3000
 sbnd_detproperties.TimeOffsetU:       0.


### PR DESCRIPTION
This should update the electron lifetime and the calorimetry calibration constants