### PR TITLE
Fix for opDetDigitizerSBND

### DIFF
--- a/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
@@ -277,7 +277,6 @@ namespace opdet {
     if (fUseSimPhotonsLite) {
       fPhotonLiteHandles.clear();
       //Get *ALL* SimPhotonsCollectionLite from Event
-      //e.getManyByType(fPhotonLiteHandles);
       fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
       if (fPhotonLiteHandles.size() == 0)
         mf::LogError("OpDetDigitizer") << "sim::SimPhotonsLite not found -> No Optical Detector Simulation!\n";
@@ -285,7 +284,6 @@ namespace opdet {
     else {
       fPhotonHandles.clear();
       //Get *ALL* SimPhotonsCollection from Event
-      //e.getManyByType(fPhotonHandles);
       fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
       if (fPhotonHandles.size() == 0)
         mf::LogError("OpDetDigitizer") << "sim::SimPhotons not found -> No Optical Detector Simulation!\n";

--- a/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerSBND_module.cc
@@ -278,7 +278,7 @@ namespace opdet {
       fPhotonLiteHandles.clear();
       //Get *ALL* SimPhotonsCollectionLite from Event
       //e.getManyByType(fPhotonLiteHandles);
-      auto fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
+      fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
       if (fPhotonLiteHandles.size() == 0)
         mf::LogError("OpDetDigitizer") << "sim::SimPhotonsLite not found -> No Optical Detector Simulation!\n";
     }
@@ -286,7 +286,7 @@ namespace opdet {
       fPhotonHandles.clear();
       //Get *ALL* SimPhotonsCollection from Event
       //e.getManyByType(fPhotonHandles);
-      auto fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
+      fPhotonLiteHandles = e.getMany<std::vector<sim::SimPhotonsLite>>();
       if (fPhotonHandles.size() == 0)
         mf::LogError("OpDetDigitizer") << "sim::SimPhotons not found -> No Optical Detector Simulation!\n";
     }

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.cc
@@ -153,22 +153,22 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
     for (const art::Handle<std::vector<sim::SimPhotonsLite>> &opdetHandle : photon_handles) {
       const bool Reflected = (opdetHandle.provenance()->productInstanceName() == "Reflected");
       for (auto const& litesimphotons : (*opdetHandle)){
-	
-	if(Reflected){
-	  auto it = AllPhotonsMap["Reflected"].find(litesimphotons.OpChannel);
-	  if(it==AllPhotonsMap["Reflected"].end())
-	    AllPhotonsMap["Reflected"][litesimphotons.OpChannel] = litesimphotons;
-	  else
-	    AllPhotonsMap["Reflected"][litesimphotons.OpChannel] += litesimphotons;
-	}
 
-	else{ //Direct
-	  auto it = AllPhotonsMap["Direct"].find(litesimphotons.OpChannel);
-	  if(it==AllPhotonsMap["Direct"].end())
-	    AllPhotonsMap["Direct"][litesimphotons.OpChannel] = litesimphotons;
-	  else
-	    AllPhotonsMap["Direct"][litesimphotons.OpChannel] += litesimphotons;
-	}
+        if(Reflected){
+          auto it = AllPhotonsMap["Reflected"].find(litesimphotons.OpChannel);
+          if(it==AllPhotonsMap["Reflected"].end())
+            AllPhotonsMap["Reflected"][litesimphotons.OpChannel] = litesimphotons;
+          else
+            AllPhotonsMap["Reflected"][litesimphotons.OpChannel] += litesimphotons;
+        }
+
+        else{ //Direct
+          auto it = AllPhotonsMap["Direct"].find(litesimphotons.OpChannel);
+          if(it==AllPhotonsMap["Direct"].end())
+            AllPhotonsMap["Direct"][litesimphotons.OpChannel] = litesimphotons;
+          else
+            AllPhotonsMap["Direct"][litesimphotons.OpChannel] += litesimphotons;
+        }
       }
     }
 
@@ -185,8 +185,8 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
       const bool Reflected = (simphotons_cols.first=="Reflected");
       for (auto const& simphotons_map : simphotons_cols.second) {
 
-	auto const& litesimphotons = simphotons_map.second;
-	
+        auto const& litesimphotons = simphotons_map.second;
+
         std::vector<short unsigned int> waveform;
         waveform.reserve(fConfig.Nsamples);
         const unsigned ch = litesimphotons.OpChannel;
@@ -270,22 +270,22 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
     for (const art::Handle<std::vector<sim::SimPhotons>> &opdetHandle : photon_handles) {
       const bool Reflected = (opdetHandle.provenance()->productInstanceName() == "Reflected");
       for (auto const& simphotons : (*opdetHandle)){
-	
-	if(Reflected){
-	  auto it = AllPhotonsMap["Reflected"].find(simphotons.OpChannel());
-	  if(it==AllPhotonsMap["Reflected"].end())
-	    AllPhotonsMap["Reflected"][simphotons.OpChannel()] = simphotons;
-	  else
-	    AllPhotonsMap["Reflected"][simphotons.OpChannel()] += simphotons;
-	}
 
-	else{ //Direct
-	  auto it = AllPhotonsMap["Direct"].find(simphotons.OpChannel());
-	  if(it==AllPhotonsMap["Direct"].end())
-	    AllPhotonsMap["Direct"][simphotons.OpChannel()] = simphotons;
-	  else
-	    AllPhotonsMap["Direct"][simphotons.OpChannel()] += simphotons;
-	}
+        if(Reflected){
+          auto it = AllPhotonsMap["Reflected"].find(simphotons.OpChannel());
+          if(it==AllPhotonsMap["Reflected"].end())
+            AllPhotonsMap["Reflected"][simphotons.OpChannel()] = simphotons;
+          else
+            AllPhotonsMap["Reflected"][simphotons.OpChannel()] += simphotons;
+        }
+
+        else{ //Direct
+          auto it = AllPhotonsMap["Direct"].find(simphotons.OpChannel());
+          if(it==AllPhotonsMap["Direct"].end())
+            AllPhotonsMap["Direct"][simphotons.OpChannel()] = simphotons;
+          else
+            AllPhotonsMap["Direct"][simphotons.OpChannel()] += simphotons;
+        }
       }
     }
 
@@ -304,7 +304,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
       const bool Reflected = (simphotons_cols.first=="Reflected");
       for (auto const& simphotons_map : simphotons_cols.second) {
 
-	auto const& simphotons = simphotons_map.second;
+        auto const& simphotons = simphotons_map.second;
 
         std::vector<short unsigned int> waveform;
         const unsigned ch = simphotons.OpChannel();


### PR DESCRIPTION
Fixing a bug that was introduced with the update to art v3_09.

The `SimPhotons` Handle was saved to a new variable rather than the exiting class member. This caused no optical waveform to be created.