### PR TITLE
Update PDFastSim_sbnd.fcl

### DIFF
--- a/sbndcode/LArSoftConfigurations/PDFastSim_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/PDFastSim_sbnd.fcl
@@ -15,6 +15,9 @@ BEGIN_PROLOG
 sbnd_pdfastsim_par:                     @local::standard_pdfastsim_par_ar
 
 sbnd_pdfastsim_par.SimulationLabel:     "ionandscint:priorSCE"
+# Updating the triplet decay-time (Phys. Rev. C 91, 035503). Note that in our simulations we account 
+# independently for the TPB-delay time and the emission (fast and slow) decay times.
+sbnd_pdfastsim_par.ScintTimeTool.SlowDecayTime: 1300.0
 
 # Direct (VUV)
 sbnd_pdfastsim_par.VUVTiming:           @local::sbnd_vuv_timing_parameterization
@@ -37,6 +40,7 @@ sbnd_pdfastsim_pvs:                     @local::standard_pdfastsim_pvs
 sbnd_pdfastsim_pvs.SimulationLabel:     "ionandscintout"
 sbnd_pdfastsim_pvs.IncludePropTime: true
 sbnd_pdfastsim_pvs.StoreReflected: true
+sbnd_pdfastsim_pvs.ScintTimeTool.SlowDecayTime: 1300.0
 
 
 


### PR DESCRIPTION
Updating the triplet-time to 1300ns in the newlarg4.
Notice that scintillation decay times are (re)defined in a new place "scinitllationtime_tool.fcl". The reason for this redefinition (instead of keep using the "larproperties.fcl" values) is that the logic of the new LArG4  is to try to minimize the dependence on services, since they interfere with multi-threading and make it harder to understand how the code is behaving. The new philosophy on any new code that goes in is to move configuration parameters to sit in the place where they are used.