### PR TITLE
Turn previously disabled geometry tests back on

### DIFF
--- a/test/Geometry/test_geometry_sbnd.fcl
+++ b/test/Geometry/test_geometry_sbnd.fcl
@@ -58,12 +58,6 @@ physics: {
       RunTests: [
         # run the default test suite (actually unnecessary):
         "@default",
-        # the following tests are known to fail (geometry needs to be fixed)
-        "-WireCoordFromPlane",  
-        "-PlanePointDecomposition",
-        "-WireCoordAngle",
-        "-NearestWire",
-        "-WirePitch",
         # in addition (overriding the default): print wires
         "+PrintWires"
       ]


### PR DESCRIPTION
As per discussion in PR #141 it was noted (thanks @PetrilloAtWork) that there are a series of geometry tests within the unit tests for the CI which aren't active due to issues in the old geometry making them fail. I ran tests this morning with [e20](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=lar_ci/12196&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=unit_test&buildtype=slf7%20e20:prof) and [c7](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=lar_ci/12197&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=unit_test&buildtype=slf7%20c7:prof) in which the "new" tests all succeeded. I see no reason why we shouldn't reactivate these tests from now on!

There will be merge conflicts with this and the previously mentioned PR. We want to keep the changes from both i.e. remove all the lines that I remove here but add the line that is `"-WireIntersection"` from the other PR. A further PR will be issued to remove this line as well once the issue in the geometry test has been solved by [this](https://eur02.safelinks.protection.outlook.com/?url=https%3A%2F%2Fgithub.com%2FLArSoft%2Flarcorealg%2Fpull%2F20%23issuecomment-897931692&data=04%7C01%7Clayh%40live.lancs.ac.uk%7Cabb6062a15b546fdc35008d95dcc8a66%7C9c9bcd11977a4e9ca9a0bc734090164a%7C0%7C0%7C637643955337793935%7CUnknown%7CTWFpbGZsb3d8eyJWIjoiMC4wLjAwMDAiLCJQIjoiV2luMzIiLCJBTiI6Ik1haWwiLCJXVCI6Mn0%3D%7C1000&sdata=o0eXWyzOzVRCO4nVZvacv66JyrqnMON9u9w5FDxuZko%3D&reserved=0).