### PR TITLE
OpHits Times When Running with 3-Drifts

### DIFF
--- a/sbndcode/OpDetReco/OpFlash/SBNDFlashAna_module.cc
+++ b/sbndcode/OpDetReco/OpFlash/SBNDFlashAna_module.cc
@@ -128,10 +128,24 @@ void SBNDFlashAna::analyze(art::Event const& e)
   //   throw std::exception();
   // }
 
+
+  art::Handle<std::vector<recob::OpHit>> ophit_h;
+  e.getByLabel("ophitpmt", ophit_h);
+  if(!ophit_h.isValid()){
+    std::cout << "Invalid producer for recob::OpHit: " << "ophitpmt" << ". Ignoring." << std::endl;
+  }
+  std::vector<art::Ptr<recob::OpHit>> ophit_v;
+  art::fill_ptr_vector(ophit_v, ophit_h);
+  // for (auto oh : ophit_v) {
+  //   std::cout << "ophit time " << oh->PeakTime() << std::endl;
+  // }
+
+
+
   _run    = e.id().run();
   _subrun = e.id().subRun();
   _event  = e.id().event();
-  
+
   for (size_t l = 0; l < _flash_label_v.size(); l++) {
     art::Handle<std::vector<recob::OpFlash>> flash_h;
     e.getByLabel(_flash_label_v[l], flash_h);

--- a/sbndcode/OpDetReco/OpFlash/job/run_flashfinder.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/run_flashfinder.fcl
@@ -43,7 +43,7 @@ outputs:
     fileName:    "flashfinder-art.root"
     dataTier:    "reconstructed"
     compressionLevel: 1
-    SelectEvents: ["reco"]
+    # SelectEvents: ["reco"]
  }
 }
 

--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -196,6 +196,10 @@ namespace opdet {
 
     // These is the storage pointer we will put in the event
     std::unique_ptr< std::vector< recob::OpHit > >
+    HitPtrFinal(new std::vector< recob::OpHit >);
+
+    // These is a temporary storage pointer
+    std::unique_ptr< std::vector< recob::OpHit > >
     HitPtr(new std::vector< recob::OpHit >);
 
     std::vector< const sim::BeamGateInfo* > beamGateArray;
@@ -272,10 +276,27 @@ namespace opdet {
                    clockData,
                    calibrator);
       // for (auto h : *HitPtr)
-      //   std::cout << "> ophit time " << h.PeakTime() << ", area " << h.Area() << ", pe " << h.PE() << std::endl;
+      //   std::cout << "> ophit time " << h.PeakTime()
+      //             << ", corrected " << h.PeakTime() - clockData.TriggerTime()
+      //             << ", area " << h.Area()
+      //             << ", pe " << h.PE() << std::endl;
+    }
+
+    // Now correct the time. Unfortunately, there are no setter methods for OpHits,
+    // so we have to make a new OpHit vector.
+    for (auto h : *HitPtr) {
+      (*HitPtrFinal).emplace_back(h.OpChannel(),
+                                  h.PeakTime() + clockData.TriggerTime(),
+                                  h.PeakTimeAbs(),
+                                  h.Frame(),
+                                  h.Width(),
+                                  h.Area(),
+                                  h.Amplitude(),
+                                  h.PE(),
+                                  0.0);
     }
     // Store results into the event
-    evt.put(std::move(HitPtr));
+    evt.put(std::move(HitPtrFinal));
 
   }
 


### PR DESCRIPTION
Fixes #67.

The OpHit code in `larana` calculates the OpHit time by removing the trigger time:
https://github.com/LArSoft/larana/blob/develop/larana/OpticalDetector/OpHitFinder/OpHitAlg.cxx#L76

This is not needed, so it is now added back in the SBNDOpHitFinder module.

Tested with both the 1-drift and 3-drift configurations and appears to give the correct results.