### PR TITLE
Height of Cosmic Generation Surface

### DIFF
--- a/sbndcode/LArSoftConfigurations/cosmic_common_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/cosmic_common_sbnd.fcl
@@ -6,7 +6,7 @@ sbnd_cosmic_common: {
   SampleTime:       3.2e-3  #  0.2 ms (G4 rise time) + 1.3 ms (1 full drift window) + 1.7 ms (readout) @ 500 V/cm, 154.4 cm/ms
   TimeOffset:      -1.7e-3  # -0.2 ms (G4 rise time) - 1.3 ms (1 full drift window) - 0.2 ms (front porch)
   BufferBox:        [ -300.0, +300.0, -300.0, +300.0, -300.0, +300.0 ]  # [ cm ]
-  ProjectToHeight:  1800 # height to which particles are projected
+  ProjectToHeight:  1850 # height to which particles are projected
 }
 
 END_PROLOG

--- a/sbndcode/LArSoftConfigurations/cosmic_common_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/cosmic_common_sbnd.fcl
@@ -6,7 +6,7 @@ sbnd_cosmic_common: {
   SampleTime:       3.2e-3  #  0.2 ms (G4 rise time) + 1.3 ms (1 full drift window) + 1.7 ms (readout) @ 500 V/cm, 154.4 cm/ms
   TimeOffset:      -1.7e-3  # -0.2 ms (G4 rise time) - 1.3 ms (1 full drift window) - 0.2 ms (front porch)
   BufferBox:        [ -300.0, +300.0, -300.0, +300.0, -300.0, +300.0 ]  # [ cm ]
-  ProjectToHeight:  1850 # height to which particles are projected
+  ProjectToHeight:  1850 # height to which particles are projected [ cm ]
 }
 
 END_PROLOG


### PR DESCRIPTION
Increases the height of the cosmic generation surface from 18 m to 18.5 m to make sure that it doesn't intersect with the building in geometry v2 (PR #116).

Fixes #98.