### PR TITLE
Turn off genie random seed flag

### DIFF
--- a/test/ci/sbnd_ci_nucosmics_gen_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_gen_quick_test_sbndcode.fcl
@@ -21,10 +21,7 @@ physics.producers.generator: {
   
   # ... and be as strict as possible with random seeds: GENIE is wild!
   Seed: 63213
-  
-  FluxCopyMethod: "DIRECT"
-  FluxSearchPaths: "/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/fluxFiles/bnb/BooNEtoGSimple/configH-v1/march2021/neutrinoMode"
-}
+}	
 
 # Override CORSIKA flux file path to be able to access them without a proxy
 physics.producers.corsika.ShowerInputFiles:[
@@ -34,3 +31,5 @@ physics.producers.corsika.ShowerInputFiles:[
             "/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/CORSIKA/standard/Mg_showers_*.db",
             "/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/CORSIKA/standard/Fe_showers_*.db"
 ]
+
+physics.producers.generator.UseHelperRndGen4GENIE : false


### PR DESCRIPTION
This PR solves SBNSoftware/sbndcode#130 which has been a persistent issue with the CI. 

I did some further debugging on this today with the idea of opening a larsoft level issue. I established that alongside the original noted issue:
- the occasional occurrence of pileup events (visible in the CI output as a difference in the number of `MCTruth`)

There is also a more deep level random seed issue:
- the generated single event (even when the pileup doesn't occur) is non-identical (different energies & positions)

I found a section of [GENIEHelper](https://cdcvs.fnal.gov/redmine/projects/nugen/repository/revisions/master/entry/nugen/EventGeneratorBase/GENIE/GENIEHelper.cxx#L1592) that uses a fcl flag `UseHelperRndGen4GENIE` which is set to true by default. This parameter is meant to avoid issues with the random seed by storing it to re-initialise with a few lines later, however by deactivating it both seeding issues are solved and the CI produces the same event every time (I ran 20 iterations). 

I won't pretend to understand what exactly was going on with these different stored random number helpers in the relevant section but I _am_ confident this solves the persistent issue we've faced with this CI test.

The other changes in this commit are just extra changes I noticed whilst working on this (we don't need this lines they are resetting these parameters to the values they already hold from the inherited tables).

I've cast a wide net for reviews from anyone who's been involved in these discussion previously for completeness' sake.