### PR TITLE
Adding 3drift legacy configuration for anyone wanting to process MC g…

### DIFF
--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -26,5 +26,3 @@ physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
 #physics.producers.larg4intime.SparsifyTrajectory: "true"
 
 process_name: CosmicsCorsikaCMCGenAndG4InTime
-
-#include "3drift_services_sbnd.fcl"

--- a/sbndcode/LArSoftConfigurations/3drift_services_sbnd_legacy.fcl
+++ b/sbndcode/LArSoftConfigurations/3drift_services_sbnd_legacy.fcl
@@ -1,0 +1,11 @@
+# Include this file at the bottom of any fhicl that is consuming MC files generated using
+# 3 drift windows prior to v09_22_00.
+
+#include "3drift_services_sbnd.fcl"
+services.DetectorPropertiesService.NumberTimeSamples: 7500
+services.DetectorPropertiesService.ReadOutWindowSize: 7500
+services.DetectorClocksService.G4RefTime:             -2.7e3 # [us]
+services.DetectorClocksService.TriggerOffsetTPC:      -1.25e3 # [us]
+services.DetectorClocksService.FramePeriod:           1.25e3 # [us]
+services.DetectorClocksService.DefaultTrigTime:       2.7e3 # [us]
+services.DetectorClocksService.DefaultBeamTime:       2.7e3 # [us]


### PR DESCRIPTION
Just adding `3drift_services_sbnd_legacy.fcl` for anyone who happens to be processing the old nu+cosmics MC generated with the previous drift length configuration. This file should be removed once a new MC production campaign takes place.