### PR TITLE
Rename the SO name of NuAnaAlg, include the full path to header, cleanup

### DIFF
--- a/sbndcode/MCTruthExtractor/CMakeLists.txt
+++ b/sbndcode/MCTruthExtractor/CMakeLists.txt
@@ -1,44 +1,11 @@
-#
-#art_make_library( LIBRARY_NAME NuAna
-#                  SOURCE NuAna_module
-#                  LIBRARIES
-#                        NuAna
-#                        Geometry
-#                        Geometry_service
-#                        Simulation
-#                        Utilities
-#                        TimeService_service
-#                        Filters
-#                        RawData
-#                        SignalShapingServiceT1034_service
-#                        nugen_NuReweight_art
-#                        nusimdata_SimulationBase
-#                        ${ART_FRAMEWORK_CORE}
-#                        ${ART_FRAMEWORK_PRINCIPAL}
-#                        ${ART_FRAMEWORK_SERVICES_REGISTRY}
-#                        ${ART_ROOT_IO_TFILE_SUPPORT} ${ROOT_CORE}
-#                        ${ART_ROOT_IO_TFILESERVICE_SERVICE}
-#                        ${ART_FRAMEWORK_SERVICES_OPTIONAL_RANDOMNUMBERGENERATOR_SERVICE}
-#                        art_Persistency_Common canvas
-#                        art_Persistency_Provenance canvas
-#                        art_Utilities canvas
-#                        ${MF_MESSAGELOGGER}
-#                        
-#                        ${FHICLCPP}
-#                        cetlib cetlib_except
-#                        ${CLHEP}
-#                        ${ROOT_BASIC_LIB_LIST}
-#)
-
-# simple_plugin()
-
 add_subdirectory(alg)
 include_directories ( $ENV{GENIE_INC}/GENIE )
 
 art_make(
-          LIBRARY_NAME Ntuples          
-          MODULE_LIBRARIES 
-            NuAnaAlg
+            LIBRARY_NAME Ntuples
+            MODULE_LIBRARIES
+            sbndcode_MCTruthExtractor_alg
+
             larcore_Geometry_Geometry_service
             # TimeService_service
             ${ART_ROOT_IO_TFILESERVICE_SERVICE}
@@ -59,7 +26,7 @@ art_make(
             art_Utilities
             canvas
             ${MF_MESSAGELOGGER}
-            
+
             ${FHICLCPP}
             cetlib cetlib_except
             ${CLHEP}
@@ -68,5 +35,3 @@ art_make(
 
 install_headers()
 install_fhicl()
-# install_source()
-

--- a/sbndcode/MCTruthExtractor/NuAna_module.cc
+++ b/sbndcode/MCTruthExtractor/NuAna_module.cc
@@ -3,7 +3,7 @@
 
 /// Framework includes
 #include "art/Framework/Core/EDAnalyzer.h"
-#include "art/Framework/Core/ModuleMacros.h" 
+#include "art/Framework/Core/ModuleMacros.h"
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Handle.h"
 #include "art/Framework/Principal/SubRun.h"
@@ -39,8 +39,8 @@
 #include <iostream>
 #include <fstream>
 
-// LArSoft includes                                                                                         
-#include "alg/NuAnaAlg.h"
+// LArSoft includes
+#include "sbndcode/MCTruthExtractor/alg/NuAnaAlg.h"
 
 
 
@@ -52,7 +52,7 @@ namespace sbnd{
     explicit NuAna(fhicl::ParameterSet const& pset);
     virtual ~NuAna(){};
 
-    void beginJob();    
+    void beginJob();
     // void reconfigure(fhicl::ParameterSet const& pset);
     void analyze(const art::Event& evt);
     void beginSubRun (const art::SubRun& subrun);
@@ -70,7 +70,7 @@ namespace sbnd{
     std::string fMode;      // mode is beam mode, nu or nubar
     double fBaseline;       // baseline is 100, 470, or 600 meters
     bool fFullOscTrue;      // fullosctrue is obvious.
-    
+
     //Variables needed from the .fcl file to get things out of the event
     std::string fGenieModuleLabel;
     std::string fLarg4ModuleLabel;
@@ -95,10 +95,10 @@ namespace sbnd{
     TTree* fTreeTot;    //This tree stores all the important information from an event
     // TTree* PoTTree;     //This tree only stores the POT of the file, nothing else.
 
-    std::vector<std::vector<float> > eventWeights;  
+    std::vector<std::vector<float> > eventWeights;
 
     std::vector<float>     neutMom;      // Neutrino Momentum
-    
+
     // Information about the lepton:
     // muons are tracked till they exit, electrons are just the initial
     // particle's position and momemtum (since they are showering)
@@ -106,16 +106,16 @@ namespace sbnd{
     std::vector< std::vector<float> > leptonMom; // mom of lepton till it exits
     double Elep;                // Energy of the produced lepton
     double thetaLep, phiLep;    // angles in the detector of the produced lepton
-    
-    
+
+
     int NPi0FinalState;     // Number of neutral pions in Final State Particles
     int NGamma;             // Number of gammas in the Final State Particles
     int NChargedPions;      // Number of charged pions in the Final State Particles
-    
+
     bool foundAllPhotons;   // True by default, goes to false ONLY if there
                             // are final state photons that the alg didn't
                             // find in the larg4 particle list
-                             
+
     // Keep track of where photons convert and what their energy is.
     // Except in categories 1, 3, 5, these are probably not filled.
     // The vectors here labeled p1 and p2 keep track only of photons from neutral pion decay
@@ -123,24 +123,24 @@ namespace sbnd{
     std::vector< std::vector<float> > p1PhotonConversionMom;  // Store the momentum 4vector at conversion
     std::vector< std::vector<float> > p2PhotonConversionPos;  // Store the position of conversion
     std::vector< std::vector<float> > p2PhotonConversionMom;  // Store the momentum 4vector at conversion
-    
+
     // These vectors keep track of any other photon conversions we need to look at.
     std::vector< std::vector<float> > miscPhotonConversionPos;  // Store the position of conversion
     std::vector< std::vector<float> > miscPhotonConversionMom;    // Store the momentum 4vector at conversion
-    
+
     std::vector< std::vector < std::vector<float> > > chargedPionPos; // store position of charged pions
     std::vector< std::vector < std::vector<float> > > chargedPionMom; // store momentum of charged pions
     std::vector< int > chargedPionSign;  // Sign (+/-) of the charged pions, one to one with above vectors
-    
+
     // Track any pions
     // Only keeping the position of decay and the momentum at decay
     std::vector< std::vector<float> > pionPos;  // Position at decay
-    std::vector< std::vector<float> > pionMom;  // Momentum at decay                            
-    
+    std::vector< std::vector<float> > pionMom;  // Momentum at decay
+
     //Info from the genie truth:
     std::vector<int>    GeniePDG;       // Contains the pdg of the FSP in genie generated
     std::vector<std::vector<float>> GenieMomentum;
-    std::vector<std::string> GenieProc; // Contains the process information 
+    std::vector<std::string> GenieProc; // Contains the process information
     // Genie Reweight vectors:
     std::vector< std::vector< float > > genieReweights;
 
@@ -152,7 +152,7 @@ namespace sbnd{
     int isCC;                       // isCC event? isCC == 1 means CC, isCC == 0 means NC
     int mode;                       // beam mode
     double enugen;                  // Energy of the neutrino
-    double nuleng;                  // Length the neutrino traveled. 
+    double nuleng;                  // Length the neutrino traveled.
     std::vector<float> vertex;                // Vertex location
     std::vector<float> neutVertexInWindow;    // origin of neutrino in flux window
     std::vector<float> ParentVertex;          // Parent Vertex (not in detector)
@@ -166,17 +166,17 @@ namespace sbnd{
     For more information on some of the neutrino parentage information, start here
     http://genie.hepforge.org/doxygen/html/classgenie_1_1flux_1_1GSimpleNtpNuMI.html
      */
-    
+
     // #---------------------------------------------------------------
     // # End of the list of variables for the tree
     // #---------------------------------------------------------------
-    
+
 
   }; // end of class NuAna
 // }
 
 // namespace sbnd{
-  
+
   NuAna::NuAna(fhicl::ParameterSet const& pset)
     : EDAnalyzer(pset)
     , fMode             (pset.get< std::string >              ("Mode"))
@@ -192,7 +192,7 @@ namespace sbnd{
   {
 
     // This function sets up the ttrees
-    // get access to the TFile service  
+    // get access to the TFile service
     art::ServiceHandle<art::TFileService> tfs;
 
     // PoTTree  = tfs->make<TTree>("POT", "POT");
@@ -208,9 +208,9 @@ namespace sbnd{
     gROOT -> ProcessLine(".L loadLibs.C+");
 
     fTreeTot = tfs->make<TTree>("EventsTot", "Event info for ALL types");
-    
+
     fTreeTot->Branch("POT",&POT,"POT/D");
-    
+
     // Neutrino/event variables:
     fTreeTot->Branch("iflux",    &iflux,    "iflux/I");
     fTreeTot->Branch("nuchan",   &nuchan,   "nuchan/I");
@@ -227,10 +227,10 @@ namespace sbnd{
 
     // Genie Variables
     fTreeTot->Branch("GeniePDG",       &GeniePDG);
-    fTreeTot->Branch("GenieMomentum", "std::vector<std::vector<float> >",  &GenieMomentum);  
+    fTreeTot->Branch("GenieMomentum", "std::vector<std::vector<float> >",  &GenieMomentum);
     fTreeTot->Branch("GenieProc",      &GenieProc);
           // "var","std::vector<std::vector<float> >",&vec
-    
+
     // Flux variables:
     fTreeTot->Branch("ptype", &ptype, "ptype/I");
     fTreeTot->Branch("tptype",&tptype,"tptype/I");
@@ -258,7 +258,7 @@ namespace sbnd{
     fTreeTot->Branch("ChargedPionPos","std::vector<std::vector< std::vector<float> > >",&chargedPionPos, 32000,0);
     fTreeTot->Branch("ChargedPionMom","std::vector<std::vector< std::vector<float> > >",&chargedPionMom, 32000,0);
     fTreeTot->Branch("ChargedPionSign","ChargedPionSign",&chargedPionSign, 32000,0);
-    
+
 
     if (fXSecReweight){
       fTreeTot->Branch("MultiWeight","MultiWeight",&eventWeights,32000,0);
@@ -277,7 +277,7 @@ namespace sbnd{
     std::cout << "This set of events is ";
     if (fFullOscTrue) std::cout << "fullosc" << std::endl;
     else std::cout << "not fullosc" << std::endl;
-    std::cout << "The baseline for this detector is " 
+    std::cout << "The baseline for this detector is "
               << fBaseline << "m." << std::endl << std::endl;
 
     reset();
@@ -300,8 +300,8 @@ namespace sbnd{
 
 
   void NuAna::beginSubRun(const art::SubRun& subrun){
-    
-    // Go through POTSummary objects 
+
+    // Go through POTSummary objects
     art::Handle< sumdata::POTSummary > potHandle;
     subrun.getByLabel(fGenieModuleLabel, potHandle);
     const sumdata::POTSummary& potSum = (*potHandle);
@@ -310,9 +310,9 @@ namespace sbnd{
     return;
   }
   void NuAna::reset(){
-    
+
     // This method takes ANYTHING that goes into the ntuple and sets it to default.
-    
+
     // Start by making sure the appropriate vectors are cleared and emptied:
     eventWeights.clear();
     leptonPos.clear();
@@ -328,11 +328,11 @@ namespace sbnd{
     chargedPionPos.clear();
     chargedPionMom.clear();
     chargedPionSign.clear();
-    
+
     GeniePDG.clear();
     GenieMomentum.clear();
     GenieProc.clear();
-    
+
     NPi0FinalState  = 0;
     NChargedPions   = 0;
     NGamma          = 0;
@@ -359,7 +359,7 @@ namespace sbnd{
     isCC     = -999;             // isCC event? isCC == 1 means CC, isCC == 0 means NC
     mode     = -999;             // beam mode
     enugen   = -999;             // Energy of the neutrino (both)
-    nuleng   = -999;             // Length the neutrino traveled.    
+    nuleng   = -999;             // Length the neutrino traveled.
     Elep     = -999;
     thetaLep = -999;
     phiLep   = -999;
@@ -370,7 +370,7 @@ namespace sbnd{
     // for (auto & weight : eventReweight)
     // {
     //   weight.clear();
-    //   weight.resize(1000); 
+    //   weight.resize(1000);
     // }
 
     return;
@@ -379,10 +379,10 @@ namespace sbnd{
   void NuAna::analyze(const art::Event& evt){
 
     this -> reset();
-    
-    //get the MC generator information out of the event       
+
+    //get the MC generator information out of the event
     //these are all handles to mc information.
-    art::Handle< std::vector<simb::MCTruth> > mclistGENIE;  
+    art::Handle< std::vector<simb::MCTruth> > mclistGENIE;
     art::Handle< std::vector<simb::MCParticle> > mclistLARG4;
     art::Handle< std::vector<simb::MCFlux> > mcflux;
     art::Handle< std::vector<simb::GTruth> > mcgtruth;
@@ -397,12 +397,12 @@ namespace sbnd{
     evt.getByLabel(fGenieModuleLabel,mclistGENIE);
     evt.getByLabel(fGenieModuleLabel,mcflux);
     evt.getByLabel(fGenieModuleLabel,mcgtruth);
-    if (!fFullOscTrue) 
+    if (!fFullOscTrue)
         evt.getByLabel(fLarg4ModuleLabel,mclistLARG4);
 
     // contains the mctruth object from genie
     art::Ptr<simb::MCTruth> mc(mclistGENIE,0);
-    
+
     // contains the mcflux object
     art::Ptr<simb::MCFlux > flux(mcflux,0);
 
@@ -413,8 +413,8 @@ namespace sbnd{
 
     // Contains the neutrino info
     simb::MCNeutrino neutrino = mc -> GetNeutrino();
-    
-    // std::cout << "The interaction info is: \n" 
+
+    // std::cout << "The interaction info is: \n"
     //           << "  gtruth->ftgtPDG................." << gtruth->ftgtPDG << "\n"
     //           << "  gtruth->ftgtZ..................." << gtruth->ftgtZ << "\n"
     //           << "  gtruth->ftgtA..................." << gtruth->ftgtA << "\n"
@@ -429,7 +429,7 @@ namespace sbnd{
 
     // Now start packing up the variables to fill the tree
     // In general, have the algorithm do this:
-    
+
 
     // get the basic neutrino info:
     fNuAnaAlg.packNeutrinoInfo( &neutrino,
@@ -446,9 +446,9 @@ namespace sbnd{
 
 
     // Pack up the flux info:
-    fNuAnaAlg.packFluxInfo(     flux, 
+    fNuAnaAlg.packFluxInfo(     flux,
                                 ptype, tptype, ndecay,
-                                neutVertexInWindow,  
+                                neutVertexInWindow,
                                 ParentVertex,
                                 nuParentMomAtDecay,
                                 nuParentMomAtProd,
@@ -468,11 +468,11 @@ namespace sbnd{
                                 NPi0FinalState,
                                 NGamma,
                                 NChargedPions);
-    
+
 
     // pack up the larg4 photon info:
     if(!fFullOscTrue)
-        fNuAnaAlg.packLarg4Info(mclistLARG4, isCC, NPi0FinalState, 
+        fNuAnaAlg.packLarg4Info(mclistLARG4, isCC, NPi0FinalState,
                                 NGamma, NChargedPions,
                                 leptonPos,
                                 leptonMom,
@@ -491,14 +491,14 @@ namespace sbnd{
 
 
 
-    
+
 
     // If needed, set up the weights.
-    
+
     if (fFluxReweight){
         fNuAnaAlg.packFluxWeight(flux, eventWeights);
     }
-    
+
     // Find a new weight for this event:
     // std::vector<std::vector<float> > weights;
     if (fXSecReweight){

--- a/sbndcode/MCTruthExtractor/alg/CMakeLists.txt
+++ b/sbndcode/MCTruthExtractor/alg/CMakeLists.txt
@@ -1,10 +1,7 @@
 include_directories ( $ENV{GENIE_INC}/GENIE )
 
-
-
 art_make(
-          LIBRARY_NAME NuAnaAlg
-          LIB_LIBRARIES 
+            LIB_LIBRARIES
             larcore_Geometry_Geometry_service
             larcorealg_Geometry
             nugen_NuReweight_art
@@ -19,7 +16,7 @@ art_make(
             art_Utilities
             canvas
             ${MF_MESSAGELOGGER}
-            
+
             ${FHICLCPP}
             cetlib cetlib_except
             ${CLHEP}
@@ -28,6 +25,4 @@ art_make(
           )
 
 install_headers()
-# install_fhicl()
-# install_source()
 

--- a/sbndcode/MCTruthExtractor/alg/NuAnaAlg.cxx
+++ b/sbndcode/MCTruthExtractor/alg/NuAnaAlg.cxx
@@ -1,6 +1,4 @@
-
-#include "NuAnaAlg.h"
-
+#include "sbndcode/MCTruthExtractor/alg/NuAnaAlg.h"
 ////#define CUSTOM_NUTOOLS
 
 namespace sbnd{
@@ -14,7 +12,7 @@ namespace sbnd{
   // }
 
   void NuAnaAlg::configureGeometry(art::ServiceHandle<geo::Geometry> geom){
-  
+
     xlow  = - geom -> DetHalfWidth();
     xhigh = geom -> DetHalfWidth();
     ylow  = - geom -> DetHalfHeight();
@@ -36,7 +34,7 @@ namespace sbnd{
   }
 
 /**
-* 
+*
 * This function configures the reweighting machinery.  I am guess that,
 * due to the overhead in configuring the genie reweighting, it's faster
 * to make one reweight object for each weight needed.
@@ -54,66 +52,66 @@ namespace sbnd{
     //             << " equal to the number of boundaries (range).\n";
     //   exit(-1);
     // }
- 
+
     // don't forget the last vector with all of the weights
     reweightVector.back().resize(reweightingSigmas.front().size());
     for (auto & ptr : reweightVector.back()) ptr = new rwgt::NuReweight;
 
     for (unsigned int i_weight = 0; i_weight < reweightingSigmas.front().size(); ++i_weight)
     {
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
       //     -> ReweightNCEL(reweightingSigmas[kNCEL][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightQEMA(reweightingSigmas[kQEMA][i_weight]);
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
       //     -> ReweightQEVec(reweightingSigmas[kQEVec][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightResGanged(reweightingSigmas[kResGanged][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightCCRes(reweightingSigmas[kCCRes][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNCRes(reweightingSigmas[kNCRes][i_weight]);
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
           // -> ReweightCoh(reweightingSigmas[kCoh][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNonResRvp1pi(reweightingSigmas[kNonResRvp1pi][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNonResRvbarp1pi(reweightingSigmas[kNonResRvbarp1pi][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNonResRvp2pi(reweightingSigmas[kNonResRvp2pi][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNonResRvbarp2pi(reweightingSigmas[kNonResRvbarp2pi][i_weight]);
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
           // -> ReweightResDecay(reweightingSigmas[kResDecay][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightNC(reweightingSigmas[kNC][i_weight]);
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
           // -> ReweightDIS(reweightingSigmas[kDIS][i_weight]);
-      reweightVector.back().at(i_weight) 
+      reweightVector.back().at(i_weight)
           -> ReweightDISnucl(reweightingSigmas[kDISnucl][i_weight]);
-      // reweightVector.back().at(i_weight) 
+      // reweightVector.back().at(i_weight)
       //     -> ReweightAGKY(reweightingSigmas[kAGKY][i_weight]);
     }
 
 
     // loop over the physical knobs and expand to the correct number of weights
     for (unsigned int i_reweightingKnob = 0;
-         i_reweightingKnob < reweightVector.size()-1; 
-         i_reweightingKnob++) 
+         i_reweightingKnob < reweightVector.size()-1;
+         i_reweightingKnob++)
     {
 
-      // resize this row to accomodate all of the weight points 
+      // resize this row to accomodate all of the weight points
       reweightVector[i_reweightingKnob].resize(
             reweightingSigmas[i_reweightingKnob].size());
 
-      for (unsigned int weight_point = 0; 
-           weight_point < reweightingSigmas[i_reweightingKnob].size(); 
+      for (unsigned int weight_point = 0;
+           weight_point < reweightingSigmas[i_reweightingKnob].size();
            weight_point++){
 
         // Figure out what is the value going in to this reweight
-        // double stepSize = (reweightingSigmas[i_reweightingKnob] 
+        // double stepSize = (reweightingSigmas[i_reweightingKnob]
         //                - rangeLow[i_reweightingKnob])/(nWeights-1);
-        // double reweightingValue = rangeLow[i_reweightingKnob] 
+        // double reweightingValue = rangeLow[i_reweightingKnob]
         //                         + weight_point*stepSize;
 
         reweightVector[i_reweightingKnob][weight_point] = new rwgt::NuReweight;
@@ -217,7 +215,7 @@ namespace sbnd{
 
     TRandom rand;
     rand.SetSeed(RandSeed);
-    
+
     reweightingSigmas.resize(kNReWeights);
     for (unsigned int i = 0; i < reweightingSigmas.size(); ++i)
     {
@@ -275,18 +273,18 @@ namespace sbnd{
            i_reweightingKnob < reweightVector[i_weight].size();
            i_reweightingKnob ++)
       {
-        weights[i_weight][i_reweightingKnob] 
-          = reweightVector[i_weight][i_reweightingKnob] 
+        weights[i_weight][i_reweightingKnob]
+          = reweightVector[i_weight][i_reweightingKnob]
             -> CalcWeight(*mctruth,*gtruth);
       }
     }
-    
+
     return;
   }
 
 
   // get the basic neutrino info:
-  void NuAnaAlg::packNeutrinoInfo(simb::MCNeutrino * neutrino, 
+  void NuAnaAlg::packNeutrinoInfo(simb::MCNeutrino * neutrino,
                                   int& nuchan,
                                   int& inno,
                                   double& enugen,
@@ -306,7 +304,7 @@ namespace sbnd{
     vertex.resize(3);
 
     // 1000 is the offset value used for NUANCE
-    nuchan = (neutrino->InteractionType() - 1000); 
+    nuchan = (neutrino->InteractionType() - 1000);
     inno = neutrino->Nu().PdgCode();
     enugen = neutrino->Nu().E();
     // Is it a CC or NC interaction?
@@ -332,7 +330,7 @@ namespace sbnd{
 
   }
 
-  void NuAnaAlg::packFluxInfo(art::Ptr<simb::MCFlux > flux, 
+  void NuAnaAlg::packFluxInfo(art::Ptr<simb::MCFlux > flux,
                               int& ptype, int& tptype, int& ndecay,
                               std::vector<float>& neutVertexInWindow,
                               std::vector<float>& ParentVertex,
@@ -412,7 +410,7 @@ namespace sbnd{
           art::Handle< std::vector<simb::MCParticle> > & mclistLARG4,
           int PDG) const
   {
-    
+
     for(unsigned int i = 0; i < mclistLARG4 -> size(); i ++){
       art::Ptr<simb::MCParticle> particle(mclistLARG4,i);
       if ( particle -> PdgCode() == PDG){
@@ -430,17 +428,17 @@ namespace sbnd{
   }
 
   // Method to take in a photon and determine where it started converting.
-  // Looks at the photon's energy at each step.  
+  // Looks at the photon's energy at each step.
   void NuAnaAlg::GetPhotonConversionInfo(art::Ptr<simb::MCParticle> photon,
                                       TLorentzVector& ConversionPos,
                                       TLorentzVector& ConversionMom){
-    // Just loop over the photons Trajectory points in momentum space 
+    // Just loop over the photons Trajectory points in momentum space
     // and wait for a change. If it gets through the whole trajectory,
     // the conversion point must be the end of the trajectory.
-    // When it changed, return the trajectory point immediately 
+    // When it changed, return the trajectory point immediately
     // before to get the last point of the photon that's not converted.
-    
-    // Going to be watching for changes in energy, 
+
+    // Going to be watching for changes in energy,
     // so we'd better know the start energy.
     double E = photon->E(0);
     // std::cout << "Starting Energy is " << E << std::endl;
@@ -454,8 +452,8 @@ namespace sbnd{
     //     << photon->Position().Y() << ", "
     //     << photon->Position().Z() << ", "
     //     << photon->Position().T() << ") " << std::endl;
-    //Catch some special cases first. 
-    if (photon->NumberTrajectoryPoints() == 0) return;   
+    //Catch some special cases first.
+    if (photon->NumberTrajectoryPoints() == 0) return;
     if (photon->NumberTrajectoryPoints() == 1){
       ConversionPos = photon->EndPosition();
       ConversionMom = photon->EndMomentum();
@@ -477,12 +475,12 @@ namespace sbnd{
       if (photon->E(i) != E) {
         //then the energy is different.  Must be scattering or something.
         //set the conversion points and bail!
-        ConversionPos = photon->Position(i); 
+        ConversionPos = photon->Position(i);
         ConversionMom = photon->Momentum(i-1); //<- This i OK since i starts at 1.
     //      std::cout << "Conversion Pos is " << ConversionPos << std::endl;
         return;
       }
-    } 
+    }
 
     // If we made it out here, the photon must have ended without changing energy.
     // So send back end position, momentum.
@@ -525,11 +523,11 @@ namespace sbnd{
       miscPhotonConversionPos.reserve(NGamma);
       miscPhotonConversionMom.reserve(NGamma);
 
-      // some counting variables to ensure everything is done correctly 
+      // some counting variables to ensure everything is done correctly
       int nPrimaryLepton(0);  // should be == 1 at the end
       int nPrimaryGamma(0);   // should be == NGamma at the end
       int nPrimaryPi0(0);     // should be == NPi0FinalState
-      
+
       chargedPionPos.resize(NChargedPions);
       chargedPionMom.resize(NChargedPions);
 
@@ -541,7 +539,7 @@ namespace sbnd{
 
 
         if (particle -> Mother() == 0 ){ // then this is a primary
-          // std::cout << "On particle " << particle -> TrackId() 
+          // std::cout << "On particle " << particle -> TrackId()
           //           << " with PDG " << particle -> PdgCode() << std::endl;
 
           // For older files, set the nPrimaryLepton up since it didn't track neutrinos
@@ -589,7 +587,7 @@ namespace sbnd{
             if ( particle -> NumberDaughters() == 2){
               // Get the info:
               TLorentzVector conversionPoint, conversionMom;
-              art::Ptr<simb::MCParticle> daughter0 
+              art::Ptr<simb::MCParticle> daughter0
                   = getParticleByID(mclarg4,particle->Daughter(0));
               GetPhotonConversionInfo(daughter0, conversionPoint,conversionMom);
               // Pack it into the vectors
@@ -606,7 +604,7 @@ namespace sbnd{
               p2PhotonConversionPos.push_back(empty4Vector);
               p2PhotonConversionMom.push_back(empty4Vector);
               pack4Vector(conversionPoint,p2PhotonConversionPos.back());
-              pack4Vector(conversionMom,  p2PhotonConversionMom.back());              
+              pack4Vector(conversionMom,  p2PhotonConversionMom.back());
             }
             else{ // this is the "dalitz" decay
               // Only take the photon, but be sure to find it
@@ -614,7 +612,7 @@ namespace sbnd{
               p2PhotonConversionPos.push_back(empty4Vector);
               p2PhotonConversionMom.push_back(empty4Vector);
               for (int daughter = 0; daughter < 3; daughter ++ ){
-                art::Ptr<simb::MCParticle> daughterParticle 
+                art::Ptr<simb::MCParticle> daughterParticle
                   = getParticleByID(mclarg4,particle->Daughter(daughter));
                 if (daughterParticle->PdgCode() == 22) {
                   GetPhotonConversionInfo(daughterParticle,
@@ -628,7 +626,7 @@ namespace sbnd{
                 }
               }
             }
-            
+
           }
 
           if (abs(particle -> PdgCode()) == 211)  // charged pion
@@ -670,7 +668,7 @@ namespace sbnd{
     }
   } // end of packLarg4Info
 
-  void NuAnaAlg::pack4Vector(const TLorentzVector& input, 
+  void NuAnaAlg::pack4Vector(const TLorentzVector& input,
                              std::vector<float>& output) const{
     if (output.size() != 4) output.resize(4);
     output[0] = input.E();
@@ -679,7 +677,7 @@ namespace sbnd{
     output[3] = input.Z();
     return;
   }
-  void NuAnaAlg::pack3Vector(const TVector3& input, 
+  void NuAnaAlg::pack3Vector(const TVector3& input,
                              std::vector<float>& output) const{
     if (output.size() != 3) output.resize(3);
     output[0] = input.X();
@@ -694,8 +692,8 @@ namespace sbnd{
                             std::vector<std::vector<float>>& eventReweight)
     {
       // This is getting the flux weights from the flux object.
-      // It's a total hack, it's hardcoded, and requires a custom version of 
-      // the nutools software.  
+      // It's a total hack, it's hardcoded, and requires a custom version of
+      // the nutools software.
       eventReweight.clear();
       eventReweight.resize(7);
       for (int i = 0; i < 7; i ++)
@@ -718,21 +716,8 @@ namespace sbnd{
       std::cerr << "You are asking to pack flux weights but the version "
                 << "of nutools you use does not appear to support it.\n";
       return;
-    }   
+    }
 
 #endif
 
 } // end of namespace sbnd
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/sbndcode/MCTruthExtractor/alg/NuAnaAlg.h
+++ b/sbndcode/MCTruthExtractor/alg/NuAnaAlg.h
@@ -1,5 +1,5 @@
 #ifndef SBND_NUANA_ALG_H
-#define SBND_NUANA_ALG_H 
+#define SBND_NUANA_ALG_H
 
 
 #include "art/Framework/Services/Registry/ServiceHandle.h"
@@ -20,18 +20,18 @@
 
 namespace sbnd{
 
-  enum reweight {kNCEL, kQEMA, kQEVec, kResGanged, kCCRes, kNCRes, 
+  enum reweight {kNCEL, kQEMA, kQEVec, kResGanged, kCCRes, kNCRes,
         kCoh, kNonResRvp1pi, kNonResRvbarp1pi, kNonResRvp2pi,
-        kNonResRvbarp2pi, kResDecay, kNC, kDIS, kDISnucl, 
+        kNonResRvbarp2pi, kResDecay, kNC, kDIS, kDISnucl,
         kAGKY, kNReWeights};
-  
+
   class NuAnaAlg
   {
   public:
 
     NuAnaAlg();
     // ~NuAnaAlg();
-  
+
     void configureGeometry(art::ServiceHandle<geo::Geometry> );
 
     void configureReWeight(const std::vector<reweight> &,
@@ -49,11 +49,11 @@ namespace sbnd{
     unsigned int prepareSigmas(int, unsigned int,
                             std::vector<std::vector<float> > & );
 
-    void parseWeights(const std::vector<std::string> &, 
+    void parseWeights(const std::vector<std::string> &,
                             std::vector<reweight> &);
 
     // get the basic neutrino info:
-    void packNeutrinoInfo(simb::MCNeutrino * neutrino, 
+    void packNeutrinoInfo(simb::MCNeutrino * neutrino,
                             int& nuchan,
                             int& inno,
                             double& enugen,
@@ -66,7 +66,7 @@ namespace sbnd{
                             std::vector<float>& vertex);
 
     // Pack up the flux info:
-    void packFluxInfo(art::Ptr<simb::MCFlux >  flux, 
+    void packFluxInfo(art::Ptr<simb::MCFlux >  flux,
                             int& ptype, int& tptype, int& ndecay,
                             std::vector<float>& neutVertexInWindow,
                             std::vector<float>& ParentVertex,


### PR DESCRIPTION
`libNuAnaAlg.so` is awfully unspecific.

I've removed the lib name instruction so that the shared object of NuAnaAlg has the full path, just like the rest of shared objects.

Cleanup a bit here and there.