### PR TITLE
Pandora 3D Mop up

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -306,25 +306,6 @@
     <AddHitsAsIsolated>true</AddHitsAsIsolated>
   </algorithm>
 
-  <!-- NeutrinoAlgorithms -->
-  <algorithm type = "LArNeutrinoCreation">
-    <InputVertexListName>NeutrinoVertices3D</InputVertexListName>
-    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
-  </algorithm>
-  <algorithm type = "LArNeutrinoHierarchy">
-    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
-    <DaughterPfoListNames>TrackParticles3D ShowerParticles3D</DaughterPfoListNames>
-    <DisplayPfoInfoMap>false</DisplayPfoInfoMap>
-    <PfoRelationTools>
-      <tool type = "LArVertexAssociatedPfos"/>
-      <tool type = "LArEndAssociatedPfos"/>
-      <tool type = "LArBranchAssociatedPfos"/>
-    </PfoRelationTools>
-  </algorithm>
-  <algorithm type = "LArNeutrinoDaughterVertices">
-    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
-    <OutputVertexListName>DaughterVertices3D</OutputVertexListName>
-  </algorithm>
   <algorithm type = "LArBdtPfoCharacterisation">
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
@@ -373,6 +354,34 @@
         <InputPfoListNames>TrackParticles3D ShowerParticles3D</InputPfoListNames>
         <DaughterListNames>ClustersU ClustersV ClustersW</DaughterListNames>
       </algorithm>
+      <algorithm type = "LArPfoHitCleaning">
+        <PfoListNames>TrackParticles3D ShowerParticles3D</PfoListNames>
+        <ClusterListNames>TrackClusters3D ShowerClusters3D</ClusterListNames>
+      </algorithm>
+      <algorithm type = "LArThreeDHitCreation">
+        <InputPfoListName>TrackParticles3D</InputPfoListName>
+        <OutputCaloHitListName>TrackCaloHits3D</OutputCaloHitListName>
+        <OutputClusterListName>TrackClusters3D</OutputClusterListName>
+        <HitCreationTools>
+          <tool type = "LArClearTransverseTrackHits"><MinViews>3</MinViews></tool>
+          <tool type = "LArClearLongitudinalTrackHits"><MinViews>3</MinViews></tool>
+          <tool type = "LArMultiValuedLongitudinalTrackHits"><MinViews>3</MinViews></tool>
+          <tool type = "LArMultiValuedTransverseTrackHits"><MinViews>3</MinViews></tool>
+          <tool type = "LArClearTransverseTrackHits"><MinViews>2</MinViews></tool>
+          <tool type = "LArClearLongitudinalTrackHits"><MinViews>2</MinViews></tool>
+          <tool type = "LArMultiValuedLongitudinalTrackHits"><MinViews>2</MinViews></tool>
+        </HitCreationTools>
+      </algorithm>
+      <algorithm type = "LArThreeDHitCreation">
+        <InputPfoListName>ShowerParticles3D</InputPfoListName>
+        <OutputCaloHitListName>ShowerCaloHits3D</OutputCaloHitListName>
+        <OutputClusterListName>ShowerClusters3D</OutputClusterListName>
+        <HitCreationTools>
+          <tool type = "LArThreeViewShowerHits"/>
+          <tool type = "LArTwoViewShowerHits"/>
+          <tool type = "LArDeltaRayShowerHits"/>
+        </HitCreationTools>
+      </algorithm>
     </MopUpAlgorithms>
   </algorithm>
 
@@ -397,6 +406,31 @@
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
     </FeatureToolsNoChargeInfo>
+  </algorithm>
+
+  <!-- NeutrinoAlgorithms -->
+  <algorithm type = "LArNeutrinoCreation">
+    <InputVertexListName>NeutrinoVertices3D</InputVertexListName>
+    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
+  </algorithm>
+  <algorithm type = "LArNeutrinoHierarchy">
+    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
+    <DaughterPfoListNames>TrackParticles3D ShowerParticles3D</DaughterPfoListNames>
+    <DisplayPfoInfoMap>false</DisplayPfoInfoMap>
+    <PfoRelationTools>
+      <tool type = "LArVertexAssociatedPfos"/>
+      <tool type = "LArEndAssociatedPfos"/>
+      <tool type = "LArBranchAssociatedPfos"/>
+    </PfoRelationTools>
+  </algorithm>
+  <algorithm type = "LArNeutrinoDaughterVertices">
+    <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
+    <OutputVertexListName>DaughterVertices3D</OutputVertexListName>
+  </algorithm>
+
+  <algorithm type = "LArShowerHierarchyMopUp">
+    <LeadingPfoListName>NeutrinoParticles3D</LeadingPfoListName>
+    <DaughterListNames>TrackParticles3D ShowerParticles3D DaughterVertices3D ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</DaughterListNames>
   </algorithm>
 
   <algorithm type = "LArNeutrinoProperties">

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -385,6 +385,7 @@
     </MopUpAlgorithms>
   </algorithm>
 
+  <!-- Re-run the PFO Characterisation to recalculate the scores after recursive mop up -->
   <algorithm type = "LArBdtPfoCharacterisation">
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>


### PR DESCRIPTION
This PR includes 2 changes to Pandora for SBND:
- Rerun the 3D hit creation within the recursive shower mop up
- Enable shower hierarchy mop up

Details of performance changes can be seen in [DocDB #21900](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=21900)

This PR relies on https://github.com/PandoraPFA/LArContent/pull/175 and should not be merged until this is included upstream 