### PR TITLE
[MCP2020A] Fix reco2_sce fcls 

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -158,6 +158,7 @@ physics:
   fmatch:              @local::sbnd_simple_flashmatch
   fmatchSCE:           @local::sbnd_simple_flashmatch
   opt0finder:          @local::sbnd_opt0_finder_one_to_many
+  opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
  }
 
  #define the producer and filter modules for this path, order matters,
@@ -277,6 +278,8 @@ physics.producers.pandoraSCECalo.FieldDistortionEfield:          true
 physics.producers.pandoraSCECalo.TrackIsFieldDistortionCorrected:true
 physics.producers.pandoraSCEPid.TrackModuleLabel:                   "pandoraSCETrack"
 physics.producers.pandoraSCEPid.CalorimetryModuleLabel:             "pandoraSCECalo"
+
+physics.producers.opt0finderSCE.SliceProducer: "pandoraSCE"
 
 physics.producers.fmatchSCE.PandoraProducer: "pandoraSCE"
 physics.producers.fmatchSCE.TrackProducer: "pandoraSCETrack"

--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
@@ -12,8 +12,8 @@
 
 process_name: Reco2
 
-physics.reco2_sce: [@sequence::physics.reco2, flashmatch,
-            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, fmatchSCE]
+physics.reco2_sce: [@sequence::physics.reco2, opt0finder,
+            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, fmatchSCE, opt0finderSCE]
 
 physics.trigger_paths: [ reco2_sce ]
 


### PR DESCRIPTION
Fixes issue #63 by updating the naming of `flashmatch` to `opt0finder`. I think the name of the module was updated previously but the change was not propagated to the `sce` fcls.

I also took the opportunity to add the flash matching to SCE corrected Pandora, in line with what is done for `fmatch` and `fmatchSCE`

@marcodeltutto should check this is correct before it is merged. 