### PR TITLE
removing mcreco due to LArG4 empty trajectory bug

### DIFF
--- a/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
@@ -96,7 +96,10 @@ physics:
             , pdfastsim
             , pdfastsimout
             , simdrift
-            , mcreco
+            #, mcreco # Removed due to issues in LArG4 creating 
+                      # multiple copies of MCParticles without 
+                      # Trajectories leading to seg faults in mcreco
+                      # jaz8600@fnal.gov, Aug 26th, 2021
           ]
 
   # The output stream, there could be more than one if using filters


### PR DESCRIPTION
MCReco causes SegFault errors due to a bug in LArG4 that creates copies of MCParticles with no trajectory points. 

This is a hotfix for issue https://github.com/SBNSoftware/sbndcode/issues/165 but *does not* fix it

There is an open larsoft issues here:
https://cdcvs.fnal.gov/redmine/issues/26197