### PR TITLE
add caloskim to reco2_sce.fcl

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
@@ -17,5 +17,7 @@ physics.reco2_sce: [@sequence::physics.reco2, #opt0finder,
 
 physics.trigger_paths: [ reco2_sce ]
 
+physics.end_paths: [stream1, caloskimana]
+
 # turn on space charge service
 #include "enable_spacecharge_services_sbnd.fcl"


### PR DESCRIPTION
Add caloskimmer to reco2_sce.fcl (intention for the next production that might include events with sce)
This commit enables the end_paths to include the caloskimana analyzer, similarly to the standard_reco2_sbnd.fcl.