### PR TITLE
BackTracker messages are useless

### DIFF
--- a/sbndcode/LArSoftConfigurations/messages_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/messages_sbnd.fcl
@@ -169,6 +169,7 @@ sbnd_message_services_prod_debug:
 sbnd_message_services_prod_debug.destinations.LogDebugFile.categories:{
   default: { }
   GeometryBadInputPoint: { limit: 5 timespan: 1000}
+  BackTracker: { limit: 0 }
 }
 
 


### PR DESCRIPTION
We have all experience the barrage of BackTracker messages...

```
%MSG
%MSG-w BackTracker:  MCParticleHitMatching:gaushitTruthMatch@BeginModule  24-Jun-2021 18:18:27 CDT run: 1 subRun: 0 event: 50
caught exception
---- BackTracker BEGIN
  No sim::SimChannel corresponding to channel: 8658
---- BackTracker END
```

This commits ignores them