### PR TITLE
[MCP2020A] Fix Intime Cosmic MC Generation

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_sce_3drift_windows_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_sce_3drift_windows_simphotontime_filter.fcl
@@ -1,0 +1,4 @@
+#include "g4_simphotontime_filter.fcl"
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -11,8 +11,6 @@ physics.producers.largeant: {
 
 physics.simulate: [ rns, larg4outtime, largeant, mcreco ]
 
-physics.outputs.out1: {
-   outputCommands: [ "keep *_*_*_*",
+outputs.out1.outputCommands: [ "keep *_*_*_*",
                      "drop *_larg4intime_*_*",
                      "drop *_larg4outtime_*_*"]
-}

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -1,7 +1,18 @@
-#include "filterssimphotontime_sbnd.fcl"
 #include "standard_g4_sbnd.fcl"
 
-physics.filters.filter: @local::sbnd_timefilterssimphotontime
-physics.simulate: [ rns, largeant, filter, mcreco ]
+physics.producers.larg4outtime: @local::physics.producers.largeant
+physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]
 
-outputs.out1.SelectEvents: [ "simulate" ]
+physics.producers.largeant: {
+  module_type: "MergeSimSources"
+  InputSourcesLabels: [ "larg4intime","larg4outtime"]
+  TrackIDOffsets: [ 10000000,20000000 ]
+}
+
+physics.simulate: [ rns, larg4outtime, largeant, mcreco ]
+
+physics.outputs.out1: {
+   outputCommands: [ "keep *_*_*_*",
+                     "drop *_larg4intime_*_*",
+                     "drop *_larg4outtime_*_*"]
+}

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -16,7 +16,9 @@ physics.producers.larg4intime: @local::sbnd_largeant
 physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
 physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime 
 
-physics.simulate: [ generator, GenInTimeSorter, larg4intime, timefilter, rns ]
+physics.producers.corsika: @local::physics.producers.generator
+
+physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
 outputs.out1.SelectEvents: [ "simulate" ]
 
 physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"] 

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -15,7 +15,6 @@ services: {
 physics.producers.larg4intime: @local::sbnd_largeant
 physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
 physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime 
-physics.filters.timefilter.Debug: true
 
 physics.simulate: [ generator, GenInTimeSorter, larg4intime, timefilter, rns ]
 outputs.out1.SelectEvents: [ "simulate" ]

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -1,11 +1,29 @@
 #include "filtersgenintime_sbnd.fcl"
-#include "prodcorsika_cosmics_proton.fcl"
+#include "filterssimphotonlitetime_sbnd.fcl"
+#include "largeantmodules_sbnd.fcl"
 
-process_name: CosmicsCorsikaCMCGenAndG4InTime
+#include "prodcorsika_cosmics_proton.fcl"
 
 # Ported from uBooNE gen-in-time fhicl for use by SBND
 # by Gray Putnam <grayputnam@uchicago.edu>
 
-physics.filters.filter: @local::sbnd_filtergenintime
-physics.simulate: [ generator, filter, rns ]
+services: {
+  @table::services
+  @table::sbnd_g4_services
+}
+
+physics.producers.larg4intime: @local::sbnd_largeant
+physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
+physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime 
+physics.filters.timefilter.Debug: true
+
+physics.simulate: [ generator, GenInTimeSorter, larg4intime, timefilter, rns ]
 outputs.out1.SelectEvents: [ "simulate" ]
+
+physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"] 
+physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
+
+process_name: CosmicsCorsikaCMCGenAndG4InTime
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd.fcl"

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -21,7 +21,6 @@ physics.producers.corsika: @local::physics.producers.generator
 physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
 outputs.out1.SelectEvents: [ "simulate" ]
 
-physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"] 
 physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
 
 process_name: CosmicsCorsikaCMCGenAndG4InTime

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -21,6 +21,7 @@ physics.producers.corsika: @local::physics.producers.generator
 physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
 outputs.out1.SelectEvents: [ "simulate" ]
 
+physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"] 
 physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
 
 process_name: CosmicsCorsikaCMCGenAndG4InTime

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce.fcl
@@ -27,3 +27,4 @@ physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
 process_name: CosmicsCorsikaCMCGenAndG4InTime
 
 #include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd.fcl"

--- a/sbndcode/SimulationFilters/filterssimphotonlitetime_sbnd.fcl
+++ b/sbndcode/SimulationFilters/filterssimphotonlitetime_sbnd.fcl
@@ -1,0 +1,16 @@
+BEGIN_PROLOG
+
+sbnd_timefilterssimphotonlitetime: { 
+   module_type: "FilterSimPhotonLiteTime"
+   SimPhotonsLiteCollectionLabel: larg4intime
+   # Currently in overlay generation, events are generated
+   # uniformly in a window [0, 1596ns] to approximate a beam spill.
+   # Add a little width here to up that width to 2000ns
+   TimeWindows: [ [-202, 1798] ] # ns
+   # 10 PE
+   MinTotalPhotons: 10 
+   # Reflected photons are not used in trigger -- we can ignore them
+   UseReflectedPhotons: false
+}
+
+END_PROLOG


### PR DESCRIPTION
At some point in the past, the configurations I developed to generate intime-cosmic MC in SBND were changed (and then moved into the new JobConfigurations directory). Some of these updates changed the way the generation is implemented to something inconsistent with the original implementation.

This update, to the best of my ability, reverts those changes. I have dug around the ICARUS implementation (which was left intact) to find the configuration to use. I cannot completely vouch for this configs correctness relative to the original implementation, but it appears to run, etc.