### PR TITLE
Update drift distance to geometry v2

### DIFF
--- a/sbndcode/FlashMatch/flashmatch_sbnd.fcl
+++ b/sbndcode/FlashMatch/flashmatch_sbnd.fcl
@@ -40,7 +40,7 @@ sbnd_simple_flashmatch:{
   score_hist_up: 50.
 
   n_bins: 40
-  DriftDistance: 200.
+  DriftDistance: 202.05
 
   dy_bins: 100
   dy_low: -200.


### PR DESCRIPTION
The new geometry has a slightly longer drift distance.

This PR should go along with:
https://github.com/SBNSoftware/sbndcode/pull/116