### PR TITLE
Fix to xarapuca dimensions swap on the geometry

### DIFF
--- a/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
@@ -12750,10 +12750,10 @@
                 </volume>
         </structure>
 	<solids>
-		<box name="XArapucaOut" lunit="mm" x="96" y="240" z="20"/>
-		<box name="XArapucaFilter" lunit="mm" x="76" y="206" z="2"/>
-		<box name="XArapucaHole" lunit="mm" x="76" y="206" z="3.0009999999999999"/>
-		<box name="XArapucaCover" lunit="mm" x="76" y="8" z="1"/>
+                <box name="XArapucaOut" lunit="mm" x="20" y="240" z="96"/>
+                <box name="XArapucaFilter" lunit="mm" x="2" y="206" z="76"/>
+                <box name="XArapucaHole" lunit="mm" x="3.0009999999999999" y="206" z="76"/>
+                <box name="XArapucaCover" lunit="mm" x="1" y="8" z="76"/>
 		<subtraction name="XArapucaExternalWalls">
 			<first ref="XArapucaOut"/>
 			<second ref="XArapucaHole"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
@@ -4563,10 +4563,10 @@
 
 	<solids>
 
-		<box name="XArapucaOut" lunit="mm" x="XArapucaOut_w" y="XArapucaOut_l" z="XArapucaOut_t"/>
-		<box name="XArapucaFilter" lunit="mm" x="XArapucaFilter_w" y="XArapucaFilter_l" z="XArapucaFilter_t"/>
-		<box name="XArapucaHole" lunit="mm" x="XArapucaFilter_w" y="XArapucaFilter_l" z="XArapucaFilter_t+XArapucaFilterDepth+_eD_"/>
-		<box name="XArapucaCover" lunit="mm" x="XArapucaFilter_w" y="distanceBetweenXArapucaFilters" z="XArapucaFilterDepth"/>
+                <box name="XArapucaOut" lunit="mm" x="XArapucaOut_t" y="XArapucaOut_l" z="XArapucaOut_w"/>
+                <box name="XArapucaFilter" lunit="mm" x="XArapucaFilter_t" y="XArapucaFilter_l" z="XArapucaFilter_w"/>
+                <box name="XArapucaHole" lunit="mm" x="XArapucaFilter_t+XArapucaFilterDepth+_eD_" y="XArapucaFilter_l" z="XArapucaFilter_w"/>
+                <box name="XArapucaCover" lunit="mm" x="XArapucaFilterDepth" y="distanceBetweenXArapucaFilters" z="XArapucaFilter_w"/>
 
 		<subtraction name="XArapucaExternalWalls">
 			<first ref="XArapucaOut"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
@@ -12750,10 +12750,10 @@
                 </volume>
         </structure>
 	<solids>
-		<box name="XArapucaOut" lunit="mm" x="96" y="240" z="20"/>
-		<box name="XArapucaFilter" lunit="mm" x="76" y="206" z="2"/>
-		<box name="XArapucaHole" lunit="mm" x="76" y="206" z="3.0009999999999999"/>
-		<box name="XArapucaCover" lunit="mm" x="76" y="8" z="1"/>
+                <box name="XArapucaOut" lunit="mm" x="20" y="240" z="96"/>
+                <box name="XArapucaFilter" lunit="mm" x="2" y="206" z="76"/>
+                <box name="XArapucaHole" lunit="mm" x="3.0009999999999999" y="206" z="76"/>
+                <box name="XArapucaCover" lunit="mm" x="1" y="8" z="76"/>
 		<subtraction name="XArapucaExternalWalls">
 			<first ref="XArapucaOut"/>
 			<second ref="XArapucaHole"/>


### PR DESCRIPTION
This issue was found by @rodralva, he reached out to me for guidance. I'm pushing this fix with the hope that gets merged ASAP because I need it for an upcoming production. 

The new geometry mixes up the `x` and `z` coordinates of the XARAPUCAS. Thus, the dimensions of the XARAPUCAS relevant to the solid angle computation become:
```
opDet.Length(): 0.2, opDet.Height(): 20.6
```

The consequence is a sharp drop off of the collected simphotons, again, @rodralva owns the credit of finding this issue.

Talking about the active window dimensions:
- The **width**, which is `2.0 mm` runs along the     `x` axis.
- The **height**, which is      `206.0 mm` runs along the `y` axis.
- The **length**, which is      `76.0 mm` runs along the     `z` axis. 

In here **width, height, length** `(x,yz)` refer to the ones understood by larsoft. 

The geometry uses **width, length, thickness**, where **width** refers to the short side and **length** to the long side. I personally prefer larsoft's usage, as I find them easier to understand and remember.

This PR doesn't change the naming convention used on the geometry, only flips the right stuff to get simulations OK again.

```
opDet.Length(): 7.6, opDet.Height(): 20.6
```
