### PR TITLE
New Dirt Flux Files Config I

### DIFF
--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -158,6 +158,22 @@ sbnd_flux_bnb_nu_Hv1_test1: {
 }
 
 
+#
+# Booster Neutrino Beam, neutrino mode, configuration I (v1)
+#
+sbnd_flux_bnb_nu_Iv1: {
+  FluxType:       "simple_flux"
+  FluxCopyMethod: "DIRECT"
+  FluxSearchPaths: "/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/fluxFiles/bnb/BooNEtoGSimple/configI-v1/october2021/neutrinoMode"
+  FluxFiles: [ "gsimple_bnb_neutrino_sbnd_dirt_v2_*.root" ]
+}
+
+sbnd_flux_bnb_nu_Iv1_test1: {
+  @table::sbnd_flux_bnb_nu_Iv1
+  FluxFiles: [ "gsimple_bnb_neutrino_sbnd_dirt_v2_0497.root" ]
+}
+
+
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -170,8 +186,8 @@ sbnd_flux_bnb_nu_test1: @local::sbnd_flux_bnb_nu_Hv1_test1
 #
 # Booster Neutrino Beam, interaction from dirt
 #
-sbnd_flux_bnb_dirt: @local::sbnd_flux_bnb_nu_Gv1
-sbnd_flux_bnb_dirt_test1: @local::sbnd_flux_bnb_nu_Gv1_test1
+sbnd_flux_bnb_dirt: @local::sbnd_flux_bnb_nu_Iv1
+sbnd_flux_bnb_dirt_test1: @local::sbnd_flux_bnb_nu_Iv1_test1
 
 #
 # NuMI Beam (placeholder)


### PR DESCRIPTION
Zarko produced new gSimple flux files for dirt event generation. These new files are produced with the same configuration as config H (added with PR #95) but with a larger window.

The files are installed in `/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/fluxFiles/bnb/BooNEtoGSimple/configI-v1/october2021/neutrinoMode/`, and this PR sets them as the default flux files to use for dirt generation.

The wiki page has been updated accordingly: https://sbnsoftware.github.io/sbndcode_wiki/The_SBND_flux_files.html. 
