### PR TITLE
Deconvolution + HitFinder for XArapucas

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
@@ -66,8 +66,8 @@ private:
 
   double fNormUnAvSmooth;
   double fSamplingFreq;
+  double fDaphne_Freq;
   size_t MaxBinsFFT;
-
   unsigned int NDecoWf;
 
   TF1 *fFilterTF1;
@@ -114,6 +114,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
   fOpDetDataFile = p.get< std::string >("OpDetDataFile");
   fFilter = p.get< std::string >("Filter");
   fElectronics = p.get< std::string >("Electronics");
+  fDaphne_Freq  = p.get< double >("DaphneFreq");
   fScaleHypoSignal = p.get< bool >("ScaleHypoSignal");
   fUseParamFilter = p.get< bool >("UseParamFilter");
   fFilterParams = p.get< std::vector<double> >("FilterParams");
@@ -124,7 +125,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
 
   auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
   fSamplingFreq=clockData.OpticalClock().Frequency()/1000.;//in GHz
-  if (fElectronics=="Daphne") fSamplingFreq=80/1000.;//in GHz
+  if (fElectronics=="Daphne") fSamplingFreq=fDaphne_Freq/1000.;//in GHz
   auto const* lar_prop = lar::providerFrom<detinfo::LArPropertiesService>();
 
 

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
@@ -59,6 +59,7 @@ private:
   short unsigned int fBaselineSample;
   std::string fOpDetDataFile;
   std::string fFilter;
+  std::string fElectronics;
   bool fScaleHypoSignal;
   bool fUseParamFilter;
   std::vector<double> fFilterParams;
@@ -112,6 +113,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
   fBaselineSample = p.get< short unsigned int >("BaselineSample");
   fOpDetDataFile = p.get< std::string >("OpDetDataFile");
   fFilter = p.get< std::string >("Filter");
+  fElectronics = p.get< std::string >("Electronics");
   fScaleHypoSignal = p.get< bool >("ScaleHypoSignal");
   fUseParamFilter = p.get< bool >("UseParamFilter");
   fFilterParams = p.get< std::vector<double> >("FilterParams");
@@ -122,6 +124,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
 
   auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
   fSamplingFreq=clockData.OpticalClock().Frequency()/1000.;//in GHz
+  if (fElectronics=="Daphne") fSamplingFreq=80/1000.;//in GHz
   auto const* lar_prop = lar::providerFrom<detinfo::LArPropertiesService>();
 
 
@@ -132,6 +135,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
   TFile* file = TFile::Open(fname.c_str(), "READ");
   std::vector<double>* SinglePEVec_p;
   file->GetObject("SinglePEVec", SinglePEVec_p);
+  if (fElectronics=="Daphne") file->GetObject("SinglePEVec_40ftCable_Daphne", SinglePEVec_p);
   fSinglePEWave = *SinglePEVec_p;
   //for(size_t k=0; k<fSinglePEWave.size(); k++) std::cout<<"  "<<k<<":"<<fSinglePEWave[k];std::cout<<std::endl;
   mf::LogInfo("OpDeconvolutionAlg")<<"Loaded SER from "<<fOpDetDataFile<<"... size="<<fSinglePEWave.size()<<std::endl;
@@ -150,7 +154,7 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
     if(fFilter=="Wiener")
       fSignalHypothesis = ScintArrivalTimesShape(MaxBinsFFT, *lar_prop);
     else if(fFilter=="Wiener1PE")
-      fSignalHypothesis[0]=1;
+      fSignalHypothesis[0]=1; 
     mf::LogInfo("OpDeconvolutionAlg")<<"Built light signal hypothesis... L="<<fFilter<<" size"<<fSignalHypothesis.size()<<std::endl;
   }
 }

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
@@ -29,6 +29,7 @@ OpDeconvolutionAlg:
   UseParamFilter: false
   #Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))"
   FilterParams: [0.1, 20]
+  Electronics: "CAEN" # 2 Optical readouts in sbnd: "CAEN" for PMT and Apsaia XArapucas (500MHz/2 ns), "Daphne" for XArapucas with 80MHz/12.5 ns 
 }
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
@@ -30,6 +30,7 @@ OpDeconvolutionAlg:
   #Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))"
   FilterParams: [0.1, 20]
   Electronics: "CAEN" # 2 Optical readouts in sbnd: "CAEN" for PMT and Apsaia XArapucas (500MHz/2 ns), "Daphne" for XArapucas with 80MHz/12.5 ns 
+  DaphneFreq:  80 # in MHz 
 }
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/SBNDOpDeconvolution_module.cc
+++ b/sbndcode/OpDetReco/OpDeconvolution/SBNDOpDeconvolution_module.cc
@@ -51,6 +51,7 @@ private:
   // Declare member data here.
   std::string fInputLabel;
   std::vector<std::string> fPDTypes;
+  std::vector<std::string> fElectronics;
   //OpDecoAlg tool
   std::unique_ptr<opdet::OpDeconvolutionAlg> fOpDecoAlgPtr;
   //PDS map
@@ -66,6 +67,7 @@ opdet::SBNDOpDeconvolution::SBNDOpDeconvolution(fhicl::ParameterSet const& p)
   // Call appropriate consumes<>() for any products to be retrieved by this module.
   fInputLabel = p.get< std::string >("InputLabel");
   fPDTypes = p.get< std::vector<std::string> >("PDTypes");
+  fElectronics = p.get< std::vector<std::string> >("Electronics");
   fOpDecoAlgPtr = art::make_tool<opdet::OpDeconvolutionAlg>( p.get< fhicl::ParameterSet >("OpDecoAlg") );
 
   produces< std::vector< raw::OpDetWaveform > >();
@@ -85,7 +87,8 @@ void opdet::SBNDOpDeconvolution::produce(art::Event& e)
   RawWfVector.reserve(wfHandle->size());
 
   for(auto const& wf : *wfHandle){
-    if(std::find(fPDTypes.begin(), fPDTypes.end(), pdsmap.pdType(wf.ChannelNumber()) ) != fPDTypes.end() ){
+    if((std::find(fPDTypes.begin(), fPDTypes.end(), pdsmap.pdType(wf.ChannelNumber()) ) != fPDTypes.end() ) &&
+       (std::find(fElectronics.begin(), fElectronics.end(), pdsmap.electronicsType(wf.ChannelNumber()) ) != fElectronics.end()) ){
       RawWfVector.push_back(wf);
     }
   }

--- a/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
@@ -50,5 +50,10 @@ SBNDDecoSimpleFlashTPC1: @local::SBNDSimpleFlashTPC1
 SBNDDecoSimpleFlashTPC1.PECalib.SPEAreaGain: 100
 SBNDDecoSimpleFlashTPC1.OpHitProducers: ["ophitdecopmt"]
 
+#####OpHit finder for XArapuca deconvolved waveforms#####
+SBNDDecoOpHitFinderXArapuca:               @local::SBNDDecoOpHitFinderPMT
+SBNDDecoOpHitFinderXArapuca.InputModule:   "opdecoxarapuca"
+SBNDDecoOpHitFinderXArapuca.Electronics:   "Daphne"
+SBNDDecoOpHitFinderXArapuca.PD:            ["xarapuca_vis","xarapuca_vuv"]
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/opdeconvolution_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/opdeconvolution_sbnd.fcl
@@ -7,15 +7,19 @@ SBNDOpDeconvolution:
   module_type:	"SBNDOpDeconvolution"
   InputLabel: "opdaq"
   PDTypes: []
+  Electronics: []
   OpDecoAlg: @local::OpDeconvolutionAlg
 }
 
 SBNDOpDeconvolutionPMT: @local::SBNDOpDeconvolution
 SBNDOpDeconvolutionPMT.PDTypes: ["pmt_coated", "pmt_uncoated"]
+SBNDOpDeconvolutionPMT.Electronics: [""]
 SBNDOpDeconvolutionPMT.OpDecoAlg.OpDetDataFile: "OpDetSim/digi_pmt_sbnd.root"
 
-#SBNDOpDeconvolutionXARAPUCA: @local::SBNDOpDeconvolution
-#SBNDOpDeconvolutionXARAPUCA.PDTypes: ["xarapuca_vuv", "xarapuca_vis"]
-#SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.OpDetDataFile: "OpDetSim/digi_arapuca_sbnd.root"
+SBNDOpDeconvolutionXARAPUCA: @local::SBNDOpDeconvolution
+SBNDOpDeconvolutionXARAPUCA.PDTypes: ["xarapuca_vuv", "xarapuca_vis"]
+SBNDOpDeconvolutionXARAPUCA.Electronics: ["daphne"]
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.OpDetDataFile: "OpDetSim/digi_arapuca_sbnd.root"
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.Electronics: "Daphne"
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/run_decohitfinder.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/run_decohitfinder.fcl
@@ -45,13 +45,23 @@ physics:
     opflashdecotpc0:   @local::SBNDDecoSimpleFlashTPC0
     opflashdecotpc1:   @local::SBNDDecoSimpleFlashTPC1
 
+    opdecoxarapuca:     @local::SBNDOpDeconvolutionXARAPUCA
+    ophitdecoxarapuca:  @local::SBNDDecoOpHitFinderXArapuca
+    # opflashdecotpc0:   @local::SBNDDecoSimpleFlashTPC0
+    # opflashdecotpc1:   @local::SBNDDecoSimpleFlashTPC1
+
   }
 
   reco: [
     opdecopmt,
     ophitdecopmt,
     opflashdecotpc0,
-    opflashdecotpc1
+    opflashdecotpc1,
+
+    opdecoxarapuca,
+    ophitdecoxarapuca
+    # opflashdecotpc0,
+    # opflashdecotpc1
   ]
 
 

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -10,6 +10,8 @@ sbnd_ophit_finder:
   InputLabels:    [""]
   ChannelMasks:   []                  # Will ignore channels in this list
   PD:             ["pmt_coated", "pmt_uncoated"]  # Will only use PDS in this list
+  Electronics:    "CAEN" #Will only use PDS with CAEN/Daphne readouts (500/80MHz sampling frec)
+  DaphneFreq:     80    # Frequency of Daphne(XArapucas) readouts (in MHz)
   HitThreshold:   0.2   # PE
   AreaToPE:       true  # Use area to calculate number of PEs
   SPEArea:        66.33 # If AreaToPE is true, this number is
@@ -36,10 +38,11 @@ sbnd_ophit_finder_pmt.PedAlgoPset.MaxSigma:     1.7
 sbnd_ophit_finder_pmt.HitAlgoPset.ADCThreshold: 7
 
 #
-# OpHit for Arapuca - Configuration
+# OpHit for XArapuca - Configuration
 #
 sbnd_ophit_finder_arapuca: @local::sbnd_ophit_finder
-sbnd_ophit_finder_arapuca.PD: ["xarapuca_vis", "xarapuca_vuv", "arapuca_vis", "arapuca_vuv"]
+sbnd_ophit_finder_arapuca.PD: ["xarapuca_vis", "xarapuca_vuv"]
+sbnd_ophit_finder_arapuca.Electronics: "Daphne"
 sbnd_ophit_finder_arapuca.SPEArea: 8541. # It's 66.33 ADC = 132.66 ADCxns x 0.5ns^-1
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMax:  1520
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMin:  1480

--- a/sbndcode/OpDetSim/sbndPDMapAlg.hh
+++ b/sbndcode/OpDetSim/sbndPDMapAlg.hh
@@ -62,6 +62,7 @@ namespace opdet {
     std::string pdType(size_t ch) const override;
     std::string electronicsType(size_t ch) const;
     std::vector<int> getChannelsOfType(std::string pdname) const;
+    std::vector<int> getChannelsOfType(std::string pdname,std::string elname) const;//overload
     size_t size() const;
     auto getChannelEntry(size_t ch) const;
 

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -53,6 +53,15 @@ namespace opdet {
     return out_ch_v;
   }
 
+  std::vector<int> sbndPDMapAlg::getChannelsOfType(std::string pdname,std::string elname) const
+  {//overload to select channels by pdtype AND electronics type ~rodrigoa
+    std::vector<int> out_ch_v;
+    for (size_t ch = 0; ch < PDmap.size(); ch++) {
+      if ((PDmap.at(ch)["pd_type"] == pdname) && (PDmap.at(ch)["electronics"] == elname))out_ch_v.push_back(ch);
+    }
+    return out_ch_v;
+  }
+
   size_t sbndPDMapAlg::size() const
   {
     return PDmap.size();


### PR DESCRIPTION
This PR is related to the issue  #198 .

I added an electronics variable to the HitFinder and Deconvolution modules so we can distinguish daphne XArapucas from PMTs.
In the OpHitfinder side, I made an ad-hoc clock which is just a copy of the OpticalClock substituting the default optical frequency (500MHz) for the daphne readouts frequency (80MHz). The type of electronics then [decides which clock is passed](https://github.com/SBNSoftware/sbndcode/blob/bugfix/rodrigoa_hit_finder_xarapucas/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc#L232) to larana algorithm.
In this approach, deconvolved PMT and XArapuca waveforms are calculated separately. 
