### PR TITLE
CMake changes to ensure installation of files required for gallery tests

### DIFF
--- a/sbndcode/gallery/CMakeLists.txt
+++ b/sbndcode/gallery/CMakeLists.txt
@@ -6,12 +6,8 @@ foreach(ExampleDir IN ITEMS galleryAnalysis )
   # take *all* the files from the listed directory
   file(GLOB_RECURSE GalleryExamples RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} ${ExampleDir}/* )
   
-  # cet_install_files() will reproduce the intermediate subdirectories from the
-  # source list into the destination directory
- ## FIXME: replace with cmake install
- ## cet_install_files(
-  ##  LIST ${GalleryExamples}
-  ##  DIRNAME examples/gallery/${ExampleDir}
-  ##  )
+  # install will reproduce the intermediate subdirectories from the source list 
+  # into the destination directory
+  install(FILES ${GalleryExamples} DESTINATION "examples/gallery/${ExampleDir}")
   
 endforeach()


### PR DESCRIPTION
Following the changes required for the migration to art 3.09 the CI test `compilation_test_sbndcode` was failing. This was due to its inability to access the executable files in the gallery directory as they were no longer being installed during the build. This PR fixes this issue by using cmake's `install` to install these files to the same directory.

I am no CMake expert so this change was made by trial and error with some high-quality googling but it does the job ;) Anyone is welcome to suggest a better method.