### PR TITLE
Correct fcl path

### DIFF
--- a/test/ci/fcl_checks.sh
+++ b/test/ci/fcl_checks.sh
@@ -90,7 +90,7 @@ do
     fclout=${fcl%.fcl}_fhicl_dump.out
     larout=${fcl%.fcl}_lar.out
     larerr=${fcl%.fcl}_lar.err
-    lar -c ${SBNDCODE_DIR}/fcl/${fcl} --debug-config $fclout > $larout 2> $larerr
+    lar -c ${fcl} --debug-config $fclout > $larout 2> $larerr
 
 
     ##############################################


### PR DESCRIPTION
Shouldn't be giving it an explicit path it should be looking in the `$FHICL_FILE_PATH`, didn't pick this up in testing as I was only testing sbndcode fcls. The final push included a caf fcl which lives in sbncode so this showed up then! 