### PR TITLE
Match resource ranges between quick and seq tests

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -735,8 +735,8 @@ testlist=nucosmics_gen_quick_test_sbndcode nucosmics_g4_quick_test_sbndcode nuco
 STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=500:1504
-mem_usage_range=800000:1300004
+cpu_usage_range=400:1500
+mem_usage_range=800000:1800003
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_seq_test_sbndcode.fcl
@@ -756,8 +756,8 @@ STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=1500:3004
-mem_usage_range=1000000:2300004
+cpu_usage_range=400:18003
+mem_usage_range=2200000:3000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -779,8 +779,8 @@ STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=350:854
-mem_usage_range=1200000:1600004
+cpu_usage_range=500:1400
+mem_usage_range=2200000:4100003
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -802,8 +802,8 @@ STAGE_NAME=reco1
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=1400:3004
-mem_usage_range=1600000:3000004
+cpu_usage_range=300:1500
+mem_usage_range=1000000:3000003
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -825,8 +825,8 @@ STAGE_NAME=reco2
 INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=1400:3004
-mem_usage_range=1600000:3000004
+cpu_usage_range=150:1250
+mem_usage_range=800000:2500003
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -852,8 +852,8 @@ STAGE_NAME=anatree
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=250:504
-mem_usage_range=800000:1400004
+cpu_usage_range=60:650
+mem_usage_range=600000:1400003
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode


### PR DESCRIPTION
We regularly update the resource usage ranges for the quick (automatic trigger) tests. The equivalents for the sequential tests are very out-of-date so I've updated them to match the same as the quick tests.