### PR TITLE
Restoring ability to toggle noise generation

### DIFF
--- a/sbndcode/DetectorSim/SimWireSBND_module.cc
+++ b/sbndcode/DetectorSim/SimWireSBND_module.cc
@@ -81,15 +81,9 @@ public:
 
 private:
 
-  void GenNoiseInTime(std::vector<float> &noise, double noise_factor) const;
-  void GenNoiseInFreq(std::vector<float> &noise, double noise_factor) const;
-
   std::string            fDriftEModuleLabel;///< module making the ionization electrons
   raw::Compress_t        fCompression;      ///< compression type to use
 
-  double                 fNoiseWidth;       ///< exponential noise width (kHz)
-  double                 fNoiseRand;        ///< fraction of random "wiggle" in noise in freq. spectrum
-  double                 fLowCutoff;        ///< low frequency filter cutoff (kHz)
   size_t                 fNTicks;           ///< number of ticks of the clock
   double                 fSampleRate;       ///< sampling rate in ns
   unsigned int           fNTimeSamples;     ///< number of ADC readout samples in all readout frames (per event)
@@ -97,24 +91,17 @@ private:
   float                  fInductionPed;     ///< ADC value of baseline for induction plane
   float                  fCollectionSat;    ///< ADC value of pre-amp saturation for collection plane
   float                  fInductionSat;     ///< ADC value of pre-amp saturation for induction plane
+  float                  fAdcSaturation;    ///< ADC saturation value
   float                  fBaselineRMS;      ///< ADC value of baseline RMS within each channel
   TH1D*                  fNoiseDist;        ///< distribution of noise counts
-  bool fGetNoiseFromHisto;                  ///< if True -> Noise from Histogram of Freq. spectrum
-  bool fGenNoiseInTime;                     ///< if True -> Noise with Gaussian dsitribution in Time-domain
-  bool fGenNoise;                           ///< if True -> Gen Noise. if False -> Skip noise generation entierly
-
+  bool                   fGenNoise;         ///< if True -> Gen Noise. if False -> Skip noise generation entierly
+  
   art::ServiceHandle<ChannelNoiseService> noiseserv;
 
-
-  std::string fNoiseFileFname;
-  std::string fNoiseHistoName;
-  TH1D*                  fNoiseHist = nullptr; ///< distribution of noise counts
-
-  std::map< double, int > fShapingTimeOrder;
   std::string fTrigModName;                 ///< Trigger data product producer name
   //define max ADC value - if one wishes this can
   //be made a fcl parameter but not likely to ever change
-  static constexpr float adcsaturation{4095};
+  //static constexpr float adcsaturation{4095};
 
   //CLHEP::HepRandomEngine& fNoiseEngine;
   CLHEP::HepRandomEngine& fPedestalEngine;
@@ -143,56 +130,49 @@ SimWireSBND::SimWireSBND(fhicl::ParameterSet const& pset)
 //-------------------------------------------------
 SimWireSBND::~SimWireSBND()
 {
-  delete fNoiseHist;
 }
 
 //-------------------------------------------------
 void SimWireSBND::reconfigure(fhicl::ParameterSet const& p)
 {
   fDriftEModuleLabel = p.get< std::string         >("DriftEModuleLabel");
-  fNoiseWidth        = p.get< double              >("NoiseWidth");
-  fNoiseRand         = p.get< double              >("NoiseRand");
-  fLowCutoff         = p.get< double              >("LowCutoff");
-  fGetNoiseFromHisto = p.get< bool                >("GetNoiseFromHisto");
-  fGenNoiseInTime    = p.get< bool                >("GenNoiseInTime");
   fGenNoise          = p.get< bool                >("GenNoise");
   fCollectionPed     = p.get< float               >("CollectionPed",690.);
   fInductionPed      = p.get< float               >("InductionPed",2100.);
   fCollectionSat     = p.get< float               >("CollectionSat",2922.);
   fInductionSat      = p.get< float               >("InductionSat",1247.);
   fBaselineRMS       = p.get< float               >("BaselineRMS");
-
+  fAdcSaturation     = p.get< float               >("AdcSaturation",4095);
   fTrigModName       = p.get< std::string         >("TrigModName");
 
   //Map the Shaping times to the entry position for the noise ADC
   //level in fNoiseFactInd and fNoiseFactColl
-  fShapingTimeOrder = { {0.5, 0 }, {1.0, 1}, {2.0, 2}, {3.0, 3} };
+  //fShapingTimeOrder = { {0.5, 0 }, {1.0, 1}, {2.0, 2}, {3.0, 3} };
 
+  //if (fGetNoiseFromHisto)
+  //{
+  //  fNoiseHistoName = p.get< std::string         >("NoiseHistoName");
 
-  if (fGetNoiseFromHisto)
-  {
-    fNoiseHistoName = p.get< std::string         >("NoiseHistoName");
+  //  cet::search_path sp("FW_SEARCH_PATH");
+  //  sp.find_file(p.get<std::string>("NoiseFileFname"), fNoiseFileFname);
 
-    cet::search_path sp("FW_SEARCH_PATH");
-    sp.find_file(p.get<std::string>("NoiseFileFname"), fNoiseFileFname);
+  //  TFile in(fNoiseFileFname.c_str(), "READ");
+  //  if (!in.IsOpen()) {
+  //    throw art::Exception(art::errors::FileOpenError)
+  //      << "Could not find Root file '" << fNoiseHistoName
+  //      << "' for noise histogram\n";
+  //  }
+  //  fNoiseHist = (TH1D*) in.Get(fNoiseHistoName.c_str());
 
-    TFile in(fNoiseFileFname.c_str(), "READ");
-    if (!in.IsOpen()) {
-      throw art::Exception(art::errors::FileOpenError)
-        << "Could not find Root file '" << fNoiseHistoName
-        << "' for noise histogram\n";
-    }
-    fNoiseHist = (TH1D*) in.Get(fNoiseHistoName.c_str());
-
-    if (!fNoiseHist) {
-      throw art::Exception(art::errors::NotFound)
-        << "Could not find noise histogram '" << fNoiseHistoName
-        << "' in Root file '" << in.GetPath() << "'\n";
-    }
-    // release the histogram from its file; now we own it
-    fNoiseHist->SetDirectory(nullptr);
-    in.Close();
-  }
+  //  if (!fNoiseHist) {
+  //    throw art::Exception(art::errors::NotFound)
+  //      << "Could not find noise histogram '" << fNoiseHistoName
+  //      << "' in Root file '" << in.GetPath() << "'\n";
+  //  }
+  //  // release the histogram from its file; now we own it
+  //  fNoiseHist->SetDirectory(nullptr);
+  //  in.Close();
+  //}
 
   //detector properties information
   auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob();
@@ -305,53 +285,6 @@ void SimWireSBND::produce(art::Event& evt)
 
     }
     std::vector<float> noisetmp(fNTicks, 0.);
-    /*
-    //If not using new noise, use old method.
-    if(fUseNewNoise==false) {
-      //Generate Noise:
-      //std::cout<<"Using old noise method"<<std::endl;
-      size_t view = (size_t)geo->View(chan);
-
-      double noise_factor;
-      auto tempNoiseVec = sss->GetNoiseFactVec();
-      double shapingTime = 2.0; //sss->GetShapingTime(chan);
-      double asicGain = sss->GetASICGain(chan);
-
-      //std::cout << "Sim params: " << chan << " " << shapingTime << " " << asicGain << std::endl;
-
-      if (fShapingTimeOrder.find( shapingTime ) != fShapingTimeOrder.end() ) {
-	noise_factor = tempNoiseVec[view].at( fShapingTimeOrder.find( shapingTime )->second );
-	noise_factor *= asicGain/4.7;
-      }
-      else {
-	throw cet::exception("SimWireSBND")
-	  << "\033[93m"
-	  << "Shaping Time recieved from signalshapingservices_sbnd.fcl is not one of the allowed values"
-	  << std::endl
-	  << "Allowed values: 0.5, 1.0, 2.0, 3.0 us"
-	  << "\033[00m"
-	  << std::endl;
-      }
-
-
-      if (fGenNoise) {
-	if (fGenNoiseInTime) {
-	  GenNoiseInTime(noisetmp, noise_factor);
-	} else {
-	  GenNoiseInFreq(noisetmp, noise_factor);
-	}
-      }
-
-    } // End of old noise.
-
-    // Else if doing new noise calculations.
-    //else if(fUseNewNoise==true){
-    else {  
-      //std::cout<<"Using new noise method"<<std::endl;
-      noiseserv->addNoise(chan,noisetmp);
-    } // End of new noise.
-
-*/
 
     // Add noise to channel.
     if( fGenNoise ) noiseserv->addNoise(clockData, chan,noisetmp);
@@ -383,8 +316,8 @@ void SimWireSBND::produce(art::Event& evt)
         fNoiseDist->Fill(noisetmp.at(i));
 
       //allow for ADC saturation
-      if ( adcval > adcsaturation )
-        adcval = adcsaturation;
+      if ( adcval > fAdcSaturation )
+        adcval = fAdcSaturation;
       //don't allow for "negative" saturation
       if ( adcval < 0 )
         adcval = 0;
@@ -410,90 +343,9 @@ void SimWireSBND::produce(art::Event& evt)
   }// end loop over channels
 
   evt.put(std::move(digcol));
-}
+
+}//produce()
 
 
-  /*
-//-------------------------------------------------
-  void SimWireSBND::GenNoiseInTime(std::vector<float> &noise, double noise_factor) const
-{
-  CLHEP::RandGaussQ rGauss(fNoiseEngine, 0.0, noise_factor);
 
-  //In this case fNoiseFact is a value in ADC counts
-  //It is going to be the Noise RMS
-  //loop over all bins in "noise" vector
-  //and insert random noise value
-  for (unsigned int i = 0; i < noise.size(); i++)
-    noise.at(i) = rGauss.fire();
-}
-
-
-//-------------------------------------------------
-  void SimWireSBND::GenNoiseInFreq(std::vector<float> &noise, double noise_factor) const
-{
-  CLHEP::RandFlat flat(fNoiseEngine, -1, 1);
-
-  if (noise.size() != fNTicks)
-    throw cet::exception("SimWireSBND")
-        << "\033[93m"
-        << "Frequency noise vector length must match fNTicks (FFT size)"
-        << " ... " << noise.size() << " != " << fNTicks
-        << "\033[00m"
-        << std::endl;
-
-  // noise in frequency space
-  std::vector<TComplex> noiseFrequency(fNTicks / 2 + 1, 0.);
-
-  double pval = 0.;
-  double lofilter = 0.;
-  double phase = 0.;
-  double rnd[2] = {0.};
-
-  // width of frequencyBin in kHz
-  double binWidth = 1.0 / (fNTicks * fSampleRate * 1.0e-6);
-
-  for (size_t i = 0; i < fNTicks / 2 + 1; ++i) {
-    // exponential noise spectrum
-    flat.fireArray(2, rnd, 0, 1);
-    //if not from histo or in time --> then hardcoded freq. spectrum
-    if ( !fGetNoiseFromHisto )
-    {
-      pval = noise_factor * exp(-(double)i * binWidth / fNoiseWidth);
-      // low frequency cutoff
-      lofilter = 1.0 / (1.0 + exp(-(i - fLowCutoff / binWidth) / 0.5));
-      // randomize 10%
-
-      pval *= lofilter * ((1 - fNoiseRand) + 2 * fNoiseRand * rnd[0]);
-    }
-
-
-    else
-    {
-
-      pval = fNoiseHist->GetBinContent(i) * ((1 - fNoiseRand) + 2 * fNoiseRand * rnd[0]) * noise_factor;
-      //mf::LogInfo("SimWireSBND")  << " pval: " << pval;
-    }
-
-    phase = rnd[1] * 2.*TMath::Pi();
-    TComplex tc(pval * cos(phase), pval * sin(phase));
-    noiseFrequency.at(i) += tc;
-  }
-
-
-  // mf::LogInfo("SimWireSBND") << "filled noise freq";
-
-  // inverse FFT MCSignal
-  art::ServiceHandle<util::LArFFT> fFFT;
-  fFFT->DoInvFFT(noiseFrequency, noise);
-
-  noiseFrequency.clear();
-
-  // multiply each noise value by fNTicks as the InvFFT
-  // divides each bin by fNTicks assuming that a forward FFT
-  // has already been done.
-  for (unsigned int i = 0; i < noise.size(); ++i) noise.at(i) *= 1.*fNTicks;
-
-}
-  */
-
-}
+}//namespace detsim

--- a/sbndcode/DetectorSim/SimWireSBND_module.cc
+++ b/sbndcode/DetectorSim/SimWireSBND_module.cc
@@ -352,8 +352,9 @@ void SimWireSBND::produce(art::Event& evt)
     } // End of new noise.
 
 */
+
     // Add noise to channel.
-    noiseserv->addNoise(clockData, chan,noisetmp);
+    if( fGenNoise ) noiseserv->addNoise(clockData, chan,noisetmp);
 
     //Pedestal determination
     float ped_mean = fCollectionPed;
@@ -363,13 +364,12 @@ void SimWireSBND::produce(art::Event& evt)
       ped_mean = fInductionPed;
       preamp_sat = fInductionSat;
     }
-    else if (sigtype == geo::kCollection) {    
-      ped_mean = fCollectionPed;
-      preamp_sat=fCollectionSat;
-    }
     //slight variation on ped on order of RMS of baseline variation
-    CLHEP::RandGaussQ rGaussPed(fPedestalEngine, 0.0, fBaselineRMS);
-    ped_mean += rGaussPed.fire();
+    // (skip this if BaselineRMS = 0 in fhicl)
+    if( fBaselineRMS ) {
+      CLHEP::RandGaussQ rGaussPed(fPedestalEngine, 0.0, fBaselineRMS);
+      ped_mean += rGaussPed.fire();
+    }
 
     for (unsigned int i = 0; i < fNTimeSamples; ++i) {
 

--- a/sbndcode/DetectorSim/SimWireSBND_module.cc
+++ b/sbndcode/DetectorSim/SimWireSBND_module.cc
@@ -85,7 +85,6 @@ private:
   raw::Compress_t        fCompression;      ///< compression type to use
 
   size_t                 fNTicks;           ///< number of ticks of the clock
-  double                 fSampleRate;       ///< sampling rate in ns
   unsigned int           fNTimeSamples;     ///< number of ADC readout samples in all readout frames (per event)
   float                  fCollectionPed;    ///< ADC value of baseline for collection plane
   float                  fInductionPed;     ///< ADC value of baseline for induction plane

--- a/sbndcode/DetectorSim/SimWireSBND_module.cc
+++ b/sbndcode/DetectorSim/SimWireSBND_module.cc
@@ -91,7 +91,6 @@ private:
   float                  fInductionPed;     ///< ADC value of baseline for induction plane
   float                  fCollectionSat;    ///< ADC value of pre-amp saturation for collection plane
   float                  fInductionSat;     ///< ADC value of pre-amp saturation for induction plane
-  float                  fAdcSaturation;    ///< ADC saturation value
   float                  fBaselineRMS;      ///< ADC value of baseline RMS within each channel
   TH1D*                  fNoiseDist;        ///< distribution of noise counts
   bool                   fGenNoise;         ///< if True -> Gen Noise. if False -> Skip noise generation entierly
@@ -101,7 +100,7 @@ private:
   std::string fTrigModName;                 ///< Trigger data product producer name
   //define max ADC value - if one wishes this can
   //be made a fcl parameter but not likely to ever change
-  //static constexpr float adcsaturation{4095};
+  static constexpr float adcsaturation{4095};
 
   //CLHEP::HepRandomEngine& fNoiseEngine;
   CLHEP::HepRandomEngine& fPedestalEngine;
@@ -142,7 +141,6 @@ void SimWireSBND::reconfigure(fhicl::ParameterSet const& p)
   fCollectionSat     = p.get< float               >("CollectionSat",2922.);
   fInductionSat      = p.get< float               >("InductionSat",1247.);
   fBaselineRMS       = p.get< float               >("BaselineRMS");
-  fAdcSaturation     = p.get< float               >("AdcSaturation",4095);
   fTrigModName       = p.get< std::string         >("TrigModName");
 
   //Map the Shaping times to the entry position for the noise ADC
@@ -316,8 +314,8 @@ void SimWireSBND::produce(art::Event& evt)
         fNoiseDist->Fill(noisetmp.at(i));
 
       //allow for ADC saturation
-      if ( adcval > fAdcSaturation )
-        adcval = fAdcSaturation;
+      if ( adcval > adcsaturation )
+        adcval = adcsaturation;
       //don't allow for "negative" saturation
       if ( adcval < 0 )
         adcval = 0;

--- a/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
+++ b/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
@@ -7,25 +7,15 @@ sbnd_simwire:
  module_type:         "SimWireSBND"
  TrigModName:         "triggersim"
  DriftEModuleLabel:   "largeant"
- #NoiseFact:          0.15       #Noise Scale to use with histogram
- NoiseWidth:          62.4         #Exponential Noise width (kHz)
- NoiseRand:           0.1          #frac of randomness of noise freq-spec
- LowCutoff:           7.5          #Low frequency filter cutoff (kHz)
  CompressionType:     "none"       #could also be none		
+ BaselineRMS:         0.0         #ADC baseline fluctuation within channel        
  GenNoise:            true        # If false, NoiseService function is not called
- GetNoiseFromHisto:   false       # NO LONGER USED; set through NoiseService instead
- GenNoiseInTime:      true        # NO LONGER USED; set through NoiseService instead
 
  # the two settings below determine the ADC baseline for collection and induction plane, respectively;
  # here we read the settings from the pedestal service configuration,
  # so that we have only one maintenance point
  CollectionPed:       @local::sbnd_detpedestalservice.DetPedestalRetrievalAlg.DefaultCollMean # used to be 400
  InductionPed:        @local::sbnd_detpedestalservice.DetPedestalRetrievalAlg.DefaultIndMean  # used to be 2048
-#CollectionPed:        650
-#InductionPed:         2000
- BaselineRMS:         0.0         #ADC baseline fluctuation within channel        
- NoiseFileFname:      "uboone_noise_v0.1.root"
- NoiseHistoName:      "NoiseFreq"    
  CollectionSat: 2922 # in ADC, default is 2922
  InductionSat: 1247  # in ADC, default is 1247
 }

--- a/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
+++ b/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
@@ -12,9 +12,9 @@ sbnd_simwire:
  NoiseRand:           0.1          #frac of randomness of noise freq-spec
  LowCutoff:           7.5          #Low frequency filter cutoff (kHz)
  CompressionType:     "none"       #could also be none		
- GenNoise:            true        #gen noise...if false function not called
- GetNoiseFromHisto:   false
- GenNoiseInTime:      true
+ GenNoise:            true        # If false, NoiseService function is not called
+ GetNoiseFromHisto:   false       # NO LONGER USED; set through NoiseService instead
+ GenNoiseInTime:      true        # NO LONGER USED; set through NoiseService instead
 
  # the two settings below determine the ADC baseline for collection and induction plane, respectively;
  # here we read the settings from the pedestal service configuration,


### PR DESCRIPTION
Just a couple very minor updates. Restored the function of the "GenNoise" boolean in the simwire configuration, so users can turn on/off noise for tests. Also skipping the pedestal RMS routine if this is set to 0 in the fcl.