### PR TITLE
Fixing prodsingle T0

### DIFF
--- a/sbndcode/JobConfigurations/base/prodsingle_common_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodsingle_common_sbnd.fcl
@@ -90,7 +90,7 @@ outputs:
 physics.producers.generator.X0: [ 0.0 ]
 physics.producers.generator.Y0: [ 0.0 ]
 physics.producers.generator.Z0: [ -42. ]
-physics.producers.generator.T0: [ 1700 ]
+physics.producers.generator.T0: [ 0 ]              # ns (relative to beam gate time)
 physics.producers.generator.SigmaX: [ 5.0 ]      # x = (0, 256)
 physics.producers.generator.SigmaY: [ 5.5 ]      # y = (-116.5, 116.5)
 physics.producers.generator.SigmaZ: [ 0 ]      # z = (0, 1037)

--- a/sbndcode/JobConfigurations/base/prodsingle_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodsingle_sbnd.fcl
@@ -107,5 +107,5 @@ outputs:
 #
 # at the end of the configuration, we can override single parameters to reflect our needs:
 #
-physics.producers.generator.T0: [ 1.7e3 ]
+physics.producers.generator.T0: [ 0 ]
 physics.producers.generator.Theta0XZ: [ 10 ]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_dualmu_5GeV_fixposcontained_openingangle1.0degree.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_dualmu_5GeV_fixposcontained_openingangle1.0degree.fcl
@@ -8,7 +8,7 @@ physics.producers.generator.PDist: 0
 physics.producers.generator.X0: [150, 150]
 physics.producers.generator.Y0: [150, 150]
 physics.producers.generator.Z0: [25, 25]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.Theta0XZ: [-15.47, -16.47]
 physics.producers.generator.Theta0YZ: [-33.69, -33.69]
 physics.producers.generator.SigmaThetaXZ: [0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike.fcl
@@ -13,7 +13,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [0, 0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_anode_forwards_inwards.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_anode_forwards_inwards.fcl
@@ -13,7 +13,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [-45, -45]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_cathode_forwards_inwards.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_cathode_forwards_inwards.fcl
@@ -13,7 +13,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [45, 45]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_forward.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_electron_pi+_bnblike_forward.fcl
@@ -17,7 +17,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [0, 0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_gamma_pi+_bnblike.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_gamma_pi+_bnblike.fcl
@@ -18,7 +18,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [0, 0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_gamma_pi+_bnblike_forward.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_gamma_pi+_bnblike_forward.fcl
@@ -18,7 +18,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [0, 0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_10GeV_cathodecrossing.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_10GeV_cathodecrossing.fcl
@@ -8,7 +8,7 @@ physics.producers.generator.X0: [205.96, 100, -100, -205.96]
 physics.producers.generator.Y0: [630, 630, 630, 630]
 physics.producers.generator.Z0: [250, 250, 250, 250]
 physics.producers.generator.SigmaZ: [250, 250, 250, 250]
-physics.producers.generator.T0: [1700, 1700, 1700, 1700]
+physics.producers.generator.T0: [0, 0, 0, 0]
 physics.producers.generator.Theta0XZ: [-90, -90, 90, 90]
 physics.producers.generator.Theta0YZ: [-69, -80, -80, -69] #I calculated the angle to be 38.6598 but the event display suggested this angle was off so for now its hand corrected.  TODO investigate!
 physics.producers.generator.SigmaThetaXZ: [20, 20, 20, 20]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_10GeV_frontcorners_cornertocorner.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_10GeV_frontcorners_cornertocorner.fcl
@@ -7,7 +7,7 @@ physics.producers.generator.PDist: 0
 physics.producers.generator.X0: [205.96, -5.96, 5.96, -205.96]
 physics.producers.generator.Y0: [211.93, -211.93, 211.93, -211.93]
 physics.producers.generator.Z0: [-14.91, -14.91, -14.91, -14.91]
-physics.producers.generator.T0: [1700, 1700, 1700, 1700]
+physics.producers.generator.T0: [0, 0, 0, 0]
 physics.producers.generator.Theta0XZ: [-21.8014, 21.8014, -21.8014, 21.8014]
 physics.producers.generator.Theta0YZ: [-36.6598, 36.6598, -36.6598, 36.6598] #I calculated the angle to be 38.6598 but the event display suggested this angle was off so for now its hand corrected.  TODO investigate!
 physics.producers.generator.SigmaThetaXZ: [0, 0, 0, 0]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_proton_bnblike_anode_forwards_inwards.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_proton_bnblike_anode_forwards_inwards.fcl
@@ -13,7 +13,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [-45, -45]

--- a/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_proton_bnblike_cathode_forwards_inwards.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/single/prodsingle_mu_proton_bnblike_cathode_forwards_inwards.fcl
@@ -13,7 +13,7 @@ physics.producers.generator.Y0: [0, 0]
 physics.producers.generator.SigmaY: [ 0 ]
 physics.producers.generator.Z0: [250, 250]
 physics.producers.generator.SigmaZ: [ 0 ]
-physics.producers.generator.T0: [1700, 1700]
+physics.producers.generator.T0: [0, 0]
 physics.producers.generator.AngleDist: 0
 physics.producers.generator.ThetaXzYzHist: [ "hThetaXzYzHist_electrons" ]
 physics.producers.generator.Theta0XZ: [45, 45]


### PR DESCRIPTION
After doing some tests described below, it looks like prodsingle's T0 is relative to the beam gate time, so it should be set to 0.  Also, this parameter is in units of _nanoseconds_, not microseconds as I originally assumed. So by setting it to 1700 we were only offsetting the particles by 1.7 microseconds -- barely noticeable.

To test this, I simulated single 1.5 MeV electrons at the center of a TPC volume (X = -100cm) and looked at the times of reconstructed hits via `hit->PeakTime()`. For T0=0 and T0=1700, the result was the same, with hit times peaking at ~tick 1700, exactly in the center of our 3400-tick readout. But when setting T0=0.65e6 (0.65 ms, half a drift period), hit times shifted to tick 3000 as expected.