### PR TITLE
Cosmic InTime Workflow with Refactored LArG4

### DIFF
--- a/sbndcode/JobConfigurations/base/prodcosmics_corsika_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodcosmics_corsika_sbnd.fcl
@@ -48,7 +48,7 @@ process_name: CosmicsGen
 services:
 {
 
-  TFileService:         { fileName: "prodcosmics_corsika_sbnd_%p-%tc_hists.root" }
+  TFileService:         { fileName: "hists_prodcosmics_corsika_sbnd_%p-%tc.root" }
                         @table::sbnd_basic_services   # from simulationservices_sbnd.fcl
                         @table::sbnd_random_services  # from simulationservices_sbnd.fcl
                         @table::sbnd_services  # from simulationservices_sbnd.fcl

--- a/sbndcode/JobConfigurations/base/prodgenie_bnb_nu_cosmic_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_bnb_nu_cosmic_sbnd.fcl
@@ -25,7 +25,7 @@
 process_name: GenieGen
 
 # output files
-services.TFileService.fileName: "prodgenie_bnb_nu_cosmic_sbnd_%p-%tc_hists.root"
+services.TFileService.fileName: "hists_prodgenie_bnb_nu_cosmic_sbnd_%p-%tc.root"
 outputs.out1.fileName: "prodgenie_bnb_nu_cosmic_sbnd_%p-%tc.root"
 
 physics.producers.generator: @local::sbnd_genie_simple

--- a/sbndcode/JobConfigurations/base/prodgenie_common_cosmic_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_common_cosmic_sbnd.fcl
@@ -46,7 +46,7 @@ process_name: GenieGen
 #
 services: {
   
-  TFileService:          { fileName: "prodgenie_common_cosmic_sbnd_%p-%tc_hists.root" }
+  TFileService:          { fileName: "hists_prodgenie_common_cosmic_sbnd_%p-%tc.root" }
   IFDH:                  {} # required by GENIEGen
                          @table::sbnd_basic_services   # from simulationservices_sbnd.fcl
                          @table::sbnd_random_services  # from simulationservices_sbnd.fcl

--- a/sbndcode/JobConfigurations/base/prodsingle_common_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodsingle_common_sbnd.fcl
@@ -31,7 +31,7 @@ services:
 {
                         @table::sbnd_basic_services
                         @table::sbnd_random_services
-  TFileService:         { fileName: "prodeminus_0.1_0.9_sbnd_%p-%tc_hists.root" }
+  TFileService:         { fileName: "hists_prodeminus_0.1_0.9_sbnd_%p-%tc.root" }
   FileCatalogMetadata:  @local::sbnd_file_catalog_mc
 }
 

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -19,11 +19,11 @@ physics.producers.pdfastsimouttime: @local::sbnd_pdfastsim_par
 physics.producers.simdriftouttime: @local::sbnd_simdrift
 
 # Set the appropriate input labels, to run geant4 only on the outtime cosmics
-physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
+physics.producers.simdriftintime.SimulationLabel: "ionandscintintime:priorSCE"
 physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
 physics.producers.ionandscintouttime.InputModuleLabels: ["larg4outtime"]
 physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
-physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime"
+physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 
 # Add processes for light simulation outside the active volume (AV) for the intimes
 physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -1,4 +1,14 @@
+# File:    g4_simphotontime_filter.fcl
+# Purpose: ?
+#
+# This runs the new, refactored, LArG4 simulation.
+
+#include "mergesimsources_sbnd.fcl"
+
 #include "standard_g4_sbnd.fcl"
+
+# Add process to finish the electron drift simulation for the intimes
+physics.producers.simdriftintime: @local::sbnd_simdrift
 
 # Add a geant4 process, that will run only on the outtime cosmics
 physics.producers.loader: { module_type: "PhysListLoader" }
@@ -7,62 +17,104 @@ physics.producers.ionandscintouttime: @local::sbnd_ionandscint
 physics.producers.pdfastsimouttime: @local::sbnd_pdfastsim_par
 physics.producers.simdriftouttime: @local::sbnd_simdrift
 
+# Add processes for light simulation outside the active volume (AV) for the intimes
+physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
+physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
+physics.producers.ionandscintoutintime.InputModuleLabels: ["larg4intime"]
+physics.producers.pdfastsimoutintime.SimulationLabel: "ionandscintoutintime"
+
+# Add processes for light simulation outside the active volume (AV) for the outtimes
+physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
+physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
+physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
+physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
+
 # Set the appropriate input labels, to run geant4 only on the outtime cosmics
+physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
 physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
-physics.producers.ionandscintouttime.InputCollections: ["larg4outtime"]
+physics.producers.ionandscintouttime.InputModuleLabels: ["larg4outtime"]
 physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime"
 
-# Add a process that merges the intime and outtime geant4 collections
-physics.producers.largeant: {
-  module_type: "MergeSimSources"
-  InputSourcesLabels: [ "larg4intime", "larg4outtime"]
-  TrackIDOffsets: [ 10000000, 20000000 ]
-}
+# Add a process that merges the MCParticles
+physics.producers.largeant: @local::sbnd_merge_sim_sources
+physics.producers.largeant.FillMCParticles: true
+physics.producers.largeant.InputSourcesLabels: [ "larg4intime", "larg4outtime"]
 
-# Tell MCReco
-# physics.producers.mcreco.MCParticleLabel: "largeant"
-# physics.producers.mcreco.SimChannelLabel: "largeant"
+# Add a process that merges the SimEnergyDeposits
+physics.producers.ionandscint: @local::sbnd_merge_sim_sources
+physics.producers.ionandscint.FillSimEnergyDeposits: true
+physics.producers.ionandscint.InputSourcesLabels: [ "ionandscintintime", "ionandscintouttime"]
+
+# Add a process that merges the SimChannels
+physics.producers.simdrift: @local::sbnd_merge_sim_sources
+physics.producers.simdrift.FillSimChannels: true
+physics.producers.simdrift.InputSourcesLabels: [ "simdriftintime", "simdriftouttime"]
+
+# Add a process that merges the AuxDetSimChannels
+physics.producers.crtsimch: @local::sbnd_merge_sim_sources
+physics.producers.crtsimch.FillAuxDetSimChannels: true
+physics.producers.crtsimch.InputSourcesLabels: [ "?", "?"]
+
+# Add a process that merges the SimPhotons inside the AV
+physics.producers.pdfastsim: @local::sbnd_merge_sim_sources
+physics.producers.pdfastsim.FillSimPhotons: true
+physics.producers.pdfastsim.InputSourcesLabels: [ "pdfastsimintime", "pdfastsimouttime"]
+
+# Add a process that merges the SimPhotons outside the AV
+physics.producers.pdfastsimout: @local::sbnd_merge_sim_sources
+physics.producers.pdfastsimout.FillSimPhotons: true
+physics.producers.pdfastsimout.InputSourcesLabels: [ "pdfastsimoutintime", "pdfastsimoutouttime"]
 
 # Add all these new modules to the simulate path
 physics.simulate: [ rns
+                  ### Complete intime drift simulation
+                  , simdriftintime
+                  ### Do full Geant4 simulation for the outtimes
                   , loader
                   , larg4outtime
                   , ionandscintouttime
                   , pdfastsimouttime
                   , simdriftouttime
+                  ### Simulate the light outside the AV
+                  , ionandscintoutintime
+                  , pdfastsimoutintime
+                  , ionandscintoutouttime
+                  , pdfastsimoutouttime
+                  ### Merge the intime and outtime paths
                   , largeant
-                  # , mcreco
-                  , rns ]
+                  , ionandscint
+                  , simdrift
+                  , pdfastsim
+                  , pdfastsimout
+                  ### Do truth-level reconstruction
+                  , mcreco
+                  ]
+
+services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
 
 # Drop the intime and outtime collections, which have now been
 # been merged into a 'largeant' collection
-# outputs.out1.outputCommands: [ "keep *_*_*_*",
-#                                "drop *_larg4intime_*_*",
-#                                "drop *_larg4outtime_*_*"]
-
-outputs.out1.outputCommands: [ "keep *_*_*_*"]
+outputs.out1.outputCommands: [ "keep *_*_*_*"
+                             # Drop G4
+                             , "drop *_larg4intime_*_*"
+                             , "drop *_larg4outtime_*_*"
+                             # Drop IonAndScint Inside AV
+                             , "drop *_ionandscintintime_*_*"
+                             , "drop *_ionandscintouttime_*_*"
+                             # Drop PDFastSim Inside AV
+                             , "drop *_pdfastsimintime_*_*"
+                             , "drop *_pdfastsimouttime_*_*"
+                             # Drop SimDrift Inside AV
+                             , "drop *_simdriftintime_*_*"
+                             , "drop *_simdriftouttime_*_*"
+                             # Drop IonAndScint Outside AV
+                             , "drop *_ionandscintoutintime_*_*"
+                             , "drop *_ionandscintoutouttime_*_*"
+                             # Drop PDFastSim Ouside AV
+                             , "drop *_pdfastsimoutintime_*_*"
+                             , "drop *_pdfastsimoutouttime_*_*"
+                             ]
 
 # Remove unnecesary processes
-# physics.producers.ionandscint: @erase
-# physics.producers.ionandscintout: @erase
-# physics.producers.pdfastsim: @erase
-# physics.producers.pdfastsimout: @erase
-# physics.producers.simdrift: @erase
-
-
-
-# physics.producers.larg4outtime: @local::physics.producers.largeant
-# physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]
-
-# physics.producers.largeant: {
-#   module_type: "MergeSimSources"
-#   InputSourcesLabels: [ "larg4intime","larg4outtime"]
-#   TrackIDOffsets: [ 10000000,20000000 ]
-# }
-
-# physics.simulate: [ rns, larg4outtime, largeant, mcreco ]
-
-# outputs.out1.outputCommands: [ "keep *_*_*_*",
-#                      "drop *_larg4intime_*_*",
-#                      "drop *_larg4outtime_*_*"]
+physics.producers.ionandscintout: @erase

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -1,16 +1,68 @@
 #include "standard_g4_sbnd.fcl"
 
-physics.producers.larg4outtime: @local::physics.producers.largeant
-physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]
+# Add a geant4 process, that will run only on the outtime cosmics
+physics.producers.loader: { module_type: "PhysListLoader" }
+physics.producers.larg4outtime: @local::sbnd_larg4
+physics.producers.ionandscintouttime: @local::sbnd_ionandscint
+physics.producers.pdfastsimouttime: @local::sbnd_pdfastsim_par
+physics.producers.simdriftouttime: @local::sbnd_simdrift
 
+# Set the appropriate input labels, to run geant4 only on the outtime cosmics
+physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
+physics.producers.ionandscintouttime.InputCollections: ["larg4outtime"]
+physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
+physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime"
+
+# Add a process that merges the intime and outtime geant4 collections
 physics.producers.largeant: {
   module_type: "MergeSimSources"
-  InputSourcesLabels: [ "larg4intime","larg4outtime"]
-  TrackIDOffsets: [ 10000000,20000000 ]
+  InputSourcesLabels: [ "larg4intime", "larg4outtime"]
+  TrackIDOffsets: [ 10000000, 20000000 ]
 }
 
-physics.simulate: [ rns, larg4outtime, largeant, mcreco ]
+# Tell MCReco
+# physics.producers.mcreco.MCParticleLabel: "largeant"
+# physics.producers.mcreco.SimChannelLabel: "largeant"
 
-outputs.out1.outputCommands: [ "keep *_*_*_*",
-                     "drop *_larg4intime_*_*",
-                     "drop *_larg4outtime_*_*"]
+# Add all these new modules to the simulate path
+physics.simulate: [ rns
+                  , loader
+                  , larg4outtime
+                  , ionandscintouttime
+                  , pdfastsimouttime
+                  , simdriftouttime
+                  , largeant
+                  # , mcreco
+                  , rns ]
+
+# Drop the intime and outtime collections, which have now been
+# been merged into a 'largeant' collection
+# outputs.out1.outputCommands: [ "keep *_*_*_*",
+#                                "drop *_larg4intime_*_*",
+#                                "drop *_larg4outtime_*_*"]
+
+outputs.out1.outputCommands: [ "keep *_*_*_*"]
+
+# Remove unnecesary processes
+# physics.producers.ionandscint: @erase
+# physics.producers.ionandscintout: @erase
+# physics.producers.pdfastsim: @erase
+# physics.producers.pdfastsimout: @erase
+# physics.producers.simdrift: @erase
+
+
+
+# physics.producers.larg4outtime: @local::physics.producers.largeant
+# physics.producers.larg4outtime.InputLabels: [ "GenInTimeSorter:outtime" ]
+
+# physics.producers.largeant: {
+#   module_type: "MergeSimSources"
+#   InputSourcesLabels: [ "larg4intime","larg4outtime"]
+#   TrackIDOffsets: [ 10000000,20000000 ]
+# }
+
+# physics.simulate: [ rns, larg4outtime, largeant, mcreco ]
+
+# outputs.out1.outputCommands: [ "keep *_*_*_*",
+#                      "drop *_larg4intime_*_*",
+#                      "drop *_larg4outtime_*_*"]

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -1,5 +1,6 @@
 # File:    g4_simphotontime_filter.fcl
-# Purpose: ?
+# Purpose: A geant4 fcl, supposed to run after prodcorsika_proton_intime_filter.fcl, or similar,
+#          for making cosmics in time samples.
 #
 # This runs the new, refactored, LArG4 simulation.
 

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -18,6 +18,13 @@ physics.producers.ionandscintouttime: @local::sbnd_ionandscint
 physics.producers.pdfastsimouttime: @local::sbnd_pdfastsim_par
 physics.producers.simdriftouttime: @local::sbnd_simdrift
 
+# Set the appropriate input labels, to run geant4 only on the outtime cosmics
+physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
+physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
+physics.producers.ionandscintouttime.InputModuleLabels: ["larg4outtime"]
+physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
+physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime"
+
 # Add processes for light simulation outside the active volume (AV) for the intimes
 physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
 physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
@@ -29,13 +36,6 @@ physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
 physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
 physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
 physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
-
-# Set the appropriate input labels, to run geant4 only on the outtime cosmics
-physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
-physics.producers.larg4outtime.inputCollections: [ "GenInTimeSorter:outtime" ]
-physics.producers.ionandscintouttime.InputModuleLabels: ["larg4outtime"]
-physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE"
-physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime"
 
 # Add a process that merges the MCParticles
 physics.producers.largeant: @local::sbnd_merge_sim_sources
@@ -52,7 +52,7 @@ physics.producers.simdrift: @local::sbnd_merge_sim_sources
 physics.producers.simdrift.FillSimChannels: true
 physics.producers.simdrift.InputSourcesLabels: [ "simdriftintime", "simdriftouttime"]
 
-# Add a process that merges the AuxDetSimChannels
+# Add a process that merges the AuxDetSimChannels TODO
 physics.producers.crtsimch: @local::sbnd_merge_sim_sources
 physics.producers.crtsimch.FillAuxDetSimChannels: true
 physics.producers.crtsimch.InputSourcesLabels: [ "?", "?"]

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -1,6 +1,10 @@
 #include "filtersgenintime_sbnd.fcl"
 #include "filterssimphotonlitetime_sbnd.fcl"
-#include "largeantmodules_sbnd.fcl"
+
+#include "larg4_sbnd.fcl"
+#include "ionandscint_sbnd.fcl"
+#include "PDFastSim_sbnd.fcl"
+#include "simdrift_sbnd.fcl"
 
 #include "prodcorsika_cosmics_proton.fcl"
 
@@ -12,17 +16,61 @@ services: {
   @table::sbnd_g4_services
 }
 
-physics.producers.larg4intime: @local::sbnd_largeant
-physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
-physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime
-
+# Rename generator to corsika
 physics.producers.corsika: @local::physics.producers.generator
 
-physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
-outputs.out1.SelectEvents: [ "simulate" ]
+# Add a generation filter, that splits in intime and outtime cosmics
+physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
 
-physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"]
-physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
-#physics.producers.larg4intime.SparsifyTrajectory: "true"
+# Add a geant4 process, only on the intime cosmics
+physics.producers.loader: { module_type: "PhysListLoader" }
+physics.producers.larg4intime: @local::sbnd_larg4
+physics.producers.ionandscintintime: @local::sbnd_ionandscint
+physics.producers.pdfastsimintime: @local::sbnd_pdfastsim_par
+physics.producers.simdriftintime: @local::sbnd_simdrift
 
-process_name: CosmicsCorsikaCMCGenAndG4InTime
+# Add a filter on the geant4 intime output, based on sim photons
+physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime
+
+# Add all these new modules to the simulate path
+physics.simulate: [ corsika
+                  , GenInTimeSorter
+                  , loader
+                  , larg4intime
+                  , ionandscintintime
+                  , pdfastsimintime
+                  , simdriftintime
+                  , timefilter
+                  , rns ]
+
+# Remove unnecesary processes
+physics.producers.generator: @erase
+
+# Set the appropriate input labels
+physics.producers.larg4intime.inputCollections: ["GenInTimeSorter:intime"]
+physics.producers.ionandscintintime.InputCollections: ["larg4intime"]
+physics.producers.pdfastsimintime.SimulationLabel: "ionandscintintime:priorSCE"
+physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
+physics.filters.timefilter.SimPhotonsLiteCollectionLabel: "pdfastsimintime"
+
+process_name: CosmicsCorsikaProtonGenAndG4InTime
+
+
+
+
+
+
+
+# physics.producers.larg4intime: @local::sbnd_largeant
+# physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
+# physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime
+
+
+# physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
+# outputs.out1.SelectEvents: [ "simulate" ]
+
+# physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"]
+# physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
+# #physics.producers.larg4intime.SparsifyTrajectory: "true"
+
+# process_name: CosmicsCorsikaCMCGenAndG4InTime

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -1,5 +1,5 @@
 # File:    prodcorsika_proton_intime_filter.fcl
-# Purpose: Generated CORSIKA events filtering out events with no cosmics intime
+# Purpose: Generates CORSIKA events filtering out events with no cosmics intime
 #
 # This runs the new, refactored, LArG4 simulation.
 #

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter.fcl
@@ -1,3 +1,11 @@
+# File:    prodcorsika_proton_intime_filter.fcl
+# Purpose: Generated CORSIKA events filtering out events with no cosmics intime
+#
+# This runs the new, refactored, LArG4 simulation.
+#
+# Ported from uBooNE gen-in-time fhicl for use by SBND
+# by Gray Putnam <grayputnam@uchicago.edu>
+
 #include "filtersgenintime_sbnd.fcl"
 #include "filterssimphotonlitetime_sbnd.fcl"
 
@@ -8,9 +16,8 @@
 
 #include "prodcorsika_cosmics_proton.fcl"
 
-# Ported from uBooNE gen-in-time fhicl for use by SBND
-# by Gray Putnam <grayputnam@uchicago.edu>
 
+# Add the g4 services
 services: {
   @table::services
   @table::sbnd_g4_services
@@ -27,7 +34,6 @@ physics.producers.loader: { module_type: "PhysListLoader" }
 physics.producers.larg4intime: @local::sbnd_larg4
 physics.producers.ionandscintintime: @local::sbnd_ionandscint
 physics.producers.pdfastsimintime: @local::sbnd_pdfastsim_par
-physics.producers.simdriftintime: @local::sbnd_simdrift
 
 # Add a filter on the geant4 intime output, based on sim photons
 physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime
@@ -39,38 +45,22 @@ physics.simulate: [ corsika
                   , larg4intime
                   , ionandscintintime
                   , pdfastsimintime
-                  , simdriftintime
                   , timefilter
-                  , rns ]
+                  , rns
+                  ]
 
 # Remove unnecesary processes
 physics.producers.generator: @erase
 
 # Set the appropriate input labels
 physics.producers.larg4intime.inputCollections: ["GenInTimeSorter:intime"]
-physics.producers.ionandscintintime.InputCollections: ["larg4intime"]
+physics.producers.ionandscintintime.InputModuleLabels: ["larg4intime"]
 physics.producers.pdfastsimintime.SimulationLabel: "ionandscintintime:priorSCE"
-physics.producers.simdriftintime.SimulationLabel: "ionandscintintime"
 physics.filters.timefilter.SimPhotonsLiteCollectionLabel: "pdfastsimintime"
+
+services.ParticleListAction.keepGenTrajectories: ["GenInTimeSorter"]
+
+outputs.out1.SelectEvents: [ "simulate" ]
 
 process_name: CosmicsCorsikaProtonGenAndG4InTime
 
-
-
-
-
-
-
-# physics.producers.larg4intime: @local::sbnd_largeant
-# physics.filters.GenInTimeSorter: @local::sbnd_filtergenintime
-# physics.filters.timefilter: @local::sbnd_timefilterssimphotonlitetime
-
-
-# physics.simulate: [ corsika, GenInTimeSorter, larg4intime, timefilter, rns ]
-# outputs.out1.SelectEvents: [ "simulate" ]
-
-# physics.producers.larg4intime.KeepParticlesInVolumes: ["volCryostat", "volTaggerTopHigh", "volTaggerTopLow", "volTaggerSideLeft", "volTaggerSideRight", "volTaggerFaceFront", "volTaggerFaceBack", "volTaggerBot"]
-# physics.producers.larg4intime.InputLabels: [ "GenInTimeSorter:intime" ]
-# #physics.producers.larg4intime.SparsifyTrajectory: "true"
-
-# process_name: CosmicsCorsikaCMCGenAndG4InTime

--- a/sbndcode/LArG4/mergesimsources_sbnd.fcl
+++ b/sbndcode/LArG4/mergesimsources_sbnd.fcl
@@ -1,0 +1,17 @@
+
+BEGIN_PROLOG
+
+sbnd_merge_sim_sources : {
+  module_type: "MergeSimSources"
+  FillMCParticles:             false
+  FillSimPhotons:              false
+  FillSimChannels:             false
+  FillAuxDetSimChannels:       false
+  FillSimEnergyDeposits:       false
+  InputSourcesLabels:          [ "larg4intime", "larg4outtime"]
+  TrackIDOffsets:              [ 10000000, 20000000 ]
+  StoreReflected:              true
+  EnergyDepositInstanceLabels: [ "priorSCE" ]
+}
+
+END_PROLOG


### PR DESCRIPTION
This PR adds a workflow for making intime samples with the new larg4 simulation. Fixes #147. 

Depends on: 
- LArSoft/larg4#30
- LArSoft/larsim#76

With the new larg4 we have a proliferation of modules that we need to run to get all the TPC, PDS, and CRT simulated products. It's much harder to bookkeep all of this when dealing with our intime workflow, where we first simulate in-time cosmics, then out-time ones, and then we merge them together. I made this flowchart to try and not forget anything, which I hope will be useful for the future as well.

![InTime Workflow drawio](https://user-images.githubusercontent.com/17006198/138000655-28508008-67d9-4050-be6e-df5e7313a894.png)

The fcls to run are:
- `prodcorsika_proton_intime_filter.fcl`, or `prodcorsika_proton_intime_filter_sce.fcl`
- `g4_simphotontime_filter.fcl`
- `standard_detsim_sbnd.fcl` and the usuals...

