### PR TITLE
Fix to Python utilities for ROOT 6.22

### DIFF
--- a/sbndcode/gallery/python/LArSoftUtils.py
+++ b/sbndcode/gallery/python/LArSoftUtils.py
@@ -73,7 +73,7 @@ def loadGeometry(config=None, registry=None, mapping=None):
     mapping = ROOT.geo.ChannelMapStandardAlg
   SourceCode.loadHeaderFromUPS("larcorealg/Geometry/StandaloneGeometrySetup.h")
   SourceCode.loadLibrary("larcorealg_Geometry")
-  service = ROOT.lar.standalone.SetupGeometry(mapping)(geometryConfig)
+  service = ROOT.lar.standalone.SetupGeometry[mapping](geometryConfig)
   if registry: registry.register(serviceName, service)
 
   # make it easy to print points and vectors in python

--- a/sbndcode/gallery/python/galleryUtils.py
+++ b/sbndcode/gallery/python/galleryUtils.py
@@ -59,6 +59,9 @@ class HandleMaker:
        )
     # if
     HandleMaker.AlreadyMade.add(klass)
+    # if already there
+    return event.getValidHandle[klass] if event \
+      else ROOT.gallery.Event.getValidHandle[klass]
   # __call__()
   
   @staticmethod
@@ -275,7 +278,7 @@ class ConfigurationHelper:
       assert default is not None
       klass = default.__class__
     # first try to directly return the key
-    try: return self.config.get(klass)(key)
+    try: return self.config.get[klass](key)
     except Exception: pass
     # if that failed, act depending on the default value
     if default is None: raise KeyError(key)
@@ -355,7 +358,7 @@ class ConfigurationClass:
   def __init__(self, configPath):
     self.config = loadConfiguration(configPath)
   def paramsFor(self, FHiCLpath):
-    return self.config.get(ROOT.fhicl.ParameterSet)(FHiCLpath)
+    return self.config.get[ROOT.fhicl.ParameterSet](FHiCLpath)
   def service(self, serviceName):
     return self.paramsFor("services." + serviceName)
   def producer(self, moduleName):


### PR DESCRIPTION
This PR contains fixes to the galley-python interface to work with ROOT 6.22 (which is the ROOT version used since LArSoft v09_18).
Same as SBNSoftware/icarusalg#20.