### PR TITLE
G4 fcls with no optical simulation

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_no_opticalsim.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_no_opticalsim.fcl
@@ -1,4 +1,20 @@
+# File:    g4_no_opticalsim.fcl
+# Purpose: Same as standard_g4_sbnd.fcl, but does not do light simulation
+#
+# This runs the new, refactored, LArG4 simulation.
+
+
 #include "standard_g4_sbnd.fcl"
 
-services.PhotonVisibilityService: @erase
-services.LArG4Parameters: @local::sbnd_largeantparameters_noopticalsim
+# Remove the optical simulation process from the simulate path
+physics.simulate: [ rns
+                  , loader
+                  , largeant
+                  , ionandscint
+                  , simdrift
+                  , mcreco
+                ]
+
+physics.producers.ionandscintout: @erase
+physics.producers.pdfastsim: @erase
+physics.producers.pdfastsimout: @erase

--- a/sbndcode/JobConfigurations/standard/g4/g4_no_opticalsim_michel_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_no_opticalsim_michel_filter.fcl
@@ -1,20 +1,29 @@
+# File:    g4_no_opticalsim_michel_filter.fcl
+# Purpose: Same as standard_g4_sbnd.fcl, but does not do light simulation and applies the Michel
+#          electron filter
+#
+# This runs the new, refactored, LArG4 simulation.
+
+
 #include "larg4particlefilter.fcl"
 #include "g4_no_opticalsim.fcl"
 
 
+# Remove the optical simulation process from the simulate path and add the filter
 physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
-                  , pdfastsim
-                  , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco
                 ]
 
+physics.producers.ionandscintout: @erase
+physics.producers.pdfastsim: @erase
+physics.producers.pdfastsimout: @erase
 
+# Configure the Michel filter
 physics.filters.filter: @local::sbnd_larg4particlefilter
 physics.filters.filter.InterestingPDGs: [ 13 , 11 ]
 physics.filters.filter.ParticleMinMomentum: [ -1, 0 ]

--- a/sbndcode/JobConfigurations/standard/g4/g4_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_no_shower_rollup.fcl
@@ -1,3 +1,9 @@
+# File:    g4_no_shower_rollup.fcl
+# Purpose: Same as standard_g4_sbnd.fcl, but saves all EM shower daughter particles.
+#
+# This runs the new, refactored, LArG4 simulation.
+
+
 #include "standard_g4_sbnd.fcl"
 
-services.LArG4Parameters.KeepEMShowerDaughters: true
+services.ParticleListAction.keepEMShowerDaughters: true


### PR DESCRIPTION
This PR fixes the g4 fcls that run larg4 without optical simulation. Fixes #153.
