### PR TITLE
Adding tool for PMT gain fluctuations

### DIFF
--- a/sbndcode/OpDetSim/CMakeLists.txt
+++ b/sbndcode/OpDetSim/CMakeLists.txt
@@ -73,6 +73,7 @@ install_fhicl()
 install_source()
 cet_enable_asserts()
 add_subdirectory(FlashFinder)
+add_subdirectory(PMTAlg)
 
 # install sbnd_pds_mapping.json with mapping of the photon detectors
 install_fw(LIST sbnd_pds_mapping.json)

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -11,6 +11,7 @@
 
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/DelegatedParameter.h"
+#include "fhiclcpp/types/OptionalDelegatedParameter.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "CLHEP/Random/RandFlat.h"
@@ -63,7 +64,7 @@ namespace opdet {
       std::string PMTDataFile; //File containing timing emission structure for TPB, and single PE profile from data
       bool SinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
       bool MakeGainFluctuations; //Fluctuate PMT gain
-      fhicl::ParameterSet GainFluctuationsPset;
+      fhicl::ParameterSet GainFluctuationsParams;
 
       detinfo::LArProperties const* larProp = nullptr; //< LarProperties service provider.
       double frequency;       //wave sampling frequency (GHz)
@@ -132,7 +133,6 @@ namespace opdet {
     std::unique_ptr<opdet::PMTGainFluctuations> fPMTGainFluctuationsPtr;
 
     void AddSPE(size_t time_bin, std::vector<double>& wave); // add single pulse to auxiliary waveform
-    void AddSPE(size_t time_bin, std::vector<double>& wave, double npe);
     void Pulse1PE(std::vector<double>& wave);
     double Transittimespread(double fwhm);
 
@@ -267,8 +267,8 @@ namespace opdet {
         Comment("Option to fluctuate PMT gain")
       };
 
-      fhicl::DelegatedParameter gainFluctuationsPset {
-        Name("GainFluctuationsPset"),
+      fhicl::OptionalDelegatedParameter gainFluctuationsParams {
+        Name("GainFluctuationsParams"),
         Comment("Parameters used for SinglePE response fluctuations")
       };
 

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -10,6 +10,7 @@
 #define SBND_OPDETSIM_DIGIPMTSBNDALG_HH
 
 #include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/DelegatedParameter.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "CLHEP/Random/RandFlat.h"
@@ -17,6 +18,7 @@
 #include "CLHEP/Random/RandGeneral.h"
 #include "CLHEP/Random/RandPoissonQ.h"
 #include "CLHEP/Random/RandExponential.h"
+#include "art/Utilities/make_tool.h"
 
 #include <algorithm>
 #include <memory>
@@ -33,6 +35,8 @@
 #include "lardata/DetectorInfoServices/DetectorClocksServiceStandard.h"
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
+
+#include "sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations.hh"
 
 #include "TFile.h"
 
@@ -58,6 +62,8 @@ namespace opdet {
       double QERefl; //PMT quantum efficiency for reflected (TPB converted) light
       std::string PMTDataFile; //File containing timing emission structure for TPB, and single PE profile from data
       bool SinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
+      bool MakeGainFluctuations; //Fluctuate PMT gain
+      fhicl::ParameterSet GainFluctuationsPset;
 
       detinfo::LArProperties const* larProp = nullptr; //< LarProperties service provider.
       double frequency;       //wave sampling frequency (GHz)
@@ -122,7 +128,11 @@ namespace opdet {
 
     CLHEP::HepRandomEngine* fEngine; //!< Reference to art-managed random-number engine
 
+    //PMTFluctuationsAlg
+    std::unique_ptr<opdet::PMTGainFluctuations> fPMTGainFluctuationsPtr;
+
     void AddSPE(size_t time_bin, std::vector<double>& wave); // add single pulse to auxiliary waveform
+    void AddSPE(size_t time_bin, std::vector<double>& wave, double npe);
     void Pulse1PE(std::vector<double>& wave);
     double Transittimespread(double fwhm);
 
@@ -251,6 +261,17 @@ namespace opdet {
         Name("PMTDataFile"),
         Comment("File containing timing emission distribution for TPB and single pe pulse from data")
       };
+
+      fhicl::Atom<bool> makeGainFluctuations {
+        Name("MakeGainFluctuations"),
+        Comment("Option to fluctuate PMT gain")
+      };
+
+      fhicl::DelegatedParameter gainFluctuationsPset {
+        Name("GainFluctuationsPset"),
+        Comment("Parameters used for SinglePE response fluctuations")
+      };
+
     };    //struct Config
 
     DigiPMTSBNDAlgMaker(Config const& config); //Constructor

--- a/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
+++ b/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
@@ -1,0 +1,32 @@
+art_make(
+   TOOL_LIBRARIES
+         art_Utilities
+         larcore_Geometry_Geometry_service
+         lardataobj_RawData
+         lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
+         sbndcode_Utilities_SignalShapingServiceSBND_service
+         ${MF_MESSAGELOGGER}
+         ${FHICLCPP}
+         ${CETLIB}
+         ${CLHEP}
+         ${ROOT_BASIC_LIB_LIST}
+         ${ART_FRAMEWORK_CORE}
+         ${ART_FRAMEWORK_PRINCIPAL}
+         ${ART_FRAMEWORK_BASIC}
+         ${ART_FRAMEWORK_SERVICES_REGISTRY}
+         ${ART_FRAMEWORK_SERVICES_OPTIONAL}
+         ${ART_FRAMEWORK_SERVICES_OPTIONAL_TFILESERVICE_SERVICE}
+         ${ART_PERSISTENCY_COMMON}
+         ${ART_PERSISTENCY_PROVENANCE}
+         ${ART_UTILITIES}
+         cetlib
+         cetlib_except
+         ${MF_UTILITIES}
+
+)
+
+
+install_headers()
+install_fhicl()
+install_source()
+FILE(GLOB fcl_files *.fcl)

--- a/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
+++ b/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
@@ -1,28 +1,13 @@
 art_make(
    TOOL_LIBRARIES
          art_Utilities
-         larcore_Geometry_Geometry_service
-         lardataobj_RawData
-         lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-         sbndcode_Utilities_SignalShapingServiceSBND_service
          ${MF_MESSAGELOGGER}
          ${FHICLCPP}
          ${CETLIB}
          ${CLHEP}
-         ${ROOT_BASIC_LIB_LIST}
-         ${ART_FRAMEWORK_CORE}
-         ${ART_FRAMEWORK_PRINCIPAL}
-         ${ART_FRAMEWORK_BASIC}
-         ${ART_FRAMEWORK_SERVICES_REGISTRY}
-         ${ART_FRAMEWORK_SERVICES_OPTIONAL}
-         ${ART_FRAMEWORK_SERVICES_OPTIONAL_TFILESERVICE_SERVICE}
-         ${ART_PERSISTENCY_COMMON}
-         ${ART_PERSISTENCY_PROVENANCE}
-         ${ART_UTILITIES}
          cetlib
          cetlib_except
          ${MF_UTILITIES}
-
 )
 
 

--- a/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations.hh
+++ b/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations.hh
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////
+///
+/// Interface class for PMTGainFluctuations1Dynode tool
+///
+////////////////////////////////////////////////////////////////////////
+
+#ifndef SBND_PMTGainFluctuations_H
+#define SBND_PMTGainFluctuations_H
+
+
+
+namespace opdet {
+  class PMTGainFluctuations;
+}
+
+//Base class
+class opdet::PMTGainFluctuations {
+public:
+  //Constructor
+  virtual ~PMTGainFluctuations() noexcept = default;
+
+  //Returns fluctuated factor for SPR
+  virtual double GainFluctuation(unsigned int npe, CLHEP::HepRandomEngine* eng) = 0;
+};
+
+#endif

--- a/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////
+// Specific class tool for PMTGainFluctuations
+// File: PMTGainFluctuations1Dynode_tool.hh
+// Base class:        PMTGainFluctuations.hh
+// Algorithm based on function
+// 'multiplicationStageGain(unsigned int i /* = 1 */) const'
+// in icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+////////////////////////////////////////////////////////////////////////
+
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "art_root_io/TFileService.h"
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "lardata/DetectorInfoServices/LArPropertiesService.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "nurandom/RandomUtils/NuRandomService.h"
+#include "CLHEP/Random/RandPoissonQ.h"
+
+#include <vector>
+
+#include "sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations.hh"
+
+
+namespace opdet {
+  class PMTGainFluctuations1Dynode;
+}
+
+
+class opdet::PMTGainFluctuations1Dynode : opdet::PMTGainFluctuations {
+public:
+  explicit PMTGainFluctuations1Dynode(fhicl::ParameterSet const& p);
+
+  ~PMTGainFluctuations1Dynode() {}
+
+  //Returns fluctuated factor for SPR
+  double GainFluctuation(unsigned int npe, CLHEP::HepRandomEngine* eng) override;
+
+private:
+  //Configuration parameters
+  double fDynodeK;
+  unsigned int fGain;
+  std::vector<double> fVoltageDistribution;
+
+  double fRefGain;
+
+  unsigned int DynodeGain(unsigned int dynstage);
+};
+
+
+opdet::PMTGainFluctuations1Dynode::PMTGainFluctuations1Dynode(fhicl::ParameterSet const& p)
+{
+  //read fhicl paramters
+  fDynodeK = p.get< double >("DynodeK");
+  fGain = p.get< unsigned int >("Gain");
+  fVoltageDistribution  = p.get< std::vector<double> >("VoltageDistribution");
+
+  fRefGain = DynodeGain(1);
+}
+
+
+unsigned int opdet::PMTGainFluctuations1Dynode::DynodeGain(unsigned int dynstage){
+  double prodRho = 1.0;
+  for(double rho: fVoltageDistribution) prodRho *= rho;
+  double const aVk = std::pow(fGain / std::pow(prodRho, fDynodeK), 1.0/static_cast<double>(fVoltageDistribution.size()));
+  return aVk * std::pow(fVoltageDistribution.at(dynstage - 1), fDynodeK);
+}
+
+
+double opdet::PMTGainFluctuations1Dynode::GainFluctuation(unsigned int npe, CLHEP::HepRandomEngine* eng){
+  return CLHEP::RandPoissonQ::shoot(eng, npe*fRefGain)/fRefGain;
+}
+
+
+DEFINE_ART_CLASS_TOOL(opdet::PMTGainFluctuations1Dynode)

--- a/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
@@ -11,8 +11,11 @@
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "art/Utilities/ToolMacros.h"
 #include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
 #include "nurandom/RandomUtils/NuRandomService.h"
 #include "CLHEP/Random/RandPoissonQ.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
 
 #include <vector>
 
@@ -26,9 +29,30 @@ namespace opdet {
 
 class opdet::PMTGainFluctuations1Dynode : opdet::PMTGainFluctuations {
 public:
-  explicit PMTGainFluctuations1Dynode(fhicl::ParameterSet const& p);
 
-  ~PMTGainFluctuations1Dynode() {}
+  //Configuration parameters
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+
+    fhicl::Atom<double> dynodeK {
+      Name("DynodeK"),
+      Comment("Gain at each stage is proportional to pow(Voltage,DynodeK)")
+    };
+
+    fhicl::Atom<double> gain {
+      Name("Gain"),
+      Comment("PMT total gain")
+    };
+
+    fhicl::Sequence<double> voltageDistribution {
+      Name("VoltageDistribution"),
+      Comment("PMT voltage distribution ratio at each dynode")
+    };
+
+  };
+
+  explicit PMTGainFluctuations1Dynode(art::ToolConfigTable<Config> const& config);
 
   //Returns fluctuated factor for SPR
   double GainFluctuation(unsigned int npe, CLHEP::HepRandomEngine* eng) override;
@@ -36,27 +60,25 @@ public:
 private:
   //Configuration parameters
   double fDynodeK;
-  unsigned int fGain;
+  double fGain;
   std::vector<double> fVoltageDistribution;
 
-  double fRefGain;
+  double fDynodeGain;
 
-  unsigned int DynodeGain(unsigned int dynstage);
+  double DynodeGain(unsigned int dynstage);
 };
 
 
-opdet::PMTGainFluctuations1Dynode::PMTGainFluctuations1Dynode(fhicl::ParameterSet const& p)
+opdet::PMTGainFluctuations1Dynode::PMTGainFluctuations1Dynode(art::ToolConfigTable<Config> const& config)
+  : fDynodeK { config().dynodeK() }
+  , fGain { config().gain() }
+  , fVoltageDistribution { config().voltageDistribution() }
+  , fDynodeGain { DynodeGain(1) }
 {
-  //read fhicl paramters
-  fDynodeK = p.get< double >("DynodeK");
-  fGain = p.get< unsigned int >("Gain");
-  fVoltageDistribution  = p.get< std::vector<double> >("VoltageDistribution");
-
-  fRefGain = DynodeGain(1);
 }
 
 
-unsigned int opdet::PMTGainFluctuations1Dynode::DynodeGain(unsigned int dynstage){
+double opdet::PMTGainFluctuations1Dynode::DynodeGain(unsigned int dynstage){
   double prodRho = 1.0;
   for(double rho: fVoltageDistribution) prodRho *= rho;
   double const aVk = std::pow(fGain / std::pow(prodRho, fDynodeK), 1.0/static_cast<double>(fVoltageDistribution.size()));
@@ -65,7 +87,7 @@ unsigned int opdet::PMTGainFluctuations1Dynode::DynodeGain(unsigned int dynstage
 
 
 double opdet::PMTGainFluctuations1Dynode::GainFluctuation(unsigned int npe, CLHEP::HepRandomEngine* eng){
-  return CLHEP::RandPoissonQ::shoot(eng, npe*fRefGain)/fRefGain;
+  return CLHEP::RandPoissonQ::shoot(eng, npe*fDynodeGain)/fDynodeGain;
 }
 
 

--- a/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
@@ -9,9 +9,6 @@
 
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
-#include "art_root_io/TFileService.h"
-#include "lardata/DetectorInfoServices/DetectorClocksService.h"
-#include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "art/Utilities/ToolMacros.h"
 #include "art/Utilities/make_tool.h"
 #include "nurandom/RandomUtils/NuRandomService.h"

--- a/sbndcode/OpDetSim/PMTAlg/pmtgainfluctuations_config.fcl
+++ b/sbndcode/OpDetSim/PMTAlg/pmtgainfluctuations_config.fcl
@@ -3,7 +3,17 @@ BEGIN_PROLOG
 FirstDynodeGainFluctuations:
 {
   tool_type: "PMTGainFluctuations1Dynode"
+
+  #Constant DynodeK taken from Hamamatsu, PHOTOMULTIPLIER
+  #TUBES: Basics and Applications (Fourth Edition)
+  #In section 4.2.2.: "determined by the structure and material
+  #of the dynode and has a value from 0.7 to 0.8"
   DynodeK:                   0.75
+
+  #VoltageDistribution and Gain taken from Hamamatsu datasheet
+  #https://www.hamamatsu.com/resources/pdf/etd/LARGE_AREA_PMT_TPMH1376E.pdf
+  #TODO: SBND PMTs base circuit is different to the one specified in the datasheet
+  #TODO: Customize these values for the SBND configuration
   VoltageDistribution:    [ 17.4, 3.4, 5.0, 3.33, 1.67, 1.0, 1.2, 1.5, 2.2, 3.0 ]
   Gain:                   1e7            # total typical PMT gain
 }

--- a/sbndcode/OpDetSim/PMTAlg/pmtgainfluctuations_config.fcl
+++ b/sbndcode/OpDetSim/PMTAlg/pmtgainfluctuations_config.fcl
@@ -1,0 +1,11 @@
+BEGIN_PROLOG
+
+FirstDynodeGainFluctuations:
+{
+  tool_type: "PMTGainFluctuations1Dynode"
+  DynodeK:                   0.75
+  VoltageDistribution:    [ 17.4, 3.4, 5.0, 3.33, 1.67, 1.0, 1.2, 1.5, 2.2, 3.0 ]
+  Gain:                   1e7            # total typical PMT gain
+}
+
+END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -33,7 +33,7 @@ sbnd_digipmt_alg:
   SinglePEmodel:             false   # false for ideal PMT response, true for test bench measured response
   PMTDataFile:               "OpDetSim/digi_pmt_sbnd.root" # located in sbnd_data
 
-  MakeGainFluctuations: false
+  MakeGainFluctuations: true
   GainFluctuationsPset: @local::FirstDynodeGainFluctuations
 }
 

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -34,7 +34,7 @@ sbnd_digipmt_alg:
   PMTDataFile:               "OpDetSim/digi_pmt_sbnd.root" # located in sbnd_data
 
   MakeGainFluctuations: true
-  GainFluctuationsPset: @local::FirstDynodeGainFluctuations
+  GainFluctuationsParams: @local::FirstDynodeGainFluctuations
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -1,4 +1,5 @@
 #include "detsimmodules.fcl"
+#include "pmtgainfluctuations_config.fcl"
 
 BEGIN_PROLOG
 
@@ -31,6 +32,9 @@ sbnd_digipmt_alg:
   QERefl:                    0.03    #PMT quantum efficiency for reflected (TPB converted) light
   SinglePEmodel:             false   # false for ideal PMT response, true for test bench measured response
   PMTDataFile:               "OpDetSim/digi_pmt_sbnd.root" # located in sbnd_data
+
+  MakeGainFluctuations: false
+  GainFluctuationsPset: @local::FirstDynodeGainFluctuations
 }
 
 END_PROLOG


### PR DESCRIPTION
This PR adds an art tool to simulate PMT gain fluctuations (algorithm taken from icaruscode/PMT/Algorithms/PMTsimulationAlg.h). More details can be found in [docdb-23286](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=23286). Code modifications:
- Added [PMTAlg](https://github.com/SBNSoftware/sbndcode/tree/feature/fnicolas_sprfluc/sbndcode/OpDetSim/PMTAlg) directory containing the art tool for gain fluctuations
- Added modified version for the 'AddSPE' function in [DigiPMTSBNDAlg.cc](https://github.com/SBNSoftware/sbndcode/blob/feature/fnicolas_sprfluc/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc#L261)

Note that the MakeGainFluctuations parameter in [digi_pmt_sbnd.root](https://github.com/SBNSoftware/sbndcode/blob/feature/fnicolas_sprfluc/sbndcode/OpDetSim/digi_pmt_sbnd.fcl#L36) is set to true, so **SER fluctuation are simulated by default with this PR**.