### PR TITLE
Do not use xarapucas for fm

### DIFF
--- a/sbndcode/FlashMatch/flashmatch_sbnd.fcl
+++ b/sbndcode/FlashMatch/flashmatch_sbnd.fcl
@@ -14,7 +14,7 @@ sbnd_simple_flashmatch:{
   OnlyCollectionWires: false
   ForceConcurrence: true
   UseUncoatedPMT: true
-  UseARAPUCAS: true
+  UseARAPUCAS: false
   InputFileName: "FlashMatch/fm_metrics_sbnd.root"
   NoAvailableMetrics: false
   MakeTree: false


### PR DESCRIPTION
This is to address a potential issue that may arise from the change of the sampling frequency of (most of) the XARAPUCAS in: https://github.com/SBNSoftware/sbndcode/pull/133

As such, it should only be merged after that one.

The time resolution is substantially different, from 2 ns to 12.5 ns. One of the outcomes is that XARAPUCAS could potentially shift the peak towards later times. Surely there are other potential issues.

I've tested running without using xarapucas, the change of this PR, on 10k cosmics events and the FM still works OK. A more elaborate solution that allows us to mix different time resolutions needs to be worked out. 