### PR TITLE
Set SimChannel module as simdrift in main backtracker service settings

### DIFF
--- a/sbndcode/LArSoftConfigurations/simulationservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/simulationservices_sbnd.fcl
@@ -59,6 +59,7 @@ sbnd_larvoxelcalculator:   @local::standard_larvoxelcalculator # from simulation
 sbnd_backtrackerservice:          @local::standard_backtrackerservice        # from backtrackerservice.fcl
 
 sbnd_backtrackerservice.BackTracker.G4ModuleLabel: "largeant"
+sbnd_backtrackerservice.BackTracker.SimChannelModuleLabel: "simdrift"
 sbnd_backtrackerservice.BackTracker.MinimumHitEnergyFraction: 1e-1
 sbnd_backtrackerservice.BackTracker.OverrideRealData: true
 


### PR DESCRIPTION
Setting this in the main inherited "sbnd_backtrackerservice" parameters, so individual modules don't have to worry about setting it.