### PR TITLE
Commissioning HitDumper Updates

### DIFF
--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -70,6 +70,7 @@
 #include <cmath>
 
 const int kMaxHits       = 30000; ///< maximum number of hits
+const int kMaxSamples    = 5001; ///< maximum number of samples
 //const int kMaxAuxDets = 100;
 //const unsigned short kMaxTkIDs = 100;
 const int kMaxCHits      = 1000;  ///< maximum number of CRT hits
@@ -139,23 +140,23 @@ private:
   double _evttime;                     ///< The event time number
   int _t0;                             ///< The t0
 
-  int    _nhits;                       ///< Number of reco hits in the event
-  int    _hit_cryostat[kMaxHits];      ///< Cryostat where the hit belongs to
-  int    _hit_tpc[kMaxHits];           ///< TPC where the hit belongs to
-  int    _hit_plane[kMaxHits];         ///< Plane where the hit belongs to
-  int    _hit_wire[kMaxHits];          ///< Wire where the hit belongs to
-  int    _hit_channel[kMaxHits];       ///< Channel where the hit belongs to
-  double _hit_peakT[kMaxHits];         ///< Hit peak time
-  double _hit_charge[kMaxHits];        ///< Hit charge
-  double _hit_ph[kMaxHits];            ///< Hit ph?
-  double _hit_width[kMaxHits];         ///< Hit width
-  double _hit_full_integral[kMaxHits]; ///< Hit charge integral
-  int    _waveform_number[kMaxHits*5001];   ///< Number for each waveform, to allow for searching
-  double _adc_on_wire[kMaxHits*5001];       ///< ADC on wire to draw waveform
-  int    _time_for_waveform[kMaxHits*5001]; ///<Time for waveform to plot
-  int    _adc_count;    ///<Used for plotting waveforms
-  int    _waveform_integral[kMaxHits*5001]; ///<Used to see progression of the waveform integral
-  int    _adc_count_in_waveform[kMaxHits*5001]; ///<Used to view all waveforms on a hitplane together
+  int    _nhits;                                       ///< Number of reco hits in the event
+  int    _hit_cryostat[kMaxHits];                      ///< Cryostat where the hit belongs to
+  int    _hit_tpc[kMaxHits];                           ///< TPC where the hit belongs to
+  int    _hit_plane[kMaxHits];                         ///< Plane where the hit belongs to
+  int    _hit_wire[kMaxHits];                          ///< Wire where the hit belongs to
+  int    _hit_channel[kMaxHits];                       ///< Channel where the hit belongs to
+  double _hit_peakT[kMaxHits];                         ///< Hit peak time
+  double _hit_charge[kMaxHits];                        ///< Hit charge
+  double _hit_ph[kMaxHits];                            ///< Hit ph?
+  double _hit_width[kMaxHits];                         ///< Hit width
+  double _hit_full_integral[kMaxHits];                 ///< Hit charge integral
+  int    _waveform_number[kMaxHits*kMaxSamples];       ///< Number for each waveform, to allow for searching
+  double _adc_on_wire[kMaxHits*kMaxSamples];           ///< ADC on wire to draw waveform
+  int    _time_for_waveform[kMaxHits*kMaxSamples];     ///<Time for waveform to plot
+  int    _adc_count;                                   ///<Used for plotting waveforms
+  int    _waveform_integral[kMaxHits*kMaxSamples];     ///<Used to see progression of the waveform integral
+  int    _adc_count_in_waveform[kMaxHits*kMaxSamples]; ///<Used to view all waveforms on a hitplane together
 
   int _nstrips;                        ///< Number of CRT strips
   int _crt_plane[kMaxCHits];           ///< CRT plane
@@ -213,46 +214,46 @@ private:
   //mctruth information
   size_t MaxMCNeutrinos;     ///! The number of MCNeutrinos there is currently room for
   Int_t     mcevts_truth;    //number of neutrino Int_teractions in the spill
-  std::vector<Int_t>     nuScatterCode_truth; //Scattering code given by Genie for each neutrino
-  std::vector<Int_t>     nuID_truth;          //Unique ID of each true neutrino
-  std::vector<Int_t>     nuPDG_truth;         //neutrino PDG code
-  std::vector<Int_t>     ccnc_truth;          //0=CC 1=NC
-  std::vector<Int_t>     mode_truth;          //0=QE/El, 1=RES, 2=DIS, 3=Coherent production
-  std::vector<Float_t>   enu_truth;           //true neutrino energy
-  std::vector<Float_t>   Q2_truth;            //Momentum transfer squared
-  std::vector<Float_t>   W_truth;             //hadronic invariant mass
-  std::vector<Int_t>     hitnuc_truth;        //hit nucleon
-  std::vector<Float_t>   nuvtxx_truth;        //neutrino vertex x
-  std::vector<Float_t>   nuvtxy_truth;        //neutrino vertex y
-  std::vector<Float_t>   nuvtxz_truth;        //neutrino vertex z
-  std::vector<Float_t>   nu_dcosx_truth;      //neutrino dcos x
-  std::vector<Float_t>   nu_dcosy_truth;      //neutrino dcos y
-  std::vector<Float_t>   nu_dcosz_truth;      //neutrino dcos z
-  std::vector<Float_t>   lep_mom_truth;       //lepton momentum
-  std::vector<Float_t>   lep_dcosx_truth;     //lepton dcos x
-  std::vector<Float_t>   lep_dcosy_truth;     //lepton dcos y
-  std::vector<Float_t>   lep_dcosz_truth;     //lepton dcos z
+  std::vector<Int_t>     nuScatterCode_truth; ///< Scattering code given by Genie for each neutrino
+  std::vector<Int_t>     nuID_truth;          ///< Unique ID of each true neutrino
+  std::vector<Int_t>     nuPDG_truth;         ///< neutrino PDG code
+  std::vector<Int_t>     ccnc_truth;          ///< 0=CC 1=NC
+  std::vector<Int_t>     mode_truth;          ///< 0=QE/El, 1=RES, 2=DIS, 3=Coherent production
+  std::vector<Float_t>   enu_truth;           ///< true neutrino energy
+  std::vector<Float_t>   Q2_truth;            ///< Momentum transfer squared
+  std::vector<Float_t>   W_truth;             ///< hadronic invariant mass
+  std::vector<Int_t>     hitnuc_truth;        ///< hit nucleon
+  std::vector<Float_t>   nuvtxx_truth;        ///< neutrino vertex x
+  std::vector<Float_t>   nuvtxy_truth;        ///< neutrino vertex y
+  std::vector<Float_t>   nuvtxz_truth;        ///< neutrino vertex z
+  std::vector<Float_t>   nu_dcosx_truth;      ///< neutrino dcos x
+  std::vector<Float_t>   nu_dcosy_truth;      ///< neutrino dcos y
+  std::vector<Float_t>   nu_dcosz_truth;      ///< neutrino dcos z
+  std::vector<Float_t>   lep_mom_truth;       ///< lepton momentum
+  std::vector<Float_t>   lep_dcosx_truth;     ///< lepton dcos x
+  std::vector<Float_t>   lep_dcosy_truth;     ///< lepton dcos y
+  std::vector<Float_t>   lep_dcosz_truth;     ///< lepton dcos z
 
   //flux information
-    std::vector<Float_t>  tpx_flux;        //Px of parent particle leaving BNB target
-    std::vector<Float_t>  tpy_flux;        //Py of parent particle leaving BNB target
-    std::vector<Float_t>  tpz_flux;        //Pz of parent particle leaving BNB target
-    std::vector<Int_t>     tptype_flux;     //Type of parent particle leaving BNB target
+  std::vector<Float_t>  tpx_flux;             ///< Px of parent particle leaving BNB target
+  std::vector<Float_t>  tpy_flux;             ///< Py of parent particle leaving BNB target
+  std::vector<Float_t>  tpz_flux;             ///< Pz of parent particle leaving BNB target
+  std::vector<Int_t>     tptype_flux;         ///< Type of parent particle leaving BNB target
 
-    //genie information
-    size_t MaxGeniePrimaries = 0;
-    Int_t     genie_no_primaries;
-    std::vector<Int_t>     genie_primaries_pdg;
-    std::vector<Float_t>  genie_Eng;
-    std::vector<Float_t>  genie_Px;
-    std::vector<Float_t>  genie_Py;
-    std::vector<Float_t>  genie_Pz;
-    std::vector<Float_t>  genie_P;
-    std::vector<Int_t>     genie_status_code;
-    std::vector<Float_t>  genie_mass;
-    std::vector<Int_t>     genie_trackID;
-    std::vector<Int_t>     genie_ND;
-    std::vector<Int_t>     genie_mother;
+  //genie information
+  size_t MaxGeniePrimaries = 0;
+  Int_t     genie_no_primaries;
+  std::vector<Int_t>     genie_primaries_pdg;
+  std::vector<Float_t>  genie_Eng;
+  std::vector<Float_t>  genie_Px;
+  std::vector<Float_t>  genie_Py;
+  std::vector<Float_t>  genie_Pz;
+  std::vector<Float_t>  genie_P;
+  std::vector<Int_t>     genie_status_code;
+  std::vector<Float_t>  genie_mass;
+  std::vector<Int_t>     genie_trackID;
+  std::vector<Int_t>     genie_ND;
+  std::vector<Int_t>     genie_mother;
 
 
 
@@ -801,6 +802,8 @@ void Hitdumper::analyze(const art::Event& evt)
       } //end loop over hits
     }// end loop over waveforms
   }// end if fCheckTrasparency
+
+
   if (freadTruth){
 
     int nGeniePrimaries = 0, nMCNeutrinos = 0;
@@ -851,13 +854,13 @@ void Hitdumper::analyze(const art::Event& evt)
         if (!curr_mctruth->NeutrinoSet()) continue;
 
         // Genie Truth association only for the neutrino
-        if (fmgt.size()>i_mctruth){
-        std::vector< art::Ptr<simb::GTruth> > mcgtAssn = fmgt.at(i_mctruth);
+        if (fmgt.size()>i_mctruth) {
+          std::vector< art::Ptr<simb::GTruth> > mcgtAssn = fmgt.at(i_mctruth);
 
-        nuScatterCode_truth[i_mctruth] = mcgtAssn[0]->fGscatter;
-      }else{
-        nuScatterCode_truth[i_mctruth] = -1.;
-      }
+          nuScatterCode_truth[i_mctruth] = mcgtAssn[0]->fGscatter;
+        } else {
+          nuScatterCode_truth[i_mctruth] = -1.;
+        }
 
         nuPDG_truth[i_mctruth] = curr_mctruth->GetNeutrino().Nu().PdgCode();
         ccnc_truth[i_mctruth] = curr_mctruth->GetNeutrino().CCNC();
@@ -1098,7 +1101,7 @@ void Hitdumper::ResetVars(){
     _hit_full_integral[i] = -99999;
   }
 
-  for (int i = 0; i < (kMaxHits * 5001); i++) {
+  for (int i = 0; i < (kMaxHits * kMaxSamples); i++) {
     _waveform_number[i] = -99999;
     _adc_on_wire[i] = -99999;
     _time_for_waveform[i] = -99999;

--- a/sbndcode/Commissioning/hitdumpermodule.fcl
+++ b/sbndcode/Commissioning/hitdumpermodule.fcl
@@ -22,7 +22,7 @@ hitdumper:
 
     window:                   100
 
-    KeepTaggerTypes:          [1, 2] # Front and back only
+    KeepTaggerTypes:          [0, 1, 2, 3, 4, 5, 6]
 }
 
 END_PROLOG

--- a/sbndcode/Commissioning/hitdumpermodule.fcl
+++ b/sbndcode/Commissioning/hitdumpermodule.fcl
@@ -17,6 +17,7 @@ hitdumper:
     readCRTtracks:            true
     readOpHits:               true
     readTruth:                true
+    savePOTinfo:              true
     checkTransparency:        false
 
     window:                   100

--- a/sbndcode/Commissioning/run_hitdumper.fcl
+++ b/sbndcode/Commissioning/run_hitdumper.fcl
@@ -89,10 +89,10 @@ physics:
     ophit
   ]
 
-  ana:[hitdumper]
+  ana: [hitdumper]
 
   # define the output stream, there could be more than one if using filters 
-  # stream1: [out1]
+  stream1: [out1]
 
   # trigger_paths is a keyword and contains the paths that modify the art::event,
   #  ie filters and producers
@@ -102,8 +102,8 @@ physics:
   # end_paths is a keyword and contains the paths that do not modify the art::Event, 
   # ie analyzers and output streams.  these all run simultaneously
   #
-  # end_paths: [ana, stream1]  
-  end_paths: [ana]  
+  end_paths: [ana, stream1]  
+  # end_paths: [ana]  
 }
 
 


### PR DESCRIPTION
Updates to the HitDumper analyzer used for commissioning studies.

- Add POT information
- Saves all CRT taggers by default
- Keeps art-root files by default
- General clean-up