### PR TITLE
Reduce verbosity of SBNDOpT0Finder

### DIFF
--- a/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
+++ b/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
@@ -247,8 +247,8 @@ void SBNDOpT0Finder::DoMatch(art::Event& e,
 
   auto const & flash_h = e.getValidHandle<std::vector<recob::OpFlash>>(_opflash_producer_v[tpc]);
   if(!flash_h.isValid() || flash_h->empty()) {
-    mf::LogWarning("SBNDOpT0Finder") << "Don't have good flashes from producer "
-                                     << _opflash_producer_v[tpc] << std::endl;
+    mf::LogInfo("SBNDOpT0Finder") << "Don't have good flashes from producer "
+                                  << _opflash_producer_v[tpc] << std::endl;
     return;
   }
 


### PR DESCRIPTION
In my opinion is fairly normal to not have good flashes from one of the TPCs. Hence reducing the warning to an info.