### PR TITLE
Re-enable WireIntersection test

### DIFF
--- a/test/Geometry/test_geometry_sbnd.fcl
+++ b/test/Geometry/test_geometry_sbnd.fcl
@@ -73,9 +73,7 @@ physics: {
         # run the default test suite (actually unnecessary):
         "@default",
         # in addition (overriding the default): print wires
-        "+PrintWires",
-        # Disable WireIntersection temporarily as known to fail
-        "-WireIntersection"
+        "+PrintWires"
       ]
       
       # wire pitch for planes #0, #1 and #2


### PR DESCRIPTION
Now that [larcorealg PR#20](https://github.com/LArSoft/larcorealg/pull/20) has been merged, the `WireIntersection` test can be renabled, I have tested this morning that this _is_ the case and the [CI](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/7034&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=unit_test&buildtype=slf7%20e20:prof) logs show that the test passed fine.

