### PR TITLE
Adding QL-correlated G4 script

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_QLcorrelated.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_QLcorrelated.fcl
@@ -1,0 +1,4 @@
+#include "standard_g4_sbnd.fcl"
+
+# Use anti-correlated ionization/scintillation (LegacyLArG4)
+services.LArG4Parameters.IonAndScintCalculator: "Correlated" # default: "Separate"


### PR DESCRIPTION
This PR adds a script in the `JobConfigurations/standard/g4` area that sources `standard_g4_sbnd.fcl`, while enabling the charge-light correlated model in Geant. Note that this is assuming LegacyLArG4 -- I believe the method of switching models is different for the new refactored LArG4 (which I'm not familiar with).