### PR TITLE
Utilise vtx histogram range parameter

### DIFF
--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -277,6 +277,8 @@ sbnd_genie: {
 # GlobalTimeOffset:   1.28e6                  #sbnd reads out 1.6ms before the spill
   GlobalTimeOffset:   0                  #Brailsford 2017/10/09 Simulation currently only reads out one drift frame so having a 1.6ms offset (one drift frame) means almost all events get placed outside the readout window.  We COULD make the readout window 2 or 3 drift frames long but we also have a disk space problem (we don't have any free).  The solution is to remove the offset and keep one frame readout
   #EventGeneratorList:      "Default+CCMEC+NCMEC" # Only needed to generate partial samples in GENIE v3
+   DefinedVtxHistRange: true
+   VtxPosHistRange:     [ -210, 210, -210, 210, -10, 510 ]
 } # sbnd_genie
 
 sbnd_genie_hist: {


### PR DESCRIPTION
Sorry for the spam today.

While creating SBNSoftware/sbndcode#209 I was using the the `hist_` files produced in GENIEGen. I realised that for SBND this uses a vertex position range that assumes a totally positive x detector. Using this parameter ensures that the plots of the vertices x position include both TPCs not just the positive x one. Minor thing but it seemed worth changing.