### PR TITLE
Add 1-drift services file for backwards compatibility

### DIFF
--- a/sbndcode/LArSoftConfigurations/1drift_services_sbnd_legacy.fcl
+++ b/sbndcode/LArSoftConfigurations/1drift_services_sbnd_legacy.fcl
@@ -1,0 +1,9 @@
+# Include this file at the bottom of any fhicl that is consuming MC files generated using the
+# default settings (single drift window, no front/back porch) prior to v09_22_00.
+
+#include "1drift_services_sbnd.fcl"
+services.DetectorPropertiesService.NumberTimeSamples: 3000
+services.DetectorPropertiesService.ReadOutWindowSize: 3000
+services.DetectorClocksService.FramePeriod:           1250 # [us]
+
+


### PR DESCRIPTION
Just adding a small fhicl file to use in case anybody is processing older MC, made prior to the default drift window and readout length changes. We'll probably want to eventually remove this file down the line.