### PR TITLE
Add calibration ntuples caloskimmer into the standard reco2 fcl

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -222,10 +222,10 @@ physics:
  # Run caloskimmer to produce ntuples for calibration as part of reco2 chain
  
  analyzers:{
-  caloskimmer: @local::caloskim_nodigits_goldentracks
+  caloskim: @local::caloskim_nodigits_goldentracks
  }
 
- caloskimana: [ caloskimmer ]
+ caloskimana: [ caloskim ]
  
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -211,6 +211,7 @@ physics:
          , crthitt0
          , crttrackt0
          , fmatch
+	 , caloskimCalorimetry
  ]
 
  # The new flashmatching will eventually be part of reco2, but for now
@@ -219,8 +220,6 @@ physics:
  opticalt0: [ opt0finder ]
 
  # Run caloskimmer to produce ntuples for calibration as part of reco2 chain
- # First run the uncalibrated calorimetry producer then run the skimmer analyzer
- caloskimprod: [ caloskimCalorimetry ]
  
  analyzers:{
   caloskimmer: @local::caloskim_nodigits_goldentracks

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -170,7 +170,7 @@ physics:
   opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
  
   ### Uncalibrated calorimetry producer for calibration caloskimmer
-  caloskimCalorimetry: @local::caloskim_pandoraCalo
+  caloskimCalorimetry: @local::caloskim_calorimetry
  
  }
 

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -127,7 +127,7 @@ physics:
   pandoraShowerLegacy: @local::sbnd_pandoraShowerCreation
   pandoraShower:       @local::sbnd_incremental_pandoraModularShowerCreation
   pandoraShowerSBN:    @local::sbnd_sbn_pandoraModularShowerCreation
-  pandoraCalo:         @local::sbnd_calomc
+  pandoraCalo:         @local::sbnd_gnewcalomc
   pandoraPid:          @local::sbnd_chi2pid
 
   pandoraSCECalo:      @local::sbnd_gnewcalomc

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -169,8 +169,8 @@ physics:
   opt0finder:          @local::sbnd_opt0_finder_one_to_many
   opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
  
-  ### Uncalibrated calorimetry producers for caloskimmer
-  caloskimCalorimetry: @local::caloskim_pandoraSCECalo
+  ### Uncalibrated calorimetry producer for calibration caloskimmer
+  caloskimCalorimetry: @local::caloskim_pandoraCalo
  
  }
 
@@ -301,7 +301,9 @@ physics.producers.linecluster.HitFinderModuleLabel:              "gaushit"
 
 ### Added for Rhiannon's analysis work
 physics.producers.pandoraCalo.TrackModuleLabel:                  "pandoraTrack"
-physics.producers.pandoraCalo.SpacePointModuleLabel:             "pandora"
+physics.producers.pandoraCalo.FieldDistortion:                	 false
+physics.producers.pandoraCalo.FieldDistortionEfield:          	 false
+physics.producers.pandoraCalo.TrackIsFieldDistortionCorrected:	 false
 physics.producers.pandoraPid.TrackModuleLabel:                   "pandoraTrack"
 physics.producers.pandoraPid.CalorimetryModuleLabel:             "pandoraCalo"
 

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -53,6 +53,7 @@
 
 ###include "hitparticleassociations.fcl"
 
+#include "sbnd_trackcalo_skimmer.fcl"
 
 process_name: Reco
 
@@ -167,6 +168,10 @@ physics:
   fmatchSCE:           @local::sbnd_simple_flashmatch
   opt0finder:          @local::sbnd_opt0_finder_one_to_many
   opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
+ 
+  ### Uncalibrated calorimetry producers for caloskimmer
+  caloskimCalorimetry: @local::caloskim_pandoraSCECalo
+ 
  }
 
  #define the producer and filter modules for this path, order matters,
@@ -213,6 +218,16 @@ physics:
  # reco fcl files.
  opticalt0: [ opt0finder ]
 
+ # Run caloskimmer to produce ntuples for calibration as part of reco2 chain
+ # First run the uncalibrated calorimetry producer then run the skimmer analyzer
+ caloskimprod: [ caloskimCalorimetry ]
+ 
+ analyzers:{
+  caloskimmer: @local::caloskim_nodigits_goldentracks
+ }
+
+ caloskimana: [ caloskimmer ]
+ 
  #define the output stream, there could be more than one if using filters
  stream1:  [ out1 ]
 

--- a/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
@@ -12,6 +12,5 @@
 
 process_name: Reco2
 
-physics.trigger_paths: [ reco2, #opticalt0,
-			caloskimprod ]
+physics.trigger_paths: [reco2, opticalt0]
 physics.end_paths: [stream1, caloskimana]

--- a/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
@@ -12,5 +12,6 @@
 
 process_name: Reco2
 
-physics.trigger_paths: [reco2, opticalt0]
+physics.trigger_paths: [reco2 #, opticalt0
+			]
 physics.end_paths: [stream1, caloskimana]

--- a/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
@@ -12,4 +12,6 @@
 
 process_name: Reco2
 
-physics.trigger_paths: [ reco2, opticalt0 ]
+physics.trigger_paths: [ reco2, #opticalt0,
+			caloskimprod ]
+physics.end_paths: [stream1, caloskimana]


### PR DESCRIPTION
Add caloskimmer, that runs uncalibrated calorimetry then creates ntuples for calibration, into the standard sbnd reco2 file. The caloskimmer is located sbncode. This is intended for October production.

Also edit the pandoraCalo to use Gnocchi module. 