### PR TITLE
HitDumper Updates

### DIFF
--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -427,22 +427,24 @@ void Hitdumper::analyze(const art::Event& evt)
 
   ResetWireHitsVars(_nhits);
 
+  size_t counter = 0;
   for (size_t i = 0; i < hitlist.size(); ++i) {
     geo::WireID wireid = hitlist[i]->WireID();
     if (fSkipInd && wireid.Plane != 2) {
       continue;
     }
 
-    _hit_cryostat[i] = wireid.Cryostat;
-    _hit_tpc[i] = wireid.TPC;
-    _hit_plane[i] = wireid.Plane;
-    _hit_wire[i] = wireid.Wire;
-    _hit_channel[i] = hitlist[i]->Channel();
+    _hit_cryostat[counter] = wireid.Cryostat;
+    _hit_tpc[counter] = wireid.TPC;
+    _hit_plane[counter] = wireid.Plane;
+    _hit_wire[counter] = wireid.Wire;
+    _hit_channel[counter] = hitlist[i]->Channel();
     // peak time needs plane dependent offset correction applied.
-    _hit_peakT[i] = hitlist[i]->PeakTime();
-    _hit_charge[i] = hitlist[i]->Integral();
-    _hit_ph[i] = hitlist[i]->PeakAmplitude();
-    _hit_width[i] = hitlist[i]->RMS();
+    _hit_peakT[counter] = hitlist[i]->PeakTime();
+    _hit_charge[counter] = hitlist[i]->Integral();
+    _hit_ph[counter] = hitlist[i]->PeakAmplitude();
+    _hit_width[counter] = hitlist[i]->RMS();
+    counter ++;
   }
 
   //

--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -419,14 +419,14 @@ void Hitdumper::analyze(const art::Event& evt)
   }
 
   if (_nhits > _max_hits) {
-    std::cout << "Available hits are " << _nhits 
+    std::cout << "Available hits are " << _nhits
               << ", which is above the maximum number allowed to store." << std::endl;
     std::cout << "Will only store " << _max_hits << "hits." << std::endl;
     _nhits = _max_hits;
   }
-  
+
   ResetWireHitsVars(_nhits);
-  
+
   for (size_t i = 0; i < hitlist.size(); ++i) {
     geo::WireID wireid = hitlist[i]->WireID();
     if (fSkipInd && wireid.Plane != 2) {
@@ -691,7 +691,7 @@ void Hitdumper::analyze(const art::Event& evt)
     }
 
     if (_nchits > _max_chits) {
-      std::cout << "Available CRT hits are " << _nchits 
+      std::cout << "Available CRT hits are " << _nchits
                 << ", which is above the maximum number allowed to store." << std::endl;
       std::cout << "Will only store " << _max_chits << "CRT hits." << std::endl;
       _nchits = _max_chits;
@@ -778,7 +778,7 @@ void Hitdumper::analyze(const art::Event& evt)
       std::cout << "Will only store " << _max_ophits << " optical hits." << std::endl;
       _nophits = _max_ophits;
     }
-    
+
     ResetOpHitsVars(_nophits);
 
     for (int i = 0; i < _nophits; ++i) {
@@ -1260,7 +1260,7 @@ void Hitdumper::ResetOpHitsVars(int n) {
 
 
 void Hitdumper::ResetVars() {
-  
+
 
   _run = -99999;
   _subrun = -99999;

--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -311,6 +311,7 @@ private:
   bool fcheckTransparency; ///< Checks for wire transprency (to be set via fcl)
   bool fUncompressWithPed; ///< Uncompresses the waveforms if true (to be set via fcl)
   int fWindow;
+  bool fSkipInd;           ///< If true, induction planes are not saved (to be set via fcl)
   // double fSelectedPDG;
 
   std::vector<int> fKeepTaggerTypes = {0, 1, 2, 3, 4, 5, 6}; ///< Taggers to keep (to be set via fcl)
@@ -371,6 +372,7 @@ void Hitdumper::reconfigure(fhicl::ParameterSet const& p)
   fWindow            = p.get<int>("window",100);
   fKeepTaggerTypes   = p.get<std::vector<int>>("KeepTaggerTypes");
 
+  fSkipInd           = p.get<bool>("SkipInduction",false);
 }
 
 
@@ -400,6 +402,16 @@ void Hitdumper::analyze(const art::Event& evt)
   if (evt.getByLabel(fHitsModuleLabel,hitListHandle)) {
     art::fill_ptr_vector(hitlist, hitListHandle);
     _nhits = hitlist.size();
+
+    // Calculate how many hits we will save if skipping the induction planes
+    if (fSkipInd) {
+      _nhits = 0;
+      for (auto h : hitlist) {
+        if (h->WireID().Plane == 2) {
+          _nhits++;
+        }
+      }
+    }
   }
   else {
     std::cout << "Failed to get recob::Hit data product." << std::endl;
@@ -415,8 +427,12 @@ void Hitdumper::analyze(const art::Event& evt)
   
   ResetWireHitsVars(_nhits);
   
-  for (int i = 0; i < _nhits; ++i) {
+  for (size_t i = 0; i < hitlist.size(); ++i) {
     geo::WireID wireid = hitlist[i]->WireID();
+    if (fSkipInd && wireid.Plane != 2) {
+      continue;
+    }
+
     _hit_cryostat[i] = wireid.Cryostat;
     _hit_tpc[i] = wireid.TPC;
     _hit_plane[i] = wireid.Plane;

--- a/sbndcode/Commissioning/hitdumpermodule.fcl
+++ b/sbndcode/Commissioning/hitdumpermodule.fcl
@@ -30,6 +30,8 @@ hitdumper:
     window:                   100
 
     KeepTaggerTypes:          [0, 1, 2, 3, 4, 5, 6]
+
+    SkipInduction:            false
 }
 
 END_PROLOG

--- a/sbndcode/Commissioning/hitdumpermodule.fcl
+++ b/sbndcode/Commissioning/hitdumpermodule.fcl
@@ -12,7 +12,7 @@ hitdumper:
 
     DigitModuleLabel:         "daq"
     HitsModuleLabel:          "fasthit"
-    OpHitsModuleLabel:        "ophit"
+    OpHitsModuleLabel:        "ophitpmt"
     CRTHitModuleLabel:        "crthit"
     CRTStripModuleLabel:      "crt"
     CRTTrackModuleLabel:      "crttrack"

--- a/sbndcode/Commissioning/run_hitdumper.fcl
+++ b/sbndcode/Commissioning/run_hitdumper.fcl
@@ -21,7 +21,7 @@
 #include "databaseutil_sbnd.fcl"
 #include "vertexfindermodules.fcl"
 #include "hitdumpermodule.fcl"
-#include "ophitfinder_sbnd.fcl"
+#include "ophit_finder_sbnd.fcl"
 
 process_name: HitDumper
 
@@ -72,7 +72,8 @@ physics:
     ### hit-finder producers
     # gaushit:             @local::sbnd_gaushitfinder
     fasthit:             @local::standard_fasthitfinder
-    ophit:               @local::sbnd_hit_finder
+    ophitpmt:            @local::sbnd_ophit_finder_pmt
+    # ophitarapuca:        @local::sbnd_ophit_finder_arapuca
 
   }
   analyzers:

--- a/sbndcode/Commissioning/run_hitdumper.fcl
+++ b/sbndcode/Commissioning/run_hitdumper.fcl
@@ -85,7 +85,7 @@ physics:
   #filters reject all following items.  see lines starting physics.producers below
   reco2: [
     fasthit,
-    ophit
+    ophitpmt
   ]
 
   ana: [hitdumper]

--- a/sbndcode/Commissioning/run_hitdumper.fcl
+++ b/sbndcode/Commissioning/run_hitdumper.fcl
@@ -115,7 +115,7 @@ physics.analyzers.hitdumper.readCRTtracks: false
 # set thresholds
 physics.producers.fasthit.MinSigInd: 15.0
 physics.producers.fasthit.MinSigCol: 15.0
-physics.producers.fasthit.SkipInd: true
+physics.producers.fasthit.SkipInd: false
 # parameter below enlarges the window of the hit symmetrically by adding
 #  this many widths to each side.   Original window is above threshold.
 #  Both thresh and larger window in this file are appropriate only when

--- a/sbndcode/Commissioning/run_hitdumper.fcl
+++ b/sbndcode/Commissioning/run_hitdumper.fcl
@@ -81,28 +81,28 @@ physics:
     hitdumper: @local::hitdumper
   }
 
-  #define the producer and filter modules for this path, order matters, 
+  #define the producer and filter modules for this path, order matters,
   #filters reject all following items.  see lines starting physics.producers below
-  reco2: [         
+  reco2: [
     fasthit,
     ophit
   ]
 
   ana: [hitdumper]
 
-  # define the output stream, there could be more than one if using filters 
+  # define the output stream, there could be more than one if using filters
   stream1: [out1]
 
   # trigger_paths is a keyword and contains the paths that modify the art::event,
   #  ie filters and producers
-  # trigger_paths: [] 
-  trigger_paths: [reco2] 
+  # trigger_paths: []
+  trigger_paths: [reco2]
 
-  # end_paths is a keyword and contains the paths that do not modify the art::Event, 
+  # end_paths is a keyword and contains the paths that do not modify the art::Event,
   # ie analyzers and output streams.  these all run simultaneously
   #
-  end_paths: [ana, stream1]  
-  # end_paths: [ana]  
+  end_paths: [ana, stream1]
+  # end_paths: [ana]
 }
 
 
@@ -116,9 +116,9 @@ physics.analyzers.hitdumper.readCRTtracks: false
 physics.producers.fasthit.MinSigInd: 15.0
 physics.producers.fasthit.MinSigCol: 15.0
 physics.producers.fasthit.SkipInd: true
-# parameter below enlarges the window of the hit symmetrically by adding 
-#  this many widths to each side.   Original window is above threshold.  
-#  Both thresh and larger window in this file are appropriate only when 
+# parameter below enlarges the window of the hit symmetrically by adding
+#  this many widths to each side.   Original window is above threshold.
+#  Both thresh and larger window in this file are appropriate only when
 #  noise is turned off.
 physics.producers.fasthit.IncludeMoreTail: 3.0
 physics.producers.fasthit.ColMinWidth: 100.0


### PR DESCRIPTION
This PR:
- Turns off SkipInd in the fast hit finder so that hits are created also for induction planes
- Adds settable fcl config to the HitDumper module that allows not saving the induction plane wire hits
- Switches to the optical hit finder in sbncode (PMT only)