### PR TITLE
update CI cfg file

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -620,8 +620,7 @@ STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=180:1400
-# memoery upper limit updated on 10180514
+cpu_usage_range=500:1400
 mem_usage_range=2200000:4100003
 
 script=%(EXPSCRIPT_SBNDCODE)s


### PR DESCRIPTION
update cpu_usage_range lower limit for nucosmics_detsim_quick_test_sbndcode regression test.
CPU usage lower limit is above 500 since a while now, see [here](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/statistic_details?platform=Linux+3.10.0-1160.21.1.el7.x86_64&phase=ci_tests&buildtype=slf7+e19%3Aprof&test=nucosmics_detsim_quick_test_sbndcode&stat=rusage_scaled_user_cpu&daterange=&daterange=04%2F23%2F2021&submit=Update)
This PR is also intended to test Jenkins/GitHub integration.