### PR TITLE
Fix for event display Ortho3D and Display3D views

### DIFF
--- a/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
@@ -20,10 +20,9 @@
 #   update for LArSoft 5.12
 # 20160712 (petrillo@fnal.gov) [v1.2]
 #   added simulation services
-# 20200726 (d.brailsford@lancaster.ac.uk) [v1.3]
-#   Swap simulation services for the plain services (the new noise service not being loaded correctly causes the event display to die)
+#
 
-#include "services_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
 #include "evdservices_base.fcl"
 #include "calorimetry.fcl"
 
@@ -71,7 +70,7 @@ sbnd_rawdrawingopt.TotalTicks: 3000
 
 sbnd_disp:                                                                       
 {                                                                                  
-                                               @table::sbnd_services
+                                               @table::sbnd_simulation_services
   ColorDrawingOptions:                         @local::sbnd_colordrawingopt
   SimulationDrawingOptions:                    @local::sbnd_simdrawingopt
   RawDrawingOptions:                           @local::sbnd_rawdrawingopt

--- a/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
@@ -1,7 +1,7 @@
 #
 # File:    evdservices_sbnd.fcl
 # Purpose: service settings for SBND event display in LArSoft
-# Version: 1.2
+# Version: 1.4
 # 
 # Provides:
 # 
@@ -20,6 +20,10 @@
 #   update for LArSoft 5.12
 # 20160712 (petrillo@fnal.gov) [v1.2]
 #   added simulation services
+# 20200726 (d.brailsford@lancaster.ac.uk) [v1.3]
+#   Swap simulation services for the plain services (the new noise service not being loaded correctly causes the event display to die)
+# 20201028 (icaza@fnal.gov) [v1.4]
+#   Swap simulation services for g4 simulation services, avoiding the noise service issue whilst enabling back the 3D functionalities
 #
 
 #include "simulationservices_sbnd.fcl"

--- a/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/evdservices_sbnd.fcl
@@ -69,8 +69,8 @@ sbnd_evdlayoutopt.ChangeWire:               1
 sbnd_rawdrawingopt.TotalTicks: 3000
 
 sbnd_disp:                                                                       
-{                                                                                  
-                                               @table::sbnd_simulation_services
+{
+					       @table::sbnd_g4_services
   ColorDrawingOptions:                         @local::sbnd_colordrawingopt
   SimulationDrawingOptions:                    @local::sbnd_simdrawingopt
   RawDrawingOptions:                           @local::sbnd_rawdrawingopt
@@ -81,8 +81,6 @@ sbnd_disp:
   InfoTransfer:                                @local::sbnd_infotransfer
   EventDisplay:                                @local::sbnd_evd
 }
-
-
 
 
 #######################################


### PR DESCRIPTION
This addresses issue #56 and brings back the functionality of the 3D display views.

Currently its only calling the g4 services, instead of the full simulation services.