### PR TITLE
XArapucas Updates

### DIFF
--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -56,7 +56,7 @@ namespace opdet {
 	
     if(fParams.SinglePEmodel) {
 		mf::LogDebug("DigiArapucaSBNDAlg") << " using testbench pe response";
-		TFile* file = TFile::Open("/sbnd/app/users/rodrigoa/digi_arapuca_sbnd.root", "READ");//Change to TFile::Open(fname.c_str(), "READ"); as soon as OpDetSim/digi_arapuca_sbnd.root is updated in sbnd_data
+		TFile* file =  TFile::Open(fname.c_str(), "READ");
       std::vector<double>* SinglePEVec_40ftCable_Daphne;
       std::vector<double>* SinglePEVec_40ftCable_Apsaia;
       file->GetObject("SinglePEVec_40ftCable_Apsaia", SinglePEVec_40ftCable_Apsaia);

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -7,19 +7,16 @@
 namespace opdet {
 
   DigiArapucaSBNDAlg::DigiArapucaSBNDAlg(ConfigurationParameters_t const& config)
-    : fParams(config)
+    : fParams{config}
     , fSampling(fParams.frequency/ 1000.) //in GHz to cancel with ns
     , fSampling_Daphne(fParams.frequency_Daphne/ 1000.) //in GHz to cancel with ns
-    , fArapucaVUVEff(fParams.ArapucaVUVEff / fParams.larProp->ScintPreScale())
-    , fArapucaVISEff(fParams.ArapucaVISEff / fParams.larProp->ScintPreScale())
     , fXArapucaVUVEff(fParams.XArapucaVUVEff / fParams.larProp->ScintPreScale())
     , fXArapucaVISEff(fParams.XArapucaVISEff / fParams.larProp->ScintPreScale())
     , fADCSaturation(fParams.Baseline + fParams.Saturation * fParams.ADC * fParams.MeanAmplitude)
     , fEngine(fParams.engine)
   {
 
-    if(fArapucaVUVEff > 1.0001 || fArapucaVISEff > 1.0001 ||
-       fXArapucaVUVEff > 1.0001 || fXArapucaVISEff > 1.0001)
+    if(fXArapucaVUVEff > 1.0001 || fXArapucaVISEff > 1.0001)
       mf::LogWarning("DigiArapucaSBNDAlg")
         << "Quantum efficiency set in fhicl file "
         << fParams.ArapucaVUVEff << " or " << fParams.ArapucaVISEff << " or "

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -65,8 +65,8 @@ namespace opdet {
       fWaveformSP_Daphne = *SinglePEVec_40ftCable_Daphne;}	
   	else{
 	  	mf::LogDebug("DigiArapucaSBNDAlg") << " using ideal pe response";
-	    Pulse1PE(fWaveformSP);
-		  Pulse1PE_Daphne(fWaveformSP_Daphne);
+	    Pulse1PE(fWaveformSP,fSampling);
+		  Pulse1PE(fWaveformSP_Daphne,fSampling_Daphne);
 		  }
 
     file->Close();
@@ -250,11 +250,11 @@ namespace opdet {
   }
 
   //Ideal single pulse waveform, same shape for both electronics (not realistic: different capacitances, ...) 
-  void DigiArapucaSBNDAlg::Pulse1PE(std::vector<double>& fWaveformSP)//TODO: use only one Pulse1PE functions for both electronics ~rodrigoa
+  void DigiArapucaSBNDAlg::Pulse1PE(std::vector<double>& fWaveformSP, const double sampling)//TODO: use only one Pulse1PE functions for both electronics ~rodrigoa
   {
 		double constT1 = fParams.ADC * fParams.MeanAmplitude;
 		for(size_t i = 0; i<fWaveformSP.size(); i++) {
-		  double time = static_cast<double>(i) / fSampling;
+		  double time = static_cast<double>(i) / sampling;
 		  if (time < fParams.PeakTime)
 			fWaveformSP[i] = constT1 * std::exp((time - fParams.PeakTime) / fParams.RiseTime);
 		  else
@@ -262,19 +262,6 @@ namespace opdet {
 		}
   }
   
-  void DigiArapucaSBNDAlg::Pulse1PE_Daphne(std::vector<double>& fWaveformSP)//single pulse waveform for daphne readouts
-  {
-    double constT1 = fParams.ADC * fParams.MeanAmplitude;
-    for(size_t i = 0; i<fWaveformSP.size(); i++) {
-      double time = static_cast<double>(i) / fSampling_Daphne;
-      if (time < fParams.PeakTime)
-        fWaveformSP[i] = constT1 * std::exp((time - fParams.PeakTime) / fParams.RiseTime);
-      else
-        fWaveformSP[i] = constT1 * std::exp(-(time - fParams.PeakTime) / fParams.FallTime);
-    }
-  }
-
-
   void DigiArapucaSBNDAlg::AddSPE(
     const size_t time_bin,
     std::vector<double>& wave,

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -48,12 +48,10 @@ namespace opdet {
     fTimeXArapucaVUV = std::make_unique<CLHEP::RandGeneral>
       (*fEngine, TimeXArapucaVUV_p->data(), TimeXArapucaVUV_p->size());
 
-    //~fSampling = fSampling / 1000; //in GHz to cancel with ns
     size_t pulseSize = fParams.PulseLength * fSampling;
     fWaveformSP.resize(pulseSize);
 
-    //~fSampling_Daphne = fSampling_Daphne/ 1000; //in GHz to cancel with ns
-    size_t pulseSize_Daphne = fParams.PulseLength * fSampling;
+    size_t pulseSize_Daphne = fParams.PulseLength * fSampling_Daphne;
 	  fWaveformSP_Daphne.resize(pulseSize_Daphne);
 	
     if(fParams.SinglePEmodel) {

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -19,7 +19,6 @@ namespace opdet {
     if(fXArapucaVUVEff > 1.0001 || fXArapucaVISEff > 1.0001)
       mf::LogWarning("DigiArapucaSBNDAlg")
         << "Quantum efficiency set in fhicl file "
-        << fParams.ArapucaVUVEff << " or " << fParams.ArapucaVISEff << " or "
         << fParams.XArapucaVUVEff << " or " << fParams.XArapucaVISEff
         << " seems to be too large!\n"
         << "Final QE must be equal to or smaller than the scintillation "
@@ -52,19 +51,20 @@ namespace opdet {
 	  fWaveformSP_Daphne.resize(pulseSize_Daphne);
 	
     if(fParams.SinglePEmodel) {
-		  mf::LogDebug("DigiArapucaSBNDAlg") << " using testbench pe response";
-		  TFile* file =  TFile::Open(fname.c_str(), "READ");
+      mf::LogDebug("DigiArapucaSBNDAlg") << " using testbench pe response";
+      TFile* file =  TFile::Open(fname.c_str(), "READ");
       std::vector<double>* SinglePEVec_40ftCable_Daphne;
       std::vector<double>* SinglePEVec_40ftCable_Apsaia;
       file->GetObject("SinglePEVec_40ftCable_Apsaia", SinglePEVec_40ftCable_Apsaia);
       file->GetObject("SinglePEVec_40ftCable_Daphne", SinglePEVec_40ftCable_Daphne);
       fWaveformSP = *SinglePEVec_40ftCable_Apsaia;
-      fWaveformSP_Daphne = *SinglePEVec_40ftCable_Daphne;}	
+      fWaveformSP_Daphne = *SinglePEVec_40ftCable_Daphne;
+    }	
   	else{
-	  	mf::LogDebug("DigiArapucaSBNDAlg") << " using ideal pe response";
-	    Pulse1PE(fWaveformSP,fSampling);
-		  Pulse1PE(fWaveformSP_Daphne,fSampling_Daphne);
-		  }
+      mf::LogDebug("DigiArapucaSBNDAlg") << " using ideal pe response";
+      Pulse1PE(fWaveformSP,fSampling);
+      Pulse1PE(fWaveformSP_Daphne,fSampling_Daphne);
+		}
 
     file->Close();
   } // end constructor
@@ -136,9 +136,10 @@ namespace opdet {
           else nCT = 1;
           size_t timeBin = (is_daphne) ? std::floor(tphoton * fSampling_Daphne) : std::floor(tphoton * fSampling);
           if(timeBin < wave.size()) {
-						if (!is_daphne) {AddSPE(timeBin, wave, fWaveformSP, nCT);
-						}
-            else{ AddSPE(timeBin, wave, fWaveformSP_Daphne, nCT);}
+            if (!is_daphne) {AddSPE(timeBin, wave, fWaveformSP, nCT);
+            }
+            else{ AddSPE(timeBin, wave, fWaveformSP_Daphne, nCT);
+            }
           }
         }
       }
@@ -249,14 +250,12 @@ namespace opdet {
   //Ideal single pulse waveform, same shape for both electronics (not realistic: different capacitances, ...) 
   void DigiArapucaSBNDAlg::Pulse1PE(std::vector<double>& fWaveformSP, const double sampling)//TODO: use only one Pulse1PE functions for both electronics ~rodrigoa
   {
-		double constT1 = fParams.ADC * fParams.MeanAmplitude;
-		for(size_t i = 0; i<fWaveformSP.size(); i++) {
-		  double time = static_cast<double>(i) / sampling;
-		  if (time < fParams.PeakTime)
-			fWaveformSP[i] = constT1 * std::exp((time - fParams.PeakTime) / fParams.RiseTime);
-		  else
-			fWaveformSP[i] = constT1 * std::exp(-(time - fParams.PeakTime) / fParams.FallTime);
-		}
+    double constT1 = fParams.ADC * fParams.MeanAmplitude;
+    for(size_t i = 0; i<fWaveformSP.size(); i++) {
+      double time = static_cast<double>(i) / sampling;
+      if (time < fParams.PeakTime) fWaveformSP[i] = constT1 * std::exp((time - fParams.PeakTime) / fParams.RiseTime);
+      else fWaveformSP[i] = constT1 * std::exp(-(time - fParams.PeakTime) / fParams.FallTime);
+    }
   }
   
   void DigiArapucaSBNDAlg::AddSPE(
@@ -349,8 +348,6 @@ namespace opdet {
     fBaseConfig.ADC               = config.voltageToADC();
     fBaseConfig.Baseline          = config.baseline();
     fBaseConfig.Saturation        = config.saturation();
-    fBaseConfig.ArapucaVUVEff     = config.arapucaVUVEff();
-    fBaseConfig.ArapucaVISEff     = config.arapucaVISEff();
     fBaseConfig.XArapucaVUVEff    = config.xArapucaVUVEff();
     fBaseConfig.XArapucaVISEff    = config.xArapucaVISEff();
     fBaseConfig.RiseTime          = config.riseTime();
@@ -363,8 +360,8 @@ namespace opdet {
     fBaseConfig.PeakTime          = config.peakTime();
     fBaseConfig.DecayTXArapucaVIS = config.decayTXArapucaVIS();
     fBaseConfig.ArapucaDataFile   = config.arapucaDataFile();
-    fBaseConfig.SinglePEmodel  =  config.singlePEmodel();
-		fBaseConfig.frequency_Daphne= config.DaphneFrequency();
+    fBaseConfig.SinglePEmodel     = config.singlePEmodel();
+    fBaseConfig.frequency_Daphne  = config.DaphneFrequency();
   }
 
   std::unique_ptr<DigiArapucaSBNDAlg> DigiArapucaSBNDAlgMaker::operator()(

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -140,8 +140,7 @@ namespace opdet {
                                      double const& t_min,
                                      bool is_daphne);
     void AddSPE(size_t time_bin, std::vector<double>& wave, const std::vector<double>& fWaveformSP, int nphotons); // add single pulse to auxiliary waveform
-    void Pulse1PE(std::vector<double>& wave);
-    void Pulse1PE_Daphne(std::vector<double>& wave);
+    void Pulse1PE(std::vector<double>& wave,const double sampling);
     void AddLineNoise(std::vector<double>& wave);
     void AddDarkNoise(std::vector<double>& wave);
     double FindMinimumTime(sim::SimPhotons const& simphotons);

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -97,15 +97,13 @@ namespace opdet {
   private:
 
     // Declare member data here.
-    ConfigurationParameters_t fParams;
+    const ConfigurationParameters_t fParams;
 
-    double fSampling;        //wave sampling frequency (GHz)
-    double fSampling_Daphne;        //wave sampling frequency (GHz)
-    double fArapucaVUVEff;
-    double fArapucaVISEff;
-    double fXArapucaVUVEff;
-    double fXArapucaVISEff;
-    double fADCSaturation;
+    const double fSampling;        //wave sampling frequency (GHz)
+    const double fSampling_Daphne;        //wave sampling frequency (GHz)
+    const double fXArapucaVUVEff;
+    const double fXArapucaVISEff;
+    const double fADCSaturation;
 
     CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine //check this works ~rodrigoa
 

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -54,8 +54,6 @@ namespace opdet {
       double DarkNoiseRate;  //in Hz
       double CrossTalk;      //probability for producing a signal of 2 PE in response to 1 photon
       double Saturation;     //Saturation in number of p.e.
-      double ArapucaVUVEff;   //ArapucaVUV efficiency (optical window + cavity)
-      double ArapucaVISEff;   //ArapucaVIS efficiency (optical window + cavity)
       double XArapucaVUVEff;    //XArapucaVUV efficiency (optical window + cavity)
       double XArapucaVISEff;    //XArapucaVIS efficiency (optical window + cavity)
       double DecayTXArapucaVIS;// Decay time of EJ280 in ns
@@ -105,10 +103,8 @@ namespace opdet {
     const double fXArapucaVISEff;
     const double fADCSaturation;
 
-    CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine //check this works ~rodrigoa
+    CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine	
 
-    std::unique_ptr<CLHEP::RandGeneral> fTimeArapucaVUV; // histogram for getting the photon time distribution inside the Arapuca VUV box (considering the optical window)
-    std::unique_ptr<CLHEP::RandGeneral> fTimeArapucaVIS; // histogram for getting the photon time distribution inside the Arapuca VIS box (considering the optical window)
     std::unique_ptr<CLHEP::RandGeneral> fTimeXArapucaVUV;// histogram for getting the photon time distribution inside the XArapuca VUV box (considering the optical window)
     std::unique_ptr<CLHEP::RandGeneral> fTimeTPB; // histogram for getting the TPB emission time for visible (x)arapucas
 

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -101,24 +101,21 @@ namespace opdet {
 
     double fSampling;        //wave sampling frequency (GHz)
     double fSampling_Daphne;        //wave sampling frequency (GHz)
-    int pulsesize;
-    int pulsesize_Daphne;
     double fArapucaVUVEff;
     double fArapucaVISEff;
     double fXArapucaVUVEff;
     double fXArapucaVISEff;
+    double fADCSaturation;
 
-    double saturation;
-
-    CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine
+    CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine //check this works ~rodrigoa
 
     std::unique_ptr<CLHEP::RandGeneral> fTimeArapucaVUV; // histogram for getting the photon time distribution inside the Arapuca VUV box (considering the optical window)
     std::unique_ptr<CLHEP::RandGeneral> fTimeArapucaVIS; // histogram for getting the photon time distribution inside the Arapuca VIS box (considering the optical window)
     std::unique_ptr<CLHEP::RandGeneral> fTimeXArapucaVUV;// histogram for getting the photon time distribution inside the XArapuca VUV box (considering the optical window)
     std::unique_ptr<CLHEP::RandGeneral> fTimeTPB; // histogram for getting the TPB emission time for visible (x)arapucas
 
-    std::vector<double> wsp; //single photon pulse vector
-    std::vector<double> wsp_Daphne; //single photon pulse vector
+    std::vector<double> fWaveformSP; //single photon pulse vector
+    std::vector<double> fWaveformSP_Daphne; //single photon pulse vector
     std::unordered_map< raw::Channel_t, std::vector<double> > fFullWaveforms;
 
     void CreatePDWaveform(sim::SimPhotons const& SimPhotons,
@@ -142,8 +139,7 @@ namespace opdet {
                                      std::map<int, int> const& photonMap,
                                      double const& t_min,
                                      bool is_daphne);
-    void AddSPE(size_t time_bin, std::vector<double>& wave, int nphotons); // add single pulse to auxiliary waveform
-    void AddSPE_Daphne(size_t time_bin, std::vector<double>& wave, int nphotons); // add single pulse to auxiliary waveform
+    void AddSPE(size_t time_bin, std::vector<double>& wave, const std::vector<double>& fWaveformSP, int nphotons); // add single pulse to auxiliary waveform
     void Pulse1PE(std::vector<double>& wave);
     void Pulse1PE_Daphne(std::vector<double>& wave);
     void AddLineNoise(std::vector<double>& wave);

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -60,9 +60,12 @@ namespace opdet {
       double XArapucaVISEff;    //XArapucaVIS efficiency (optical window + cavity)
       double DecayTXArapucaVIS;// Decay time of EJ280 in ns
       std::string ArapucaDataFile; //File containing timing structure for arapucas
+      bool SinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
 
       detinfo::LArProperties const* larProp = nullptr; ///< LarProperties service provider.
       double frequency; ///< Optical-clock frequency
+      double frequency_Daphne; ///< Optical-clock frequency for daphne readouts	
+
       CLHEP::HepRandomEngine* engine = nullptr;
     };// ConfigurationParameters_t
 
@@ -80,12 +83,14 @@ namespace opdet {
                            sim::SimPhotons const& simphotons,
                            std::vector<short unsigned int>& waveform,
                            std::string pdtype,
+                           bool is_daphne,
                            double start_time,
                            unsigned n_samples);
     void ConstructWaveformLite(int ch,
                                sim::SimPhotonsLite const& litesimphotons,
                                std::vector<short unsigned int>& waveform,
                                std::string pdtype,
+                               bool is_daphne,
                                double start_time,
                                unsigned n_samples);
 
@@ -95,7 +100,9 @@ namespace opdet {
     ConfigurationParameters_t fParams;
 
     double fSampling;        //wave sampling frequency (GHz)
+    double fSampling_Daphne;        //wave sampling frequency (GHz)
     int pulsesize;
+    int pulsesize_Daphne;
     double fArapucaVUVEff;
     double fArapucaVISEff;
     double fXArapucaVUVEff;
@@ -111,27 +118,34 @@ namespace opdet {
     std::unique_ptr<CLHEP::RandGeneral> fTimeTPB; // histogram for getting the TPB emission time for visible (x)arapucas
 
     std::vector<double> wsp; //single photon pulse vector
+    std::vector<double> wsp_Daphne; //single photon pulse vector
     std::unordered_map< raw::Channel_t, std::vector<double> > fFullWaveforms;
 
     void CreatePDWaveform(sim::SimPhotons const& SimPhotons,
                           double t_min,
                           std::vector<double>& wave,
-                          std::string pdtype);
+                          std::string pdtype,
+                          bool is_daphne);
     void CreatePDWaveformLite(std::map<int, int> const& photonMap,
                               double t_min,
                               std::vector<double>& wave,
-                              std::string pdtype);
+                              std::string pdtype,
+                              bool is_daphne);
     void SinglePDWaveformCreatorLite(double effT,
                                      std::unique_ptr<CLHEP::RandGeneral>& timeHisto,
                                      std::vector<double>& wave,
                                      std::map<int, int> const& photonMap,
-                                     double const& t_min);
+                                     double const& t_min,
+                                     bool is_daphne);
     void SinglePDWaveformCreatorLite(double effT,
                                      std::vector<double>& wave,
                                      std::map<int, int> const& photonMap,
-                                     double const& t_min);
+                                     double const& t_min,
+                                     bool is_daphne);
     void AddSPE(size_t time_bin, std::vector<double>& wave, int nphotons); // add single pulse to auxiliary waveform
+    void AddSPE_Daphne(size_t time_bin, std::vector<double>& wave, int nphotons); // add single pulse to auxiliary waveform
     void Pulse1PE(std::vector<double>& wave);
+    void Pulse1PE_Daphne(std::vector<double>& wave);
     void AddLineNoise(std::vector<double>& wave);
     void AddDarkNoise(std::vector<double>& wave);
     double FindMinimumTime(sim::SimPhotons const& simphotons);
@@ -230,6 +244,17 @@ namespace opdet {
         Name("ArapucaDataFile"),
         Comment("File containing timing distribution for ArapucaVUV (optical window + cavity), ArapucaVIS (optical window + cavity), XArapuca VUV (optical window)")
       };
+      
+      fhicl::Atom<bool> singlePEmodel {
+        Name("SinglePEmodel"),
+        Comment("Model used for single PE response of PMT. =0 is ideal, =1 is from X-TDBoard data (with overshoot)")
+      };
+
+      fhicl::Atom<double> DaphneFrequency {
+        Name("DaphneFrequency"),
+        Comment("Sampling Frequency of the XArapucas with Daphne readouts (SBND Light detection system has 2 readout frequencies). Apsaia readouts read the frec value from LArSoft.")
+      };
+
 
     };    //struct Config
 

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -25,7 +25,7 @@ sbnd_digiarapuca_alg:
   XArapucaVISEff:            0.014  #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
-  SinglePEmodel:             true   # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
+  SinglePEmodel:             false   # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
   DaphneFrequency:             80.0  #in MHz. Frequency of the Daphne Readouts
 }
 

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -25,6 +25,8 @@ sbnd_digiarapuca_alg:
   XArapucaVISEff:            0.014  #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
+  SinglePEmodel:             true   # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
+  DaphneFrequency:             80.0  #in MHz. Frequency of the Daphne Readouts
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
@@ -213,8 +213,10 @@ namespace opdet {
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
     auto const detProp = art::ServiceHandle<detinfo::DetectorPropertiesService const>()->DataForJob(clockData);
     wConfig.Sampling = (clockData.OpticalClock().Frequency()) / 1000.0; //in GHz
+    wConfig.Sampling_Daphne =  config().araAlgoConfig().DaphneFrequency() / 1000.0; //in GHz
     wConfig.EnableWindow = fTriggerAlg.TriggerEnableWindow(clockData, detProp); // us
     wConfig.Nsamples = (wConfig.EnableWindow[1] - wConfig.EnableWindow[0]) * 1000. /*us -> ns*/ * wConfig.Sampling /* GHz */;
+    wConfig.Nsamples_Daphne = (wConfig.EnableWindow[1] - wConfig.EnableWindow[0]) * 1000. /*us -> ns*/ * wConfig.Sampling_Daphne /* GHz */;
 
     fFinished = false;
 

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.cc
@@ -188,31 +188,32 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         else if((pdtype == "xarapuca_vuv" && !Reflected) ||
                 (pdtype == "xarapuca_vis" && Reflected) ) {
           const bool is_daphne= fConfig.pdsMap.isElectronics(ch,"daphne");
-			    if(is_daphne){
-          arapucaDigitizer->ConstructWaveformLite(ch,
+          if(is_daphne){
+            arapucaDigitizer->ConstructWaveformLite(ch,
                                                   litesimphotons,
                                                   waveform,
                                                   pdtype,
                                                   is_daphne,
                                                   startTime,
                                                   fConfig.Nsamples_Daphne);
-          // including pre trigger window and transit time
-          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
+            // including pre trigger window and transit time
+            fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
                                                   (unsigned int)ch,
                                                   waveform);
-            }else{
-          arapucaDigitizer->ConstructWaveformLite(ch,
+            }
+            else{
+            arapucaDigitizer->ConstructWaveformLite(ch,
                                                   litesimphotons,
                                                   waveform,
                                                   pdtype,
                                                   is_daphne,
                                                   startTime,
                                                   fConfig.Nsamples);
-          // including pre trigger window and transit time
-          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
+            // including pre trigger window and transit time
+            fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
                                                   (unsigned int)ch,
                                                   waveform);
-											  }
+          }
         }
       }
     }  //end loop on simphoton lite collections
@@ -284,7 +285,8 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
           fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
                                                   (unsigned int)ch,
                                                   waveform);
-        }else{
+        }
+        else{
         arapucaDigitizer->ConstructWaveform(ch,
                                               simphotons,
                                               waveform,

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.cc
@@ -144,7 +144,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
     //                [](auto& p) {return std::addressof(p);});
 
     // to temporarily store channel and combine PMT (direct and converted) time profiles
-    const double startTime = fConfig.EnableWindow[0] * 1000 /*ns for digitizer*/;
+    const double startTime = fConfig.EnableWindow[0] * 1000. /*ns for digitizer*/;
 
     std::unordered_map<int, sim::SimPhotonsLite> DirectPhotonsMap;
     std::unordered_map<int, sim::SimPhotonsLite> ReflectedPhotonsMap;
@@ -160,8 +160,6 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         waveform.reserve(fConfig.Nsamples);
         const unsigned ch = litesimphotons.OpChannel;
         const std::string pdtype = fConfig.pdsMap.pdType(ch);
-        const bool is_daphne= fConfig.pdsMap.isSampling(ch,"daphne");
-        if (is_daphne)waveform.reserve(fConfig.Nsamples_Daphne);
 
         // only work on the prescribed channels
         if (ch < start || ch >= start + n) continue;
@@ -189,7 +187,8 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         // getting only xarapuca channels with appropriate type of light
         else if((pdtype == "xarapuca_vuv" && !Reflected) ||
                 (pdtype == "xarapuca_vis" && Reflected) ) {
-			if(is_daphne){		
+          const bool is_daphne= fConfig.pdsMap.isElectronics(ch,"daphne");
+			    if(is_daphne){
           arapucaDigitizer->ConstructWaveformLite(ch,
                                                   litesimphotons,
                                                   waveform,
@@ -235,7 +234,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
     std::unordered_set<short unsigned int> coatedpmts_todigitize;
 
     const std::vector<art::Handle<std::vector<sim::SimPhotons>>> &photon_handles = *fPhotonHandles;
-    const double startTime = fConfig.EnableWindow[0] * 1000 /*ns for digitizer*/;
+    const double startTime = fConfig.EnableWindow[0] * 1000. /*ns for digitizer*/;
 
     const unsigned start = StartChannelToProcess(fConfig.nChannels);
     const unsigned n = NChannelsToProcess(fConfig.nChannels);
@@ -245,7 +244,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         std::vector<short unsigned int> waveform;
         const unsigned ch = simphotons.OpChannel();
         const std::string pdtype = fConfig.pdsMap.pdType(ch);
-        const bool is_daphne = fConfig.pdsMap.isSampling(ch,"daphne"); 
+        const bool is_daphne = fConfig.pdsMap.isElectronics(ch,"daphne");
         // only work on the prescribed channels
         if (ch < start || ch >= start + n) continue;
         //coated PMTs

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.cc
@@ -160,6 +160,9 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         waveform.reserve(fConfig.Nsamples);
         const unsigned ch = litesimphotons.OpChannel;
         const std::string pdtype = fConfig.pdsMap.pdType(ch);
+        const bool is_daphne= fConfig.pdsMap.isSampling(ch,"daphne");
+        if (is_daphne)waveform.reserve(fConfig.Nsamples_Daphne);
+
         // only work on the prescribed channels
         if (ch < start || ch >= start + n) continue;
 
@@ -186,31 +189,32 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         // getting only xarapuca channels with appropriate type of light
         else if((pdtype == "xarapuca_vuv" && !Reflected) ||
                 (pdtype == "xarapuca_vis" && Reflected) ) {
+			if(is_daphne){		
           arapucaDigitizer->ConstructWaveformLite(ch,
                                                   litesimphotons,
                                                   waveform,
                                                   pdtype,
+                                                  is_daphne,
+                                                  startTime,
+                                                  fConfig.Nsamples_Daphne);
+          // including pre trigger window and transit time
+          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
+                                                  (unsigned int)ch,
+                                                  waveform);
+            }else{
+          arapucaDigitizer->ConstructWaveformLite(ch,
+                                                  litesimphotons,
+                                                  waveform,
+                                                  pdtype,
+                                                  is_daphne,
                                                   startTime,
                                                   fConfig.Nsamples);
           // including pre trigger window and transit time
           fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
                                                   (unsigned int)ch,
                                                   waveform);
+											  }
         }
-        // getting only arapuca channels with appropriate type of light
-        else if((pdtype == "arapuca_vuv" && !Reflected) ||
-                (pdtype == "arapuca_vis" && Reflected) ) {
-          arapucaDigitizer->ConstructWaveformLite(ch,
-                                                  litesimphotons,
-                                                  waveform,
-                                                  pdtype,
-                                                  startTime,
-                                                  fConfig.Nsamples);
-          // including pre trigger window and transit time
-          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
-                                                  (unsigned int)ch,
-                                                  waveform);
-      	}
       }
     }  //end loop on simphoton lite collections
 
@@ -241,6 +245,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         std::vector<short unsigned int> waveform;
         const unsigned ch = simphotons.OpChannel();
         const std::string pdtype = fConfig.pdsMap.pdType(ch);
+        const bool is_daphne = fConfig.pdsMap.isSampling(ch,"daphne"); 
         // only work on the prescribed channels
         if (ch < start || ch >= start + n) continue;
         //coated PMTs
@@ -265,13 +270,27 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
                                                   (unsigned int)ch,
                                                   waveform);
         }
-        // getting only arapuca channels with appropriate type of light
-        if((pdtype == "arapuca_vuv" && !Reflected) ||
-           (pdtype == "arapuca_vis" && Reflected)) {
+        // getting only xarapuca channels with appropriate type of light
+        if((pdtype == "xarapuca_vuv" && !Reflected) ||
+           (pdtype == "xarapuca_vis" && Reflected)) {
+          if(is_daphne){
           arapucaDigitizer->ConstructWaveform(ch,
                                               simphotons,
                                               waveform,
                                               pdtype,
+                                              is_daphne,
+                                              startTime,
+                                              fConfig.Nsamples_Daphne);
+          // including pre trigger window and transit time
+          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
+                                                  (unsigned int)ch,
+                                                  waveform);
+        }else{
+        arapucaDigitizer->ConstructWaveform(ch,
+                                              simphotons,
+                                              waveform,
+                                              pdtype,
+                                              is_daphne,
                                               startTime,
                                               fConfig.Nsamples);
           // including pre trigger window and transit time
@@ -279,19 +298,6 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
                                                   (unsigned int)ch,
                                                   waveform);
         }
-        // getting only arapuca channels with appropriate type of light
-        if((pdtype == "xarapuca_vuv" && !Reflected) ||
-           (pdtype == "xarapuca_vis" && Reflected)) {
-          arapucaDigitizer->ConstructWaveform(ch,
-                                              simphotons,
-                                              waveform,
-                                              pdtype,
-                                              startTime,
-                                              fConfig.Nsamples);
-          // including pre trigger window and transit time
-          fWaveforms->at(ch) = raw::OpDetWaveform(fConfig.EnableWindow[0],
-                                                  (unsigned int)ch,
-                                                  waveform);
         }
       }//optical channel loop
     }//type of light loop

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.hh
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.hh
@@ -42,7 +42,9 @@ namespace opdet {
 
       std::array<double, 2> EnableWindow;
       double Sampling;       //wave sampling frequency (GHz)
+      double Sampling_Daphne;
       unsigned int Nsamples; //Samples per waveform
+      unsigned int Nsamples_Daphne; //Samples per waveform
 
       Config(const opdet::DigiPMTSBNDAlgMaker::Config &pmt_config, const opdet::DigiArapucaSBNDAlgMaker::Config &arapuca_config);
     };

--- a/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
+++ b/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
@@ -2,16 +2,18 @@
 #include "lardataalg/DetectorInfo/DetectorClocksData.h"
 
 namespace {
-  double optical_period(detinfo::DetectorClocksData const& clockData)
+  double optical_period(detinfo::DetectorClocksData const& clockData,bool is_daphne)
   {
+    if (is_daphne) return clockData.OpticalClock().TickPeriod()*500/80; //500MHz Apsaia, 80MHz Daphne. TODO load frequency values from fcl ~rodrigoa
     return clockData.OpticalClock().TickPeriod();
   }
 
   raw::TimeStamp_t tick_to_timestamp(detinfo::DetectorClocksData const& clockData,
                                      raw::TimeStamp_t waveform_start,
-                                     size_t waveform_index)
+                                     size_t waveform_index,
+                                     bool is_daphne)
   {
-    return waveform_start + waveform_index * optical_period(clockData);
+    return waveform_start + waveform_index * optical_period(clockData,is_daphne);
   }
 }
 
@@ -75,42 +77,45 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   std::string opdet_type = fOpDetMap.pdType(channel);
   bool is_arapuca = false;
   if( opdet_type.find("arapuca") != std::string::npos ) is_arapuca = true; 
+  bool is_daphne = false;
+  std::string sampling_type = fOpDetMap.SamplingType(channel);
+  if (sampling_type == "daphne") is_daphne = true;
+
   int threshold = is_arapuca ? fConfig.TriggerThresholdADCArapuca() : fConfig.TriggerThresholdADCPMT(); 
   int polarity = is_arapuca ? fConfig.PulsePolarityArapuca() : fConfig.PulsePolarityPMT(); 
 
   // find the start and end points of the trigger window in this waveform
   std::array<double, 2> trigger_window = TriggerEnableWindow(clockData, detProp);
-  raw::TimeStamp_t start = tick_to_timestamp(clockData, waveform.TimeStamp(), 0);
-
+  raw::TimeStamp_t start = tick_to_timestamp(clockData, waveform.TimeStamp(), 0,is_daphne);
   if (start > trigger_window[1]) return;
-  size_t start_i = start > trigger_window[0] ? 0 : (size_t)((trigger_window[0] - start) / optical_period(clockData));
+  size_t start_i = start > trigger_window[0] ? 0 : (size_t)((trigger_window[0] - start) / optical_period(clockData,is_daphne));
 
   // fix rounding on division if necessary
   if (!IsTriggerEnabled(clockData,
                         detProp,
-                        tick_to_timestamp(clockData, waveform.TimeStamp(), start_i))) {
+                        tick_to_timestamp(clockData, waveform.TimeStamp(), start_i,is_daphne))) {
     start_i += 1;
   }
   assert(IsTriggerEnabled(clockData,
                           detProp,
-                          tick_to_timestamp(clockData, waveform.TimeStamp(), start_i)));
+                          tick_to_timestamp(clockData, waveform.TimeStamp(), start_i,is_daphne)));
 
   // if start is past end of waveform, we can return
   if (start_i >= adcs.size()) return;
 
   // get the end time
-  raw::TimeStamp_t end = tick_to_timestamp(clockData, waveform.TimeStamp(), adcs.size() - 1);
-  size_t end_i = end < trigger_window[1] ? adcs.size()-1 : (size_t)((trigger_window[1] - start) / optical_period(clockData));
+  raw::TimeStamp_t end = tick_to_timestamp(clockData, waveform.TimeStamp(), adcs.size() - 1,is_daphne);
+  size_t end_i = end < trigger_window[1] ? adcs.size()-1 : (size_t)((trigger_window[1] - start) / optical_period(clockData,is_daphne));
  
   // fix rounding error...
   if (IsTriggerEnabled(clockData,
                        detProp,
-                       tick_to_timestamp(clockData, waveform.TimeStamp(), end_i+1)) && end_i+1 < adcs.size()) {
+                       tick_to_timestamp(clockData, waveform.TimeStamp(), end_i+1,is_daphne)) && end_i+1 < adcs.size()) {
     end_i += 1;
   }
   assert(end_i+1 == adcs.size() || !IsTriggerEnabled(clockData,
                                                      detProp,
-                                                     tick_to_timestamp(clockData, waveform.TimeStamp(), end_i+1)));
+                                                     tick_to_timestamp(clockData, waveform.TimeStamp(), end_i+1,is_daphne)));
 
   std::vector<std::array<raw::TimeStamp_t, 2>> this_trigger_locations; 
   bool above_threshold = false;
@@ -120,8 +125,8 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   raw::TimeStamp_t trigger_start;
   // find all ADC counts above threshold
   for (size_t i = start_i; i <= end_i; i++) {
-    raw::TimeStamp_t time = tick_to_timestamp(clockData, waveform.TimeStamp(),i);
-    t_since_last_trigger += optical_period(clockData);
+    raw::TimeStamp_t time = tick_to_timestamp(clockData, waveform.TimeStamp(),i,is_daphne);
+    t_since_last_trigger += optical_period(clockData,is_daphne);
     bool isLive = (t_since_last_trigger > t_deadtime);
     raw::ADC_Count_t val = polarity * (adcs.at(i) - baseline);
     // only open new trigger if enough deadtime has passed
@@ -140,7 +145,7 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
     // add beam trigger (if enabled)
     // since the clock ticks might not sync up exactly, use the closet sample
     if( isLive && fConfig.BeamTriggerEnable() && !beam_trigger_added &&
-      fabs(time-fConfig.BeamTriggerTime()) <= optical_period(clockData)/2. ){
+      fabs(time-fConfig.BeamTriggerTime()) <= optical_period(clockData,is_daphne)/2. ){
       AddTriggerLocation(this_trigger_locations, {{time,time}});
       beam_trigger_added = true;
       t_since_last_trigger = 0;
@@ -334,6 +339,10 @@ std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detin
   raw::Channel_t channel = waveform.ChannelNumber();
   const std::vector<raw::TimeStamp_t> &trigger_times = GetTriggerTimes(channel);
   if( trigger_times.size() == 0 ) return ret;
+  bool is_daphne = false;
+  std::string sampling_type = fOpDetMap.SamplingType(channel);
+  if (sampling_type == "daphne") is_daphne = true;
+
 
 //  std::cout
 //  <<"=======================\n"
@@ -347,13 +356,13 @@ std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detin
   // Set the pre- and post-readout sizes
   double    preTrig	= ReadoutWindowPreTrigger(channel);
   double    postTrig	= ReadoutWindowPostTrigger(channel);
-  unsigned  ro_samples  = (preTrig+postTrig)/optical_period(clockData);	// samples
+  unsigned  ro_samples  = (preTrig+postTrig)/optical_period(clockData,is_daphne);	// samples
 
   // Are beam triggers enabled?
   double    beamTrigTime= fConfig.BeamTriggerTime();		// should be 0
   double    preTrigBeam	= ReadoutWindowPreTriggerBeam(channel);
   double    postTrigBeam	= ReadoutWindowPostTriggerBeam(channel);
-  unsigned  ro_samples_beam= (preTrigBeam+postTrigBeam)/optical_period(clockData); // samples
+  unsigned  ro_samples_beam= (preTrigBeam+postTrigBeam)/optical_period(clockData,is_daphne); // samples
 
   // --------------------------------------------
   // Scan the waveform
@@ -364,14 +373,14 @@ std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detin
   unsigned  min_ro_samples = ro_samples;
 
   for(size_t i=0; i<adcs.size(); i++){
-    double time = tick_to_timestamp(clockData, waveform.TimeStamp(), i);
+    double time = tick_to_timestamp(clockData, waveform.TimeStamp(), i,is_daphne);
 
     // if we're out of triggers or nearing the end of the waveform, break
     if( trigger_i >= trigger_times.size() ) break;
     if( i >= adcs.size()-1-min_ro_samples ) break;
 
     // check if the current trigger is from the beam
-    isBeamTrigger = ( fabs(next_trig-beamTrigTime)<optical_period(clockData)/2 );
+    isBeamTrigger = ( fabs(next_trig-beamTrigTime)<optical_period(clockData,is_daphne)/2 );
 
     // scan ahead to the "next" trigger if we've reached the end of the previous one
     double dT = time-next_trig;
@@ -379,7 +388,7 @@ std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detin
         ((isBeamTrigger && dT >= postTrigBeam)||(!isBeamTrigger && dT >= postTrig))) {
       for(size_t j=trigger_i+1; j<trigger_times.size(); j++){
         double this_trig = trigger_times[j];
-        isBeamTrigger = ( fabs(this_trig-beamTrigTime)<optical_period(clockData)/2 );
+        isBeamTrigger = ( fabs(this_trig-beamTrigTime)<optical_period(clockData,is_daphne)/2 );
         double t1 = this_trig-preTrig;
         double t2 = this_trig+postTrig;
         if(isBeamTrigger){

--- a/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
+++ b/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
@@ -78,7 +78,7 @@ void opDetSBNDTriggerAlg::FindTriggerLocations(detinfo::DetectorClocksData const
   bool is_arapuca = false;
   if( opdet_type.find("arapuca") != std::string::npos ) is_arapuca = true; 
   bool is_daphne = false;
-  std::string sampling_type = fOpDetMap.SamplingType(channel);
+  std::string sampling_type = fOpDetMap.electronicsType(channel);
   if (sampling_type == "daphne") is_daphne = true;
 
   int threshold = is_arapuca ? fConfig.TriggerThresholdADCArapuca() : fConfig.TriggerThresholdADCPMT(); 
@@ -340,7 +340,7 @@ std::vector<raw::OpDetWaveform> opDetSBNDTriggerAlg::ApplyTriggerLocations(detin
   const std::vector<raw::TimeStamp_t> &trigger_times = GetTriggerTimes(channel);
   if( trigger_times.size() == 0 ) return ret;
   bool is_daphne = false;
-  std::string sampling_type = fOpDetMap.SamplingType(channel);
+  std::string sampling_type = fOpDetMap.electronicsType(channel);
   if (sampling_type == "daphne") is_daphne = true;
 
 

--- a/sbndcode/OpDetSim/opHitFinderSBND_module.cc
+++ b/sbndcode/OpDetSim/opHitFinderSBND_module.cc
@@ -86,17 +86,17 @@ namespace opdet {
     int fEvNumber;
     int fChNumber;
     std::string opdetType;
-    std::string SamplingType;
+    std::string electronicsType;
     int threshold;
     std::vector<double> fwaveform;
     std::vector<double> outwvform;
     //int fSize;
     //int fTimePMT;         //Start time of PMT signal
     //int fTimeMax;         //Time of maximum (minimum) PMT signal
-    void subtractBaseline(std::vector<double>& waveform, std::string pdtype, std::string SamplingType,double& rms);
+    void subtractBaseline(std::vector<double>& waveform, std::string pdtype, std::string electronicsType,double& rms);
     bool findAndSuppressPeak(std::vector<double>& waveform, size_t& timebin,
                              double& Area, double& amplitude,
-                             const int& threshold, const std::string& opdetType, const std::string& SamplingType);
+                             const int& threshold, const std::string& opdetType, const std::string& electronicsType);
     void denoise(std::vector<double>& waveform, std::vector<double>& outwaveform);
     bool TV1D_denoise(std::vector<double>& waveform,
                       std::vector<double>& outwaveform,
@@ -162,7 +162,7 @@ namespace opdet {
 
       fChNumber = wvf.ChannelNumber();
       opdetType = map.pdType(fChNumber);
-      SamplingType = map.SamplingType(fChNumber);
+      electronicsType = map.electronicsType(fChNumber);
       if(opdetType == "pmt_coated" || opdetType == "pmt_uncoated") {
         threshold = fThresholdPMT;
       }
@@ -179,7 +179,7 @@ namespace opdet {
         fwaveform[i] = wvf[i];
       }
 
-      subtractBaseline(fwaveform, opdetType,SamplingType, rms);
+      subtractBaseline(fwaveform, opdetType,electronicsType, rms);
 
       if(fUseDenoising) {
         if((opdetType == "pmt_coated") || (opdetType == "pmt_uncoated")) {
@@ -195,8 +195,8 @@ namespace opdet {
       }
 
       // TODO: pass rms to this function once that's sorted. ~icaza
-      while(findAndSuppressPeak(fwaveform, timebin, Area, amplitude, threshold, opdetType,SamplingType)){
-        if(SamplingType == "daphne"){
+      while(findAndSuppressPeak(fwaveform, timebin, Area, amplitude, threshold, opdetType,electronicsType)){
+        if(electronicsType == "daphne"){
         time = wvf.TimeStamp() + (double)timebin / fSampling_Daphne;}
         else{
         time = wvf.TimeStamp() + (double)timebin / fSampling;}
@@ -226,13 +226,13 @@ namespace opdet {
   DEFINE_ART_MODULE(opHitFinderSBND)
 
   void opHitFinderSBND::subtractBaseline(std::vector<double>& waveform,
-                                         std::string pdtype,std::string SamplingType, double& rms)
+                                         std::string pdtype,std::string electronicsType, double& rms)
   {
     double baseline = 0.0;
     rms = 0.0;
     int cnt = 0;
     double NBins=fBaselineSample;
-    if (SamplingType=="daphne") NBins/=(fSampling/fSampling_Daphne);//correct the number of bins to the sampling frecuency. TODO: use a fixed time interval instead, then use the channel frequency to get the number of bins ~rodrigoa
+    if (electronicsType=="daphne") NBins/=(fSampling/fSampling_Daphne);//correct the number of bins to the sampling frecuency. TODO: use a fixed time interval instead, then use the channel frequency to get the number of bins ~rodrigoa
     // TODO: this is broken it assumes that the beginning of the
     // waveform is only noise, which is not always the case. ~icaza.
     // TODO: use std::accumulate instead of this loop. ~icaza.
@@ -264,7 +264,7 @@ namespace opdet {
                                             size_t& timebin, double& Area,
                                             double& amplitude, const int& threshold,
                                             const std::string& opdetType,
-                                            const std::string& SamplingType)
+                                            const std::string& electronicsType)
   {
 
     std::vector<double>::iterator max_element_it = std::max_element(waveform.begin(), waveform.end());
@@ -290,7 +290,7 @@ namespace opdet {
     // we convert it to GHz here so as to
     // have an area in ADC*ns.
     Area = std::accumulate(it_s, it_e, 0.0);
-    if (SamplingType == "daphne"){
+    if (electronicsType == "daphne"){
     Area = Area / (fSampling_Daphne / 1000.);}
     else{
     Area = Area / (fSampling / 1000.);};

--- a/sbndcode/OpDetSim/opHitFinderSBND_module.cc
+++ b/sbndcode/OpDetSim/opHitFinderSBND_module.cc
@@ -93,7 +93,7 @@ namespace opdet {
     //int fSize;
     //int fTimePMT;         //Start time of PMT signal
     //int fTimeMax;         //Time of maximum (minimum) PMT signal
-    void subtractBaseline(std::vector<double>& waveform, std::string pdtype, std::string electronicsType,double& rms);
+    void subtractBaseline(std::vector<double>& waveform, std::string pdtype, std::string electronicsType, double& rms);
     bool findAndSuppressPeak(std::vector<double>& waveform, size_t& timebin,
                              double& Area, double& amplitude,
                              const int& threshold, const std::string& opdetType, const std::string& electronicsType);
@@ -123,7 +123,7 @@ namespace opdet {
 
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
     fSampling = clockData.OpticalClock().Frequency(); // MHz
-    fSampling_Daphne = p.get<double >("DaphneFrequency" );; 
+    fSampling_Daphne = p.get<double>("DaphneFrequency"); 
 
     // Call appropriate produces<>() functions here.
     produces<std::vector<recob::OpHit>>();
@@ -179,7 +179,7 @@ namespace opdet {
         fwaveform[i] = wvf[i];
       }
 
-      subtractBaseline(fwaveform, opdetType,electronicsType, rms);
+      subtractBaseline(fwaveform, opdetType, electronicsType, rms);
 
       if(fUseDenoising) {
         if((opdetType == "pmt_coated") || (opdetType == "pmt_uncoated")) {
@@ -195,11 +195,9 @@ namespace opdet {
       }
 
       // TODO: pass rms to this function once that's sorted. ~icaza
-      while(findAndSuppressPeak(fwaveform, timebin, Area, amplitude, threshold, opdetType,electronicsType)){
-        if(electronicsType == "daphne"){
-        time = wvf.TimeStamp() + (double)timebin / fSampling_Daphne;}
-        else{
-        time = wvf.TimeStamp() + (double)timebin / fSampling;}
+      while(findAndSuppressPeak(fwaveform, timebin, Area, amplitude, threshold, opdetType, electronicsType)){
+        if(electronicsType == "daphne") time = wvf.TimeStamp() + (double)timebin / fSampling_Daphne;
+        else time = wvf.TimeStamp() + (double)timebin / fSampling;
 
         if(opdetType == "pmt_coated" || opdetType == "pmt_uncoated") {
           phelec = Area / fArea1pePMT;
@@ -226,7 +224,7 @@ namespace opdet {
   DEFINE_ART_MODULE(opHitFinderSBND)
 
   void opHitFinderSBND::subtractBaseline(std::vector<double>& waveform,
-                                         std::string pdtype,std::string electronicsType, double& rms)
+                                         std::string pdtype, std::string electronicsType, double& rms)
   {
     double baseline = 0.0;
     rms = 0.0;

--- a/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
+++ b/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
@@ -16,7 +16,7 @@ sbnd_hit_finder:
   PulsePolarityPMT:     -1         # use -1 for inverse polarity
   PulsePolarityArapuca:  1         # use -1 for inverse polarity
   UseDenoising:          true      # denoising algorithm to use with arapucas
-  DaphneFrequency: 					80.0  #in MHz. Frequency of the Daphne Readouts
+  DaphneFrequency:       80.0      # in MHz. Frequency of the Daphne Readouts
 
 }
 

--- a/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
+++ b/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
@@ -16,6 +16,8 @@ sbnd_hit_finder:
   PulsePolarityPMT:     -1         # use -1 for inverse polarity
   PulsePolarityArapuca:  1         # use -1 for inverse polarity
   UseDenoising:          true      # denoising algorithm to use with arapucas
+  DaphneFrequency: 					80.0  #in MHz. Frequency of the Daphne Readouts
+
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/sbndPDMapAlg.hh
+++ b/sbndcode/OpDetSim/sbndPDMapAlg.hh
@@ -58,9 +58,9 @@ namespace opdet {
     // void setup() {}
 
     bool isPDType(size_t ch, std::string pdname) const override;
-    bool isSampling(size_t ch, std::string pdname) const;
+    bool isElectronics(size_t ch, std::string pdname) const;
     std::string pdType(size_t ch) const override;
-    std::string SamplingType(size_t ch) const;
+    std::string electronicsType(size_t ch) const;
     std::vector<int> getChannelsOfType(std::string pdname) const;
     size_t size() const;
     auto getChannelEntry(size_t ch) const;

--- a/sbndcode/OpDetSim/sbndPDMapAlg.hh
+++ b/sbndcode/OpDetSim/sbndPDMapAlg.hh
@@ -8,15 +8,16 @@
 // This class stores the SBND PDS Map and channel's properties;
 // also implements functions to access these.
 //
-// As of version v09_08_00 each entry of the PDS Map
+// As of version v09_24_01 each entry of the PDS Map
 // has the following characteristics:
 //
-// channel: 0 to 303
-// pd_type: pmt_coated, pmt_uncoated, xarapuca_vuv, xarapuca_vis, arapuca_vuv, arapuca_vis
+// channel: 0 to 311
+// pd_type: pmt_coated, pmt_uncoated, xarapuca_vuv, xarapuca_vis
 // pds_box: 0 to 23
 // sensible_to_vis: true or false
 // sensible_to_vuv: true or false
 // tpc: 0, 1
+// sampling: apsaia, daphne
 ////////////////////////////////////////////////////////////////////////
 
 #ifndef SBND_OPDETSIM_SBNDPDMAPALG_HH
@@ -57,7 +58,9 @@ namespace opdet {
     // void setup() {}
 
     bool isPDType(size_t ch, std::string pdname) const override;
+    bool isSampling(size_t ch, std::string pdname) const;
     std::string pdType(size_t ch) const override;
+    std::string SamplingType(size_t ch) const;
     std::vector<int> getChannelsOfType(std::string pdname) const;
     size_t size() const;
     auto getChannelEntry(size_t ch) const;

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -31,7 +31,7 @@ namespace opdet {
   bool sbndPDMapAlg::isElectronics(size_t ch, std::string pdname) const
   {
     if(PDmap.at(ch)["electronics"] == std::string(pdname)) return true; // TODO: add number of electronics, daphne01, daphne02, .... ~rodrigoa; at() throws an exception if no such channel
-      return "There is no such channel";
+      return false;
 }
 
   std::string sbndPDMapAlg::pdType(size_t ch) const

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -28,22 +28,20 @@ namespace opdet {
     return false;
   }
 
-  bool sbndPDMapAlg::isSampling(size_t ch, std::string pdname) const
+  bool sbndPDMapAlg::isElectronics(size_t ch, std::string pdname) const
   {
-    if(PDmap.at(ch)["sampling"] == std::string(pdname)) return true;
-    return false;
+    if(PDmap.at(ch)["electronics"] == std::string(pdname)) return true; // TODO: add number of electronics, daphne01, daphne02, .... ~rodrigoa; at() throws an exception if no such channel
   }
 
   std::string sbndPDMapAlg::pdType(size_t ch) const
   {
-    if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];
+    if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];//TODO: remove all if(ch < PDmap.size()) 
     return "There is no such channel";
   }
 
-  std::string sbndPDMapAlg::SamplingType(size_t ch) const
+  std::string sbndPDMapAlg::electronicsType(size_t ch) const
   {
-    if(ch < PDmap.size()) return PDmap.at(ch)["sampling"];
-    return "There is no such channel";
+    return PDmap.at(ch)["electronics"]; //TODO: change to electronics, ~rodrigoa
   }
 
   std::vector<int> sbndPDMapAlg::getChannelsOfType(std::string pdname) const

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -31,17 +31,18 @@ namespace opdet {
   bool sbndPDMapAlg::isElectronics(size_t ch, std::string pdname) const
   {
     if(PDmap.at(ch)["electronics"] == std::string(pdname)) return true; // TODO: add number of electronics, daphne01, daphne02, .... ~rodrigoa; at() throws an exception if no such channel
-  }
+      return "There is no such channel";
+}
 
   std::string sbndPDMapAlg::pdType(size_t ch) const
   {
-    if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];//TODO: remove all if(ch < PDmap.size()) 
+    if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];//TODO: remove all if(ch < PDmap.size()) ~rodrigoa
     return "There is no such channel";
   }
 
   std::string sbndPDMapAlg::electronicsType(size_t ch) const
   {
-    return PDmap.at(ch)["electronics"]; //TODO: change to electronics, ~rodrigoa
+    return PDmap.at(ch)["electronics"]; 
   }
 
   std::vector<int> sbndPDMapAlg::getChannelsOfType(std::string pdname) const

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -30,14 +30,13 @@ namespace opdet {
 
   bool sbndPDMapAlg::isElectronics(size_t ch, std::string pdname) const
   {
-    if(PDmap.at(ch)["electronics"] == std::string(pdname)) return true; // TODO: add number of electronics, daphne01, daphne02, .... ~rodrigoa; at() throws an exception if no such channel
-      return false;
-}
+    if(PDmap.at(ch)["electronics"] == std::string(pdname)) return true; // TODO: add number of electronics, daphne01, daphne02, .... ~rodrigoa
+    return false;
+  }
 
   std::string sbndPDMapAlg::pdType(size_t ch) const
   {
-    if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];//TODO: remove all if(ch < PDmap.size()) ~rodrigoa
-    return "There is no such channel";
+    return PDmap.at(ch)["pd_type"];
   }
 
   std::string sbndPDMapAlg::electronicsType(size_t ch) const

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -28,9 +28,21 @@ namespace opdet {
     return false;
   }
 
+  bool sbndPDMapAlg::isSampling(size_t ch, std::string pdname) const
+  {
+    if(PDmap.at(ch)["sampling"] == std::string(pdname)) return true;
+    return false;
+  }
+
   std::string sbndPDMapAlg::pdType(size_t ch) const
   {
     if(ch < PDmap.size()) return PDmap.at(ch)["pd_type"];
+    return "There is no such channel";
+  }
+
+  std::string sbndPDMapAlg::SamplingType(size_t ch) const
+  {
+    if(ch < PDmap.size()) return PDmap.at(ch)["sampling"];
     return "There is no such channel";
   }
 

--- a/sbndcode/OpDetSim/sbnd_pds_mapping.json
+++ b/sbndcode/OpDetSim/sbnd_pds_mapping.json
@@ -6,7 +6,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 1,
@@ -15,7 +15,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 2,
@@ -24,7 +24,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 3,
@@ -33,7 +33,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 4,
@@ -42,7 +42,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 5,
@@ -51,7 +51,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 6,
@@ -60,7 +60,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 7,
@@ -69,7 +69,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 8,
@@ -78,7 +78,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 9,
@@ -87,7 +87,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 10,
@@ -96,7 +96,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 11,
@@ -105,7 +105,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 12,
@@ -114,7 +114,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 13,
@@ -123,7 +123,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 14,
@@ -132,7 +132,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 15,
@@ -141,7 +141,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 16,
@@ -150,7 +150,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 17,
@@ -159,7 +159,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 18,
@@ -168,7 +168,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 19,
@@ -177,7 +177,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 20,
@@ -186,7 +186,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 21,
@@ -195,7 +195,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 22,
@@ -204,7 +204,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 23,
@@ -213,7 +213,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 24,
@@ -222,7 +222,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 25,
@@ -231,7 +231,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 26,
@@ -240,7 +240,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 27,
@@ -249,7 +249,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 28,
@@ -258,7 +258,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 29,
@@ -267,7 +267,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 30,
@@ -276,7 +276,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 31,
@@ -285,7 +285,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 32,
@@ -294,7 +294,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 33,
@@ -303,7 +303,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 34,
@@ -312,7 +312,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 35,
@@ -321,7 +321,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 36,
@@ -330,7 +330,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 37,
@@ -339,7 +339,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 38,
@@ -348,7 +348,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 39,
@@ -357,7 +357,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 40,
@@ -366,7 +366,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 41,
@@ -375,7 +375,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 42,
@@ -384,7 +384,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 43,
@@ -393,7 +393,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 44,
@@ -402,7 +402,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 45,
@@ -411,7 +411,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 46,
@@ -420,7 +420,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 47,
@@ -429,7 +429,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 48,
@@ -438,7 +438,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 49,
@@ -447,7 +447,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 50,
@@ -456,7 +456,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 51,
@@ -465,7 +465,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 52,
@@ -474,7 +474,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 53,
@@ -483,7 +483,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 54,
@@ -492,7 +492,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 55,
@@ -501,7 +501,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 56,
@@ -510,7 +510,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 57,
@@ -519,7 +519,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 58,
@@ -528,7 +528,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 59,
@@ -537,7 +537,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 60,
@@ -546,7 +546,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 61,
@@ -555,7 +555,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 62,
@@ -564,7 +564,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 63,
@@ -573,7 +573,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 64,
@@ -582,7 +582,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 65,
@@ -591,7 +591,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 66,
@@ -600,7 +600,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 67,
@@ -609,7 +609,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 68,
@@ -618,7 +618,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 69,
@@ -627,7 +627,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 70,
@@ -636,7 +636,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 71,
@@ -645,7 +645,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 72,
@@ -654,7 +654,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 73,
@@ -663,7 +663,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 74,
@@ -672,7 +672,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 75,
@@ -681,7 +681,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 76,
@@ -690,7 +690,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 77,
@@ -699,7 +699,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 78,
@@ -708,7 +708,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 79,
@@ -717,7 +717,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 80,
@@ -726,7 +726,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 81,
@@ -735,7 +735,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 82,
@@ -744,7 +744,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 83,
@@ -753,7 +753,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 84,
@@ -762,7 +762,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 85,
@@ -771,7 +771,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 86,
@@ -780,7 +780,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 87,
@@ -789,7 +789,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 88,
@@ -798,7 +798,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 89,
@@ -807,7 +807,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 90,
@@ -816,7 +816,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 91,
@@ -825,7 +825,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 92,
@@ -834,7 +834,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 93,
@@ -843,7 +843,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 94,
@@ -852,7 +852,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 95,
@@ -861,7 +861,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 96,
@@ -870,7 +870,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 97,
@@ -879,7 +879,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 98,
@@ -888,7 +888,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 99,
@@ -897,7 +897,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 100,
@@ -906,7 +906,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 101,
@@ -915,7 +915,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 102,
@@ -924,7 +924,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 103,
@@ -933,7 +933,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 104,
@@ -942,7 +942,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 105,
@@ -951,7 +951,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 106,
@@ -960,7 +960,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 107,
@@ -969,7 +969,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 108,
@@ -978,7 +978,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 109,
@@ -987,7 +987,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 110,
@@ -996,7 +996,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 111,
@@ -1005,7 +1005,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 112,
@@ -1014,7 +1014,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 113,
@@ -1023,7 +1023,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 114,
@@ -1032,7 +1032,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 115,
@@ -1041,7 +1041,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 116,
@@ -1050,7 +1050,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 117,
@@ -1059,7 +1059,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 118,
@@ -1068,7 +1068,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 119,
@@ -1077,7 +1077,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 120,
@@ -1086,7 +1086,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 121,
@@ -1095,7 +1095,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 122,
@@ -1104,7 +1104,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 123,
@@ -1113,7 +1113,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 124,
@@ -1122,7 +1122,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 125,
@@ -1131,7 +1131,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 126,
@@ -1140,7 +1140,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 127,
@@ -1149,7 +1149,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 128,
@@ -1158,7 +1158,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 129,
@@ -1167,7 +1167,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 130,
@@ -1176,7 +1176,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 131,
@@ -1185,7 +1185,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 132,
@@ -1194,7 +1194,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 133,
@@ -1203,7 +1203,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 134,
@@ -1212,7 +1212,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 135,
@@ -1221,7 +1221,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 136,
@@ -1230,7 +1230,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 137,
@@ -1239,7 +1239,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 138,
@@ -1248,7 +1248,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 139,
@@ -1257,7 +1257,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 140,
@@ -1266,7 +1266,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 141,
@@ -1275,7 +1275,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 142,
@@ -1284,7 +1284,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 143,
@@ -1293,7 +1293,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 144,
@@ -1302,7 +1302,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 145,
@@ -1311,7 +1311,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 146,
@@ -1320,7 +1320,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 147,
@@ -1329,7 +1329,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 148,
@@ -1338,7 +1338,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 149,
@@ -1347,7 +1347,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 150,
@@ -1356,7 +1356,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 151,
@@ -1365,7 +1365,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 152,
@@ -1374,7 +1374,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 153,
@@ -1383,7 +1383,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 154,
@@ -1392,7 +1392,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 155,
@@ -1401,7 +1401,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 156,
@@ -1410,7 +1410,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 157,
@@ -1419,7 +1419,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 158,
@@ -1428,7 +1428,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 159,
@@ -1437,7 +1437,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 160,
@@ -1446,7 +1446,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 161,
@@ -1455,7 +1455,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 162,
@@ -1464,7 +1464,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 163,
@@ -1473,7 +1473,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 164,
@@ -1482,7 +1482,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 165,
@@ -1491,7 +1491,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 166,
@@ -1500,7 +1500,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 167,
@@ -1509,7 +1509,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 168,
@@ -1518,7 +1518,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 169,
@@ -1527,7 +1527,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 170,
@@ -1536,7 +1536,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 171,
@@ -1545,7 +1545,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 172,
@@ -1554,7 +1554,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 173,
@@ -1563,7 +1563,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 174,
@@ -1572,7 +1572,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 175,
@@ -1581,7 +1581,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 176,
@@ -1590,7 +1590,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 177,
@@ -1599,7 +1599,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "apsaia"
+    "electronics": "apsaia"
   },
   {
     "channel": 178,
@@ -1608,7 +1608,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 179,
@@ -1617,7 +1617,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 180,
@@ -1626,7 +1626,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 181,
@@ -1635,7 +1635,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 182,
@@ -1644,7 +1644,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 183,
@@ -1653,7 +1653,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 184,
@@ -1662,7 +1662,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 185,
@@ -1671,7 +1671,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 186,
@@ -1680,7 +1680,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 187,
@@ -1689,7 +1689,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 188,
@@ -1698,7 +1698,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 189,
@@ -1707,7 +1707,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 190,
@@ -1716,7 +1716,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 191,
@@ -1725,7 +1725,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 192,
@@ -1734,7 +1734,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 193,
@@ -1743,7 +1743,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 194,
@@ -1752,7 +1752,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 195,
@@ -1761,7 +1761,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 196,
@@ -1770,7 +1770,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 197,
@@ -1779,7 +1779,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 198,
@@ -1788,7 +1788,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 199,
@@ -1797,7 +1797,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 200,
@@ -1806,7 +1806,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 201,
@@ -1815,7 +1815,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 202,
@@ -1824,7 +1824,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 203,
@@ -1833,7 +1833,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 204,
@@ -1842,7 +1842,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 205,
@@ -1851,7 +1851,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 206,
@@ -1860,7 +1860,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 207,
@@ -1869,7 +1869,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 208,
@@ -1878,7 +1878,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 209,
@@ -1887,7 +1887,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 210,
@@ -1896,7 +1896,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 211,
@@ -1905,7 +1905,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 212,
@@ -1914,7 +1914,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 213,
@@ -1923,7 +1923,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 214,
@@ -1932,7 +1932,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 215,
@@ -1941,7 +1941,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 216,
@@ -1950,7 +1950,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 217,
@@ -1959,7 +1959,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 218,
@@ -1968,7 +1968,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 219,
@@ -1977,7 +1977,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 220,
@@ -1986,7 +1986,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 221,
@@ -1995,7 +1995,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 222,
@@ -2004,7 +2004,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 223,
@@ -2013,7 +2013,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 224,
@@ -2022,7 +2022,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 225,
@@ -2031,7 +2031,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 226,
@@ -2040,7 +2040,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 227,
@@ -2049,7 +2049,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 228,
@@ -2058,7 +2058,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 229,
@@ -2067,7 +2067,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 230,
@@ -2076,7 +2076,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 231,
@@ -2085,7 +2085,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 232,
@@ -2094,7 +2094,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 233,
@@ -2103,7 +2103,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 234,
@@ -2112,7 +2112,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 235,
@@ -2121,7 +2121,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 236,
@@ -2130,7 +2130,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 237,
@@ -2139,7 +2139,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 238,
@@ -2148,7 +2148,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 239,
@@ -2157,7 +2157,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 240,
@@ -2166,7 +2166,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 241,
@@ -2175,7 +2175,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 242,
@@ -2184,7 +2184,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 243,
@@ -2193,7 +2193,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 244,
@@ -2202,7 +2202,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 245,
@@ -2211,7 +2211,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 246,
@@ -2220,7 +2220,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 247,
@@ -2229,7 +2229,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 248,
@@ -2238,7 +2238,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 249,
@@ -2247,7 +2247,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 250,
@@ -2256,7 +2256,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 251,
@@ -2265,7 +2265,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 252,
@@ -2274,7 +2274,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 253,
@@ -2283,7 +2283,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 254,
@@ -2292,7 +2292,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 255,
@@ -2301,7 +2301,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 256,
@@ -2310,7 +2310,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 257,
@@ -2319,7 +2319,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 258,
@@ -2328,7 +2328,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 259,
@@ -2337,7 +2337,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 260,
@@ -2346,7 +2346,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 261,
@@ -2355,7 +2355,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 262,
@@ -2364,7 +2364,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 263,
@@ -2373,7 +2373,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 264,
@@ -2382,7 +2382,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 265,
@@ -2391,7 +2391,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 266,
@@ -2400,7 +2400,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 267,
@@ -2409,7 +2409,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 268,
@@ -2418,7 +2418,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 269,
@@ -2427,7 +2427,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 270,
@@ -2436,7 +2436,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 271,
@@ -2445,7 +2445,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 272,
@@ -2454,7 +2454,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 273,
@@ -2463,7 +2463,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 274,
@@ -2472,7 +2472,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 275,
@@ -2481,7 +2481,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 276,
@@ -2490,7 +2490,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 277,
@@ -2499,7 +2499,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 278,
@@ -2508,7 +2508,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 279,
@@ -2517,7 +2517,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 280,
@@ -2526,7 +2526,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 281,
@@ -2535,7 +2535,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 282,
@@ -2544,7 +2544,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 283,
@@ -2553,7 +2553,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 284,
@@ -2562,7 +2562,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 285,
@@ -2571,7 +2571,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 286,
@@ -2580,7 +2580,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 287,
@@ -2589,7 +2589,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 288,
@@ -2598,7 +2598,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 289,
@@ -2607,7 +2607,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 290,
@@ -2616,7 +2616,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 291,
@@ -2625,7 +2625,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 292,
@@ -2634,7 +2634,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 293,
@@ -2643,7 +2643,7 @@
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 294,
@@ -2652,7 +2652,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 295,
@@ -2661,7 +2661,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 296,
@@ -2670,7 +2670,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 297,
@@ -2679,7 +2679,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 298,
@@ -2688,7 +2688,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 299,
@@ -2697,7 +2697,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 300,
@@ -2706,7 +2706,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 301,
@@ -2715,7 +2715,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 302,
@@ -2724,7 +2724,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 303,
@@ -2733,7 +2733,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 304,
@@ -2742,7 +2742,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 0,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 305,
@@ -2751,7 +2751,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
     "tpc": 1,
-    "sampling": ""
+    "electronics": ""
   },
   {
     "channel": 306,
@@ -2760,7 +2760,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 307,
@@ -2769,7 +2769,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 308,
@@ -2778,7 +2778,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 309,
@@ -2787,7 +2787,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 310,
@@ -2796,7 +2796,7 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 0,
-    "sampling": "daphne"
+    "electronics": "daphne"
   },
   {
     "channel": 311,
@@ -2805,6 +2805,6 @@
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
     "tpc": 1,
-    "sampling": "daphne"
+    "electronics": "daphne"
   }
 ]

--- a/sbndcode/OpDetSim/sbnd_pds_mapping.json
+++ b/sbndcode/OpDetSim/sbnd_pds_mapping.json
@@ -5,7 +5,8 @@
     "pds_box": 0,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 1,
@@ -13,7 +14,8 @@
     "pds_box": 1,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 2,
@@ -21,7 +23,8 @@
     "pds_box": 2,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 3,
@@ -29,7 +32,8 @@
     "pds_box": 3,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 4,
@@ -37,7 +41,8 @@
     "pds_box": 4,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 5,
@@ -45,7 +50,8 @@
     "pds_box": 5,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 6,
@@ -53,7 +59,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 7,
@@ -61,7 +68,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 8,
@@ -69,7 +77,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 9,
@@ -77,7 +86,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 10,
@@ -85,7 +95,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 11,
@@ -93,7 +104,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 12,
@@ -101,7 +113,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 13,
@@ -109,7 +122,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 14,
@@ -117,7 +131,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 15,
@@ -125,7 +140,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 16,
@@ -133,7 +149,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 17,
@@ -141,7 +158,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 18,
@@ -149,7 +167,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 19,
@@ -157,7 +176,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 20,
@@ -165,7 +185,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 21,
@@ -173,7 +194,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 22,
@@ -181,7 +203,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 23,
@@ -189,7 +212,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 24,
@@ -197,7 +221,8 @@
     "pds_box": 0,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 25,
@@ -205,7 +230,8 @@
     "pds_box": 1,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 26,
@@ -213,7 +239,8 @@
     "pds_box": 0,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 27,
@@ -221,7 +248,8 @@
     "pds_box": 1,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 28,
@@ -229,7 +257,8 @@
     "pds_box": 2,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 29,
@@ -237,7 +266,8 @@
     "pds_box": 3,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 30,
@@ -245,7 +275,8 @@
     "pds_box": 2,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 31,
@@ -253,7 +284,8 @@
     "pds_box": 3,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 32,
@@ -261,7 +293,8 @@
     "pds_box": 4,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 33,
@@ -269,7 +302,8 @@
     "pds_box": 5,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 34,
@@ -277,7 +311,8 @@
     "pds_box": 4,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 35,
@@ -285,7 +320,8 @@
     "pds_box": 5,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 36,
@@ -293,7 +329,8 @@
     "pds_box": 0,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 37,
@@ -301,7 +338,8 @@
     "pds_box": 1,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 38,
@@ -309,7 +347,8 @@
     "pds_box": 2,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 39,
@@ -317,7 +356,8 @@
     "pds_box": 3,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 40,
@@ -325,7 +365,8 @@
     "pds_box": 4,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 41,
@@ -333,7 +374,8 @@
     "pds_box": 5,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 42,
@@ -341,7 +383,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 43,
@@ -349,7 +392,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 44,
@@ -357,7 +401,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 45,
@@ -365,7 +410,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 46,
@@ -373,7 +419,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 47,
@@ -381,7 +428,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 48,
@@ -389,7 +437,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 49,
@@ -397,7 +446,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 50,
@@ -405,7 +455,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 51,
@@ -413,7 +464,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 52,
@@ -421,7 +473,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 53,
@@ -429,7 +482,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 54,
@@ -437,7 +491,8 @@
     "pds_box": 0,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 55,
@@ -445,7 +500,8 @@
     "pds_box": 1,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 56,
@@ -453,7 +509,8 @@
     "pds_box": 2,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 57,
@@ -461,7 +518,8 @@
     "pds_box": 3,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 58,
@@ -469,7 +527,8 @@
     "pds_box": 4,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 59,
@@ -477,7 +536,8 @@
     "pds_box": 5,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 60,
@@ -485,7 +545,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 61,
@@ -493,7 +554,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 62,
@@ -501,7 +563,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 63,
@@ -509,7 +572,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 64,
@@ -517,7 +581,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 65,
@@ -525,7 +590,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 66,
@@ -533,7 +599,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 67,
@@ -541,7 +608,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 68,
@@ -549,7 +617,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 69,
@@ -557,7 +626,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 70,
@@ -565,7 +635,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 71,
@@ -573,7 +644,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 72,
@@ -581,7 +653,8 @@
     "pds_box": 0,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 73,
@@ -589,7 +662,8 @@
     "pds_box": 1,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 74,
@@ -597,7 +671,8 @@
     "pds_box": 2,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 75,
@@ -605,7 +680,8 @@
     "pds_box": 3,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 76,
@@ -613,7 +689,8 @@
     "pds_box": 4,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 77,
@@ -621,7 +698,8 @@
     "pds_box": 5,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 78,
@@ -629,7 +707,8 @@
     "pds_box": 6,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 79,
@@ -637,7 +716,8 @@
     "pds_box": 7,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 80,
@@ -645,7 +725,8 @@
     "pds_box": 8,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 81,
@@ -653,7 +734,8 @@
     "pds_box": 9,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 82,
@@ -661,7 +743,8 @@
     "pds_box": 10,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 83,
@@ -669,7 +752,8 @@
     "pds_box": 11,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 84,
@@ -677,7 +761,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 85,
@@ -685,7 +770,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 86,
@@ -693,7 +779,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 87,
@@ -701,7 +788,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 88,
@@ -709,7 +797,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 89,
@@ -717,7 +806,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 90,
@@ -725,7 +815,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 91,
@@ -733,7 +824,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 92,
@@ -741,7 +833,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 93,
@@ -749,7 +842,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 94,
@@ -757,7 +851,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 95,
@@ -765,7 +860,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 96,
@@ -773,7 +869,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 97,
@@ -781,7 +878,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 98,
@@ -789,7 +887,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 99,
@@ -797,7 +896,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 100,
@@ -805,7 +905,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 101,
@@ -813,7 +914,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 102,
@@ -821,7 +923,8 @@
     "pds_box": 6,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 103,
@@ -829,7 +932,8 @@
     "pds_box": 7,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 104,
@@ -837,7 +941,8 @@
     "pds_box": 6,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 105,
@@ -845,7 +950,8 @@
     "pds_box": 7,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 106,
@@ -853,7 +959,8 @@
     "pds_box": 8,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 107,
@@ -861,7 +968,8 @@
     "pds_box": 9,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 108,
@@ -869,7 +977,8 @@
     "pds_box": 8,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 109,
@@ -877,7 +986,8 @@
     "pds_box": 9,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 110,
@@ -885,7 +995,8 @@
     "pds_box": 10,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 111,
@@ -893,7 +1004,8 @@
     "pds_box": 11,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 112,
@@ -901,7 +1013,8 @@
     "pds_box": 10,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 113,
@@ -909,7 +1022,8 @@
     "pds_box": 11,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 114,
@@ -917,7 +1031,8 @@
     "pds_box": 6,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 115,
@@ -925,7 +1040,8 @@
     "pds_box": 7,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 116,
@@ -933,7 +1049,8 @@
     "pds_box": 8,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 117,
@@ -941,7 +1058,8 @@
     "pds_box": 9,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 118,
@@ -949,7 +1067,8 @@
     "pds_box": 10,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 119,
@@ -957,7 +1076,8 @@
     "pds_box": 11,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 120,
@@ -965,7 +1085,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 121,
@@ -973,7 +1094,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 122,
@@ -981,7 +1103,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 123,
@@ -989,7 +1112,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 124,
@@ -997,7 +1121,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 125,
@@ -1005,7 +1130,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 126,
@@ -1013,7 +1139,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 127,
@@ -1021,7 +1148,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 128,
@@ -1029,7 +1157,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 129,
@@ -1037,7 +1166,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 130,
@@ -1045,7 +1175,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 131,
@@ -1053,7 +1184,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 132,
@@ -1061,7 +1193,8 @@
     "pds_box": 6,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 133,
@@ -1069,7 +1202,8 @@
     "pds_box": 7,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 134,
@@ -1077,7 +1211,8 @@
     "pds_box": 8,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 135,
@@ -1085,7 +1220,8 @@
     "pds_box": 9,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 136,
@@ -1093,7 +1229,8 @@
     "pds_box": 10,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 137,
@@ -1101,7 +1238,8 @@
     "pds_box": 11,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 138,
@@ -1109,7 +1247,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 139,
@@ -1117,7 +1256,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 140,
@@ -1125,7 +1265,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 141,
@@ -1133,7 +1274,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 142,
@@ -1141,7 +1283,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 143,
@@ -1149,7 +1292,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 144,
@@ -1157,7 +1301,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 145,
@@ -1165,7 +1310,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 146,
@@ -1173,7 +1319,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 147,
@@ -1181,7 +1328,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 148,
@@ -1189,7 +1337,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 149,
@@ -1197,7 +1346,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 150,
@@ -1205,7 +1355,8 @@
     "pds_box": 6,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 151,
@@ -1213,7 +1364,8 @@
     "pds_box": 7,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 152,
@@ -1221,7 +1373,8 @@
     "pds_box": 8,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 153,
@@ -1229,7 +1382,8 @@
     "pds_box": 9,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 154,
@@ -1237,7 +1391,8 @@
     "pds_box": 10,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 155,
@@ -1245,7 +1400,8 @@
     "pds_box": 11,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 156,
@@ -1253,7 +1409,8 @@
     "pds_box": 12,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 157,
@@ -1261,7 +1418,8 @@
     "pds_box": 13,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 158,
@@ -1269,7 +1427,8 @@
     "pds_box": 14,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 159,
@@ -1277,7 +1436,8 @@
     "pds_box": 15,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 160,
@@ -1285,7 +1445,8 @@
     "pds_box": 16,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 161,
@@ -1293,7 +1454,8 @@
     "pds_box": 17,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 162,
@@ -1301,7 +1463,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 163,
@@ -1309,7 +1472,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 164,
@@ -1317,7 +1481,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 165,
@@ -1325,7 +1490,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 166,
@@ -1333,7 +1499,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 167,
@@ -1341,7 +1508,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 168,
@@ -1349,7 +1517,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 169,
@@ -1357,7 +1526,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 170,
@@ -1365,7 +1535,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 171,
@@ -1373,7 +1544,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 172,
@@ -1381,7 +1553,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 173,
@@ -1389,7 +1562,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 174,
@@ -1397,7 +1571,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 175,
@@ -1405,7 +1580,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 176,
@@ -1413,7 +1589,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "apsaia"
   },
   {
     "channel": 177,
@@ -1421,7 +1598,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "apsaia"
   },
   {
     "channel": 178,
@@ -1429,7 +1607,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 179,
@@ -1437,7 +1616,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 180,
@@ -1445,7 +1625,8 @@
     "pds_box": 12,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 181,
@@ -1453,7 +1634,8 @@
     "pds_box": 13,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 182,
@@ -1461,7 +1643,8 @@
     "pds_box": 12,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 183,
@@ -1469,7 +1652,8 @@
     "pds_box": 13,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 184,
@@ -1477,7 +1661,8 @@
     "pds_box": 14,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 185,
@@ -1485,7 +1670,8 @@
     "pds_box": 15,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 186,
@@ -1493,7 +1679,8 @@
     "pds_box": 14,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 187,
@@ -1501,7 +1688,8 @@
     "pds_box": 15,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 188,
@@ -1509,7 +1697,8 @@
     "pds_box": 16,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 189,
@@ -1517,7 +1706,8 @@
     "pds_box": 17,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 190,
@@ -1525,7 +1715,8 @@
     "pds_box": 16,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 191,
@@ -1533,7 +1724,8 @@
     "pds_box": 17,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 192,
@@ -1541,7 +1733,8 @@
     "pds_box": 12,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 193,
@@ -1549,7 +1742,8 @@
     "pds_box": 13,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 194,
@@ -1557,7 +1751,8 @@
     "pds_box": 14,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 195,
@@ -1565,7 +1760,8 @@
     "pds_box": 15,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 196,
@@ -1573,7 +1769,8 @@
     "pds_box": 16,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 197,
@@ -1581,7 +1778,8 @@
     "pds_box": 17,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 198,
@@ -1589,7 +1787,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 199,
@@ -1597,7 +1796,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 200,
@@ -1605,7 +1805,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 201,
@@ -1613,7 +1814,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 202,
@@ -1621,7 +1823,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 203,
@@ -1629,7 +1832,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 204,
@@ -1637,7 +1841,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 205,
@@ -1645,7 +1850,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 206,
@@ -1653,7 +1859,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 207,
@@ -1661,7 +1868,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 208,
@@ -1669,7 +1877,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 209,
@@ -1677,7 +1886,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 210,
@@ -1685,7 +1895,8 @@
     "pds_box": 12,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 211,
@@ -1693,7 +1904,8 @@
     "pds_box": 13,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 212,
@@ -1701,7 +1913,8 @@
     "pds_box": 14,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 213,
@@ -1709,7 +1922,8 @@
     "pds_box": 15,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 214,
@@ -1717,7 +1931,8 @@
     "pds_box": 16,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 215,
@@ -1725,7 +1940,8 @@
     "pds_box": 17,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 216,
@@ -1733,7 +1949,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 217,
@@ -1741,7 +1958,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 218,
@@ -1749,7 +1967,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 219,
@@ -1757,7 +1976,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 220,
@@ -1765,7 +1985,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 221,
@@ -1773,7 +1994,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 222,
@@ -1781,7 +2003,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 223,
@@ -1789,7 +2012,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 224,
@@ -1797,7 +2021,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 225,
@@ -1805,7 +2030,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 226,
@@ -1813,7 +2039,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 227,
@@ -1821,7 +2048,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 228,
@@ -1829,7 +2057,8 @@
     "pds_box": 12,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 229,
@@ -1837,7 +2066,8 @@
     "pds_box": 13,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 230,
@@ -1845,7 +2075,8 @@
     "pds_box": 14,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 231,
@@ -1853,7 +2084,8 @@
     "pds_box": 15,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 232,
@@ -1861,7 +2093,8 @@
     "pds_box": 16,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 233,
@@ -1869,7 +2102,8 @@
     "pds_box": 17,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 234,
@@ -1877,7 +2111,8 @@
     "pds_box": 18,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 235,
@@ -1885,7 +2120,8 @@
     "pds_box": 19,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 236,
@@ -1893,7 +2129,8 @@
     "pds_box": 20,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 237,
@@ -1901,7 +2138,8 @@
     "pds_box": 21,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 238,
@@ -1909,7 +2147,8 @@
     "pds_box": 22,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 239,
@@ -1917,7 +2156,8 @@
     "pds_box": 23,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 240,
@@ -1925,7 +2165,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 241,
@@ -1933,7 +2174,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 242,
@@ -1941,7 +2183,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 243,
@@ -1949,7 +2192,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 244,
@@ -1957,7 +2201,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 245,
@@ -1965,7 +2210,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 246,
@@ -1973,7 +2219,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 247,
@@ -1981,7 +2228,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 248,
@@ -1989,7 +2237,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 249,
@@ -1997,7 +2246,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 250,
@@ -2005,7 +2255,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 251,
@@ -2013,7 +2264,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 252,
@@ -2021,7 +2273,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 253,
@@ -2029,7 +2282,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 254,
@@ -2037,7 +2291,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 255,
@@ -2045,7 +2300,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 256,
@@ -2053,7 +2309,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 257,
@@ -2061,7 +2318,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 258,
@@ -2069,7 +2327,8 @@
     "pds_box": 18,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 259,
@@ -2077,7 +2336,8 @@
     "pds_box": 19,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 260,
@@ -2085,7 +2345,8 @@
     "pds_box": 18,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 261,
@@ -2093,7 +2354,8 @@
     "pds_box": 19,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 262,
@@ -2101,7 +2363,8 @@
     "pds_box": 20,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 263,
@@ -2109,7 +2372,8 @@
     "pds_box": 21,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 264,
@@ -2117,7 +2381,8 @@
     "pds_box": 20,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 265,
@@ -2125,7 +2390,8 @@
     "pds_box": 21,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 266,
@@ -2133,7 +2399,8 @@
     "pds_box": 22,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 267,
@@ -2141,7 +2408,8 @@
     "pds_box": 23,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 268,
@@ -2149,7 +2417,8 @@
     "pds_box": 22,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 269,
@@ -2157,7 +2426,8 @@
     "pds_box": 23,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 270,
@@ -2165,7 +2435,8 @@
     "pds_box": 18,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 271,
@@ -2173,7 +2444,8 @@
     "pds_box": 19,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 272,
@@ -2181,7 +2453,8 @@
     "pds_box": 20,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 273,
@@ -2189,7 +2462,8 @@
     "pds_box": 21,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 274,
@@ -2197,7 +2471,8 @@
     "pds_box": 22,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 275,
@@ -2205,7 +2480,8 @@
     "pds_box": 23,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 276,
@@ -2213,7 +2489,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 277,
@@ -2221,7 +2498,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 278,
@@ -2229,7 +2507,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 279,
@@ -2237,7 +2516,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 280,
@@ -2245,7 +2525,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 281,
@@ -2253,7 +2534,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 282,
@@ -2261,7 +2543,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 283,
@@ -2269,7 +2552,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 284,
@@ -2277,7 +2561,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 285,
@@ -2285,7 +2570,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 286,
@@ -2293,7 +2579,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 287,
@@ -2301,7 +2588,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 288,
@@ -2309,7 +2597,8 @@
     "pds_box": 18,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 289,
@@ -2317,7 +2606,8 @@
     "pds_box": 19,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 290,
@@ -2325,7 +2615,8 @@
     "pds_box": 20,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 291,
@@ -2333,7 +2624,8 @@
     "pds_box": 21,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 292,
@@ -2341,7 +2633,8 @@
     "pds_box": 22,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 293,
@@ -2349,7 +2642,8 @@
     "pds_box": 23,
     "sensible_to_vuv": false,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 294,
@@ -2357,7 +2651,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 295,
@@ -2365,7 +2660,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 296,
@@ -2373,7 +2669,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 297,
@@ -2381,7 +2678,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 298,
@@ -2389,7 +2687,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 299,
@@ -2397,7 +2696,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 300,
@@ -2405,7 +2705,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 301,
@@ -2413,7 +2714,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 302,
@@ -2421,7 +2723,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 303,
@@ -2429,7 +2732,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 304,
@@ -2437,7 +2741,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": ""
   },
   {
     "channel": 305,
@@ -2445,7 +2750,8 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": true,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": ""
   },
   {
     "channel": 306,
@@ -2453,7 +2759,8 @@
     "pds_box": 18,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 307,
@@ -2461,7 +2768,8 @@
     "pds_box": 19,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 308,
@@ -2469,7 +2777,8 @@
     "pds_box": 20,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 309,
@@ -2477,7 +2786,8 @@
     "pds_box": 21,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   },
   {
     "channel": 310,
@@ -2485,7 +2795,8 @@
     "pds_box": 22,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 0
+    "tpc": 0,
+    "sampling": "daphne"
   },
   {
     "channel": 311,
@@ -2493,6 +2804,7 @@
     "pds_box": 23,
     "sensible_to_vuv": true,
     "sensible_to_vis": false,
-    "tpc": 1
+    "tpc": 1,
+    "sampling": "daphne"
   }
 ]

--- a/sbndcode/OpDetSim/wvfAna_module.cc
+++ b/sbndcode/OpDetSim/wvfAna_module.cc
@@ -85,7 +85,7 @@ namespace opdet {
     std::vector<std::string> fOpDetsToPlot;
     std::stringstream histname;
     std::string opdetType;
-    std::string opdetSampling;
+    std::string opdetElectronics;
   };
 
 
@@ -155,7 +155,7 @@ namespace opdet {
     for(auto const& wvf : (*waveHandle)) {
       fChNumber = wvf.ChannelNumber();
       opdetType = pdMap.pdType(fChNumber);
-      opdetSampling = pdMap.SamplingType(fChNumber);
+      opdetElectronics = pdMap.electronicsType(fChNumber);
       if (std::find(fOpDetsToPlot.begin(), fOpDetsToPlot.end(), opdetType) == fOpDetsToPlot.end()) {continue;}
       histname.str(std::string());
       histname << "event_" << fEvNumber
@@ -164,7 +164,7 @@ namespace opdet {
                << "_" << hist_id;
 
       fStartTime = wvf.TimeStamp(); //in us
-      if (opdetSampling == "daphne"){
+      if (opdetElectronics == "daphne"){
 		  fEndTime = double(wvf.size()) / fSampling_Daphne + fStartTime;} //in us
 			else{
       fEndTime = double(wvf.size()) / fSampling + fStartTime;} //in us

--- a/sbndcode/OpDetSim/wvfAna_module.cc
+++ b/sbndcode/OpDetSim/wvfAna_module.cc
@@ -99,7 +99,7 @@ namespace opdet {
 
     auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
     fSampling = clockData.OpticalClock().Frequency(); // MHz
-    fSampling_Daphne=p.get<double >("DaphneFrequency" );
+    fSampling_Daphne = p.get<double>("DaphneFrequency" );
   }
 
   void wvfAna::beginJob()
@@ -165,9 +165,11 @@ namespace opdet {
 
       fStartTime = wvf.TimeStamp(); //in us
       if (opdetElectronics == "daphne"){
-		  fEndTime = double(wvf.size()) / fSampling_Daphne + fStartTime;} //in us
+				fEndTime = double(wvf.size()) / fSampling_Daphne + fStartTime;
+			} //in us
 			else{
-      fEndTime = double(wvf.size()) / fSampling + fStartTime;} //in us
+        fEndTime = double(wvf.size()) / fSampling + fStartTime;
+      } //in us
 
       //Create a new histogram
       TH1D *wvfHist = tfs->make< TH1D >(histname.str().c_str(), TString::Format(";t - %f (#mus);", fStartTime), wvf.size(), fStartTime, fEndTime);

--- a/sbndcode/OpDetSim/wvfana.fcl
+++ b/sbndcode/OpDetSim/wvfana.fcl
@@ -11,6 +11,8 @@ wvf_ana:
   OpDetsToPlot: ["pmt_coated", "pmt_uncoated",
                  "xarapuca_vuv", "xarapuca_vis",
                  "arapuca_vuv", "arapuca_vis"]
+  DaphneFrequency: 80.0  #in MHz. Frequency of the Daphne Readouts
+
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/wvfana.fcl
+++ b/sbndcode/OpDetSim/wvfana.fcl
@@ -9,8 +9,7 @@ wvf_ana:
   InputModule: "opdaq"
   ClusterModuleLabel: "linecluster"
   OpDetsToPlot: ["pmt_coated", "pmt_uncoated",
-                 "xarapuca_vuv", "xarapuca_vis",
-                 "arapuca_vuv", "arapuca_vis"]
+                 "xarapuca_vuv", "xarapuca_vis"]
   DaphneFrequency: 80.0  #in MHz. Frequency of the Daphne Readouts
 
 }


### PR DESCRIPTION
XArapuca Updates in the OpDetSim Module related to issues [#78](https://github.com/SBNSoftware/sbndcode/issues/78), [#80](https://github.com/SBNSoftware/sbndcode/issues/80) :

-Added new sampling field to the sbnd_pds_mapping.json file.
-Modified digitizer, op hit finder, wvf analyzer and trigger modules to differentiate daphne xarapuca channels with their own frequency. 
-Updated test bench XArapuca single electron response.

The data driven response is loaded from sbnd_data  ([OpDetSim/digi_arapuca_sbnd.root](https://github.com/SBNSoftware/sbndcode/blob/feature/rodrigoa_XArapucasUpdates/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl#L27)). The file needs to be updated adding the vectors with the single electron response data before the CI tests. 