### PR TITLE
Activate Vertexing Updates

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
@@ -30,7 +30,7 @@
     </CosmicRayTaggingTools>
     <SliceIdTools>
       <tool type = "LArBdtNeutrinoId">
-        <MvaFileName>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+        <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
         <MvaName>NeutrinoId</MvaName>
         <MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
         <MaximumNeutrinos>999</MaximumNeutrinos>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -91,6 +91,11 @@
     <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
     <EnableCrossingCandidates>false</EnableCrossingCandidates>
   </algorithm>
+  <algorithm type = "LArVertexRefinement">
+    <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
+    <InputVertexListName>CandidateVertices3D</InputVertexListName>
+    <OutputVertexListName>RefinedVertices3D</OutputVertexListName>
+  </algorithm>
   <algorithm type = "LArBdtVertexSelection">
     <InputCaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</InputCaloHitListNames>
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
@@ -447,7 +452,7 @@
   <!-- Output list management -->
   <algorithm type = "LArPostProcessing">
     <PfoListNames>NeutrinoParticles3D TrackParticles3D ShowerParticles3D</PfoListNames>
-    <VertexListNames>NeutrinoVertices3D DaughterVertices3D CandidateVertices3D</VertexListNames>
+    <VertexListNames>NeutrinoVertices3D DaughterVertices3D RefinedVertices3D</VertexListNames>
     <ClusterListNames>ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</ClusterListNames>
     <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
     <CurrentPfoListReplacement>NeutrinoParticles3D</CurrentPfoListReplacement>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -318,9 +318,9 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
@@ -398,9 +398,9 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -101,7 +101,7 @@
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
     <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v08_33_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
     <RegionMvaName>VertexBDTRegion</RegionMvaName>
     <VertexMvaName>VertexBDTVertex</VertexMvaName>
     <FeatureTools>
@@ -110,7 +110,10 @@
       <tool type = "LArGlobalAsymmetryFeature"/>
       <tool type = "LArShowerAsymmetryFeature"/>
       <tool type = "LArRPhiFeature"/>
+      <tool type = "LArEnergyDepositionAsymmetryFeature"/>
     </FeatureTools>
+    <LegacyEventShapes>false</LegacyEventShapes>
+    <LegacyVariables>false</LegacyVariables>
   </algorithm>
   <algorithm type = "LArCutClusterCharacterisation">
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,7 @@ fwdir   product_dir scripts
 
 product          version
 sbncode          v09_32_01
-sbnd_data        v01_08_00 - optional
+sbnd_data        v01_09_00 - optional
 sbndutil         v09_32_01 - optional
 
 # list products required ONLY for the build


### PR DESCRIPTION
This PR activates a series of updates to Pandora's vertex reconstruction that have been presented at TPC Reco & PAC meetings this year.

All the functionality has already been included in the `larpandoracontent` repository so this PR merely updates the SBND Pandora configuration to reflect that. Due to the inclusion of the BDT update, the version of sbnd_data requires bumping and the Pandora xmls need pointing to the new BDT files at various points (not just the vertexing). 

I have run the full reconstruction validation on this branch and the results can be found [here](https://dbweb9.fnal.gov:8443/TestCI/app/ns:SBND/build_detail/phase_details?build_id=lar_ci/12810&platform=Linux%203.10.0-1160.31.1.el7.x86_64&phase=ci_validation&buildtype=slf7%20e20:prof). I highlight the vertex distance plots found in the `pfpslicevalidationcompare` folder.

The `e20:prof` _standard_ CI build will also show the following product changes in the `reco2` stage:
```
1454: 170c170
1455: < Reco2 | pandoraShower |  | art::Assns<recob::Shower,recob::SpacePoint,void> | 838
1456: ---
1457: > Reco2 | pandoraShower |  | art::Assns<recob::Shower,recob::SpacePoint,void> | 840
1458: 181c181
1459: < Reco2 | pandora |  | art::Assns<recob::SpacePoint,recob::Hit,void> | 16585
1460: ---
1461: > Reco2 | pandora |  | art::Assns<recob::SpacePoint,recob::Hit,void> | 16587
1462: 206c206
1463: < Reco2 | pandora |  | std::vector<recob::SpacePoint> | 16585
1464: ---
1465: > Reco2 | pandora |  | std::vector<recob::SpacePoint> | 16587
1466: 214,215c214,215
1467: < Reco2 | pandora |  | art::Assns<recob::PFParticle,recob::SpacePoint,void> | 16585
1468: < Reco2 | pandoraShowerSBN |  | art::Assns<recob::Shower,recob::SpacePoint,void> | 838
1469: ---
1470: > Reco2 | pandora |  | art::Assns<recob::PFParticle,recob::SpacePoint,void> | 16587
1471: > Reco2 | pandoraShowerSBN |  | art::Assns<recob::Shower,recob::SpacePoint,void> | 840
1472: 220c220
1473: < Reco2 | pandoraShower |  | art::Assns<recob::Track,recob::Hit,void> | 263
1474: ---
1475: > Reco2 | pandoraShower |  | art::Assns<recob::Track,recob::Hit,void> | 279
1476: 225c225
1477: < Reco2 | pandoraShowerSBN |  | art::Assns<recob::Track,recob::Hit,void> | 512
1478: ---
1479: > Reco2 | pandoraShowerSBN |  | art::Assns<recob::Track,recob::Hit,void> | 497
```

These are sensible small changes which reflect the small adjustments in the vertex provided by the `VertexRefinementAlgorithm`.