### PR TITLE
Update of evd_sbnd

### DIFF
--- a/sbndcode/JobConfigurations/base/evd_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/evd_sbnd.fcl
@@ -42,4 +42,4 @@ physics:
 
 
 services.RawDrawingOptions.MinimumSignal:              10.
-
+services.SimulationDrawingOptions.SimChannelLabel:     "simdrift"


### PR DESCRIPTION
With the new LArG4, the label of the G4 sim::SimChannel has changed to simdrift (instead of largeant).
![image](https://user-images.githubusercontent.com/70945401/138924379-57bc36a7-2cd7-40c6-8cbd-5dfc705a2959.png)
I discovered the issue while trying to use the 3D-display:
![image](https://user-images.githubusercontent.com/70945401/138924986-d6d34b44-08bc-4492-a9da-1ad3acd0238f.png)
The extra line:
` services.SimulationDrawingOptions.SimChannelLabel:     "simdrift"`
fixes the problem (at least for the SimChannels, I didn't check other labels that might have changed), and the 3D display works again.
 