### PR TITLE
[MCP2020A] Fix SBND Neutrino Timing

### DIFF
--- a/sbndcode/JobConfigurations/base/prodgenie_bnb_nu_cosmic_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_bnb_nu_cosmic_sbnd.fcl
@@ -30,5 +30,6 @@ outputs.out1.fileName: "prodgenie_bnb_nu_cosmic_sbnd_%p-%tc.root"
 
 physics.producers.generator: @local::sbnd_genie_simple
 physics.producers.generator.GlobalTimeOffset: 0.
-physics.producers.generator.RandomTimeOffset: 1280.
+physics.producers.generator.RandomTimeOffset: 1596.
+physics.producers.generator.SpillTimeConfig: ""
 physics.producers.generator.TopVolume: "volCryostat"


### PR DESCRIPTION
The last time I ran SBND neutrino timing config, there was a bug in the seeding of the random generator for specifying the neutrino interaction time when simulating the BNB bucket structure.

As far as I can tell from digging around the code/config, this bug has not been fixed (if I am wrong, please someone let me know).

This pull request thus turns off the BNB bucket structure, drawing the time instead from a uniform distribution. It also fixes the width of that distribution to be the width of the BNB spill.