### PR TITLE
Fixed optrigger alg to produce uniformly-sized waveforms, cleaned up a few snippets, and set readout length to 12us

### DIFF
--- a/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
+++ b/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
@@ -21,7 +21,6 @@ struct TriggerPrimitive {
   raw::TimeStamp_t start;
   raw::TimeStamp_t finish;
   raw::Channel_t channel;
-
 };
 
 // Local static functions
@@ -71,19 +70,13 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   if (fTriggerRangesPerChannel.count(channel) == 0) {
     fTriggerRangesPerChannel[channel] = std::vector<std::array<raw::TimeStamp_t,2>>();
   }
-
+  
   // get the threshold -- first check if channel is Arapuca or PMT
-  bool is_arapuca = false;
   std::string opdet_type = fOpDetMap.pdType(channel);
-  if (opdet_type == "bar" ||
-      opdet_type == "xarapucaprime" ||
-      opdet_type == "xarapuca" ||
-      opdet_type == "xarapucaT1" ||
-      opdet_type == "xarapucaT2" ||
-      opdet_type == "arapucaT1" ||
-      opdet_type == "arapucaT2") {
-    is_arapuca = true;
-  }
+  bool is_arapuca = false;
+  if( opdet_type.find("xarapuca") != std::string::npos || 
+      opdet_type.find("arapuca")  != std::string::npos ){
+    is_arapuca = true; }
   int threshold = is_arapuca ? fConfig.TriggerThresholdADCArapuca() : fConfig.TriggerThresholdADCPMT(); 
   int polarity = is_arapuca ? fConfig.PulsePolarityArapuca() : fConfig.PulsePolarityPMT(); 
 
@@ -107,10 +100,10 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   // if start is past end of waveform, we can return
   if (start_i >= adcs.size()) return;
 
-  raw::TimeStamp_t end = tick_to_timestamp(clockData, waveform.TimeStamp(), adcs.size() - 1);
   // get the end time
-  // size_t end_i = end > trigger_window[1] ? adcs.size()-1 : (size_t)((trigger_window[1] - start) / optical_period(clockData));
+  raw::TimeStamp_t end = tick_to_timestamp(clockData, waveform.TimeStamp(), adcs.size() - 1);
   size_t end_i = end < trigger_window[1] ? adcs.size()-1 : (size_t)((trigger_window[1] - start) / optical_period(clockData));
+ 
   // fix rounding error...
   if (IsTriggerEnabled(clockData,
                        detProp,
@@ -164,15 +157,16 @@ bool opDetSBNDTriggerAlg::IsChannelMasked(raw::Channel_t channel) const {
   // mask by optical detector type
   std::string opdet_type = fOpDetMap.pdType(channel);
   if (opdet_type == "bar" && fConfig.MaskLightBars() /* RIP */) return true;
-  if (opdet_type == "pmt" && fConfig.MaskPMTs()) return true;
-  if (opdet_type == "barepmt" && fConfig.MaskBarePMTs()) return true;
+  if (opdet_type == "pmt_coated" && fConfig.MaskPMTs()) return true;
+  if (opdet_type == "bar_uncoated" && fConfig.MaskBarePMTs()) return true;
   if (opdet_type == "xarapucaprime" && fConfig.MaskXArapucaPrimes()) return true;
   if (opdet_type == "xarapuca" && fConfig.MaskXArapucas()) return true;
+  if (opdet_type == "xarapuca_vuv" && fConfig.MaskXArapucas()) return true;
+  if (opdet_type == "xarapuca_vis" && fConfig.MaskXArapucas()) return true;
   if (opdet_type == "xarapucaT1" && fConfig.MaskXArapucas()) return true;
   if (opdet_type == "xarapucaT2" && fConfig.MaskXArapucas()) return true;
   if (opdet_type == "arapucaT1" && fConfig.MaskArapucaT1s()) return true;
   if (opdet_type == "arapucaT2" && fConfig.MaskArapucaT2s()) return true;
-  
   return false;
 }
 
@@ -264,14 +258,23 @@ std::array<double, 2> opDetSBNDTriggerAlg::TriggerEnableWindow(detinfo::Detector
     // Every reasonable configuration I have seen has setup the trigger time 
     // to be at t=0. If some configuration breaks this invariant, I am sorry, I 
     // did my best.
-    start = clockData.TriggerOffsetTPC() - 1 /* Give 1us of wiggle room*/;
-    end = start + detProp.ReadOutWindowSize() * clockData.TPCClock().TickPeriod() + 1 /* take back the wiggle room */;
+    //start = clockData.TriggerOffsetTPC() - 1; /* Give 1us of wiggle room*/;
+    //end = start + detProp.ReadOutWindowSize() * clockData.TPCClock().TickPeriod() + 1; /* take back the wiggle room */;
+    
+    // Mar 2021:
+    // Enable triggers for 1 full drift period prior to + throughout main drift window.
+    // For some reason, drift period is not accessible from ClocksData nor DetProp... (?!)
+    // Hard-coding for now (TODO: FIX!!!)
+    double drift  = 1300; // 1.3 ms
+    double readout= detProp.ReadOutWindowSize() * clockData.TPCClock().TickPeriod();
+    start = clockData.TriggerOffsetTPC() - drift;
+    end = clockData.TriggerOffsetTPC() + readout;
   }
   else {
     start = fConfig.TriggerEnableWindowStart();
     end = fConfig.TriggerEnableWindowStart() + fConfig.TriggerEnableWindowLength();
   }
-
+    
   return {{start, end}};
 }
 
@@ -323,69 +326,99 @@ double opDetSBNDTriggerAlg::ReadoutWindowPostTriggerBeam(raw::Channel_t channel)
 
 std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detinfo::DetectorClocksData const& clockData,
                                                                            const raw::OpDetWaveform &waveform) const {
+  
+  // Vector of "triggered" OpDetWaveforms
   std::vector<raw::OpDetWaveform> ret;
+  
+  // Get the trigger times we found earlier for this channel
   raw::Channel_t channel = waveform.ChannelNumber();
-  // if (channel > (unsigned)fOpDetMap.size()) return {};
-
   const std::vector<raw::TimeStamp_t> &trigger_times = GetTriggerTimes(channel);
+  if( trigger_times.size() == 0 ) return ret;
 
-  double readout_window_pre_trigger = ReadoutWindowPreTrigger(channel);
-  double readout_window_post_trigger = ReadoutWindowPostTrigger(channel);
-
-  double beam_readout_window_pre_trigger = ReadoutWindowPreTriggerBeam(channel);
-  double beam_readout_window_post_trigger = ReadoutWindowPostTriggerBeam(channel);
-  double beam_trigger_time = fConfig.BeamTriggerTime();
-
+  // Extract waveform of raw ADC counts 
   const std::vector<raw::ADC_Count_t> &adcs = waveform; // upcast to get adcs
-  unsigned trigger_i = 0;
   raw::OpDetWaveform this_waveform;
-  bool was_triggering = false;
-  for (size_t i = 0; i < adcs.size(); i++) {
+
+  // Set the pre- and post-readout sizes
+  // NOTE: Using same readout window size for everything
+  //       as of Mar 2021. Eventually we might want to shrink
+  //       the readout for out-of-time stuff.
+  double    preTrig	= ReadoutWindowPreTrigger(channel);
+  double    postTrig	= ReadoutWindowPostTrigger(channel);
+  double    ro_length	= preTrig+postTrig;			// microseconds
+  unsigned  ro_samples  = ro_length/optical_period(clockData);	// samples
+  double    beamTrigTime= fConfig.BeamTriggerTime();		// should be 0
+  //double preTrigBeam	= ReadoutWindowPreTriggerBeam(channel); // (not used)
+  //double postTrigBeam	= ReadoutWindowPostTriggerBeam(channel);// (not used)
+  //double ro_length_beam = preTrigBeam+postTrigBeam;		// (not used)
+  //unsigned ro_samples_beam= ro_length_beam/optical_period(clockData); 
+  
+  // Are beam triggers enabled?
+  bool	has_beam_trigger = fConfig.BeamTriggerEnable();
+
+  // --------------------------------------------
+  // Scan the waveform
+  unsigned trigger_i	= 0;
+  double  next_trig	= trigger_times[trigger_i];
+  double  end_time	= tick_to_timestamp(clockData,waveform.TimeStamp(), adcs.size()-1);
+  bool	  isReadingOut	= false;
+
+  for(size_t i=0; i<adcs.size(); i++){
     double time = tick_to_timestamp(clockData, waveform.TimeStamp(), i);
 
-    // first, scroll to the next readout window that ends after this time
-    while (trigger_i < trigger_times.size() && time >= trigger_times[trigger_i] + readout_window_post_trigger) {
-      trigger_i += 1;
-    } 
-    // see if we are reading out
-    bool has_next_trigger = trigger_i < trigger_times.size();
-    bool has_beam_trigger = fConfig.BeamTriggerEnable();
+    // if we're out of triggers or nearing the end of the waveform, break
+    if( trigger_i >= trigger_times.size() ) break;
+    if( time >= end_time - ro_length ) break;
+    
+    bool  isTriggering	= false;
+    // if we're near a trigger time, we're triggering
+    if( time >= (next_trig-preTrig) &&  time < (next_trig+postTrig))
+      isTriggering = true;
+    //
+    // if beam trigger is enabled, then we will ALWAYS read out
+    // a window around the beam time, so ensure that no triggers 
+    // prior to this overlap into this region
+    if( has_beam_trigger ){
+      if( time >= (beamTrigTime-preTrig-ro_length) &&
+	  time < beamTrigTime-preTrig ) {
+	isTriggering = false; 
+      } else 
+      if( time >= (beamTrigTime-preTrig) && time < (beamTrigTime+postTrig)) {
+	isTriggering = true;
+      }
+    }
 
-    bool is_triggering = false;
-    // check next trigger
-    if (has_next_trigger) {
-      if (time >= trigger_times[trigger_i] - readout_window_pre_trigger &&
-          time < trigger_times[trigger_i] + readout_window_post_trigger) {
-            is_triggering = true;
-      }
-    }
-    // otherwise check beam trigger
-    if (!is_triggering && has_beam_trigger) {
-      if (time >= beam_trigger_time - beam_readout_window_pre_trigger &&
-          time < beam_trigger_time + beam_readout_window_post_trigger) {
-        is_triggering = true;
-      }
-    }
-    // We were triggering and we still are! Add this adc count to the list
-    if (is_triggering && was_triggering) {
-      this_waveform.push_back(adcs[i]); 
-    } 
-    // No longer triggering -- save the waveform
-    else if (!is_triggering && was_triggering) {
-      ret.push_back(std::move(this_waveform));
-    }
-    // New Trigger! make a new OpDetWaveform
-    else if (is_triggering && !was_triggering) {
+    // start new readout
+    if( !isReadingOut && isTriggering ) {
       this_waveform = raw::OpDetWaveform(time, channel); 
       this_waveform.push_back(adcs[i]);
+      isReadingOut = true;
     }
-    // last adc -- save the waveform
-    if (is_triggering && i+1 == adcs.size()) {
+    // if alraedy reading out, keep going!
+    else if( isReadingOut && this_waveform.size() < ro_samples ){
+      this_waveform.push_back(adcs[i]);
+    } 
+    // once we've saved a full readout window, package the 
+    // waveform and reset to start looking for next trigger
+    else if( isReadingOut && this_waveform.size() >= ro_samples ){
       ret.push_back(std::move(this_waveform));
+      isReadingOut = false;
+      // keep in mind some triggers could have happened during
+      // the readout, so skip ahead to the next one coming up.
+      for(size_t j=trigger_i; j<trigger_times.size(); j++){
+	if( trigger_times.at(j) >= time ){
+	  next_trig = trigger_times.at(j);
+	  trigger_i = j;
+	  break;
+	}
+      }
     }
- 
-    was_triggering = is_triggering;
-  }
+
+  }//endloop over ADCs
+
+  //std::cout<<"We saved a total of "<<ret.size()<<" opdetwaveforms\n";
+  //for(size_t i=0; i<ret.size(); i++) std::cout<<"   - timestamp "<<ret.at(i).TimeStamp()<<"   size "<<ret.at(i).Waveform().size()<<"\n";
+  
   return ret;
 }
 

--- a/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
+++ b/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
@@ -74,9 +74,7 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   // get the threshold -- first check if channel is Arapuca or PMT
   std::string opdet_type = fOpDetMap.pdType(channel);
   bool is_arapuca = false;
-  if( opdet_type.find("xarapuca") != std::string::npos || 
-      opdet_type.find("arapuca")  != std::string::npos ){
-    is_arapuca = true; }
+  if( opdet_type.find("arapuca") != std::string::npos ) is_arapuca = true; 
   int threshold = is_arapuca ? fConfig.TriggerThresholdADCArapuca() : fConfig.TriggerThresholdADCPMT(); 
   int polarity = is_arapuca ? fConfig.PulsePolarityArapuca() : fConfig.PulsePolarityPMT(); 
 
@@ -158,7 +156,7 @@ bool opDetSBNDTriggerAlg::IsChannelMasked(raw::Channel_t channel) const {
   std::string opdet_type = fOpDetMap.pdType(channel);
   if (opdet_type == "bar" && fConfig.MaskLightBars() /* RIP */) return true;
   if (opdet_type == "pmt_coated" && fConfig.MaskPMTs()) return true;
-  if (opdet_type == "bar_uncoated" && fConfig.MaskBarePMTs()) return true;
+  if (opdet_type == "pmt_uncoated" && fConfig.MaskBarePMTs()) return true;
   if (opdet_type == "xarapucaprime" && fConfig.MaskXArapucaPrimes()) return true;
   if (opdet_type == "xarapuca" && fConfig.MaskXArapucas()) return true;
   if (opdet_type == "xarapuca_vuv" && fConfig.MaskXArapucas()) return true;

--- a/sbndcode/OpDetSim/optriggeralg_sbnd.fcl
+++ b/sbndcode/OpDetSim/optriggeralg_sbnd.fcl
@@ -9,9 +9,9 @@ sbnd_optrigger_alg:
   BeamTriggerEnable: true
   BeamTriggerTime: 0.
   TriggerEnableWindowIsTPCReadoutWindow: true
-  ReadoutWindowPreTrigger: 1
-  ReadoutWindowPostTrigger: 3
-  ReadoutWindowPreTriggerBeam: 1
-  ReadoutWindowPostTriggerBeam: 23
+  ReadoutWindowPreTrigger: 1 #[us]
+  ReadoutWindowPostTrigger: 11 #[us]
+  ReadoutWindowPreTriggerBeam: 1 #[us] (currently not used; using uniform readout length for all triggers)
+  ReadoutWindowPostTriggerBeam: 23 #[us] (currently not used; using uniform readout length for all triggers)
 }
 END_PROLOG


### PR DESCRIPTION
While testing changes to the TPC readout I noticed the optical trigger alg was creating waveforms of various lengths instead of a uniform size of 4us. I restructured this part of the code so that triggered waveforms are all of a single size. Other than that, the functionality should be the same. My understanding is eventually we'll want to change this alg so that a threshold met in one detector triggers *all* of them to read out at the same time, but that goes beyond the scope here.

The trigger enable window is now set to start accepting triggers a full drift period (~1.3ms) before the start of the TPC readout, which is required in order to be able to match to every track in the TPC.

Also made minor changes to a few other places in the code and added "xarapuca_vuv" and "xarapuca_vis" to the channel mask (since I believe these are now the names of those guys?).

Finally, the default readout length was increased from 4us to 12us, since the 4us number is outdated.