### PR TITLE
Temporarily disable optical hybrid mode

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_3drift_faketrigger_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_3drift_faketrigger_filter.fcl
@@ -8,9 +8,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
+                  # , ionandscintout
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_dirt_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_dirt_filter.fcl
@@ -2,4 +2,5 @@
 
 #include "standard_g4_sbnd.fcl"
 
-physics.simulate: [ rns , ionandscint , ionandscintout , pdfastsim , pdfastsimout , simdrift , mcreco ]
+#physics.simulate: [ rns , ionandscint , ionandscintout , pdfastsim , pdfastsimout , simdrift , mcreco ]
+physics.simulate: [ rns , ionandscint , pdfastsim , simdrift , mcreco ]

--- a/sbndcode/JobConfigurations/standard/g4/g4_enterstpc_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_enterstpc_filter.fcl
@@ -6,9 +6,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
+                  # , ionandscintout
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_michelelectron_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_michelelectron_filter.fcl
@@ -5,9 +5,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
+                  # , ionandscintout
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_mu_crt_filter_base.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_mu_crt_filter_base.fcl
@@ -7,9 +7,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
+                  # , ionandscintout
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_mu_frontbackcrt_filter_enable_spacecharge.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_mu_frontbackcrt_filter_enable_spacecharge.fcl
@@ -8,9 +8,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  , ionandscintout
+                  # , ionandscintout
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -26,16 +26,16 @@ physics.producers.pdfastsimouttime.SimulationLabel: "ionandscintouttime:priorSCE
 physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 
 # Add processes for light simulation outside the active volume (AV) for the intimes
-physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
-physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
-physics.producers.ionandscintoutintime.InputModuleLabels: ["larg4intime"]
-physics.producers.pdfastsimoutintime.SimulationLabel: "ionandscintoutintime"
+# physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
+# physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
+# physics.producers.ionandscintoutintime.InputModuleLabels: ["larg4intime"]
+# physics.producers.pdfastsimoutintime.SimulationLabel: "ionandscintoutintime"
 
 # Add processes for light simulation outside the active volume (AV) for the outtimes
-physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
-physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
-physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
-physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
+# physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
+# physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
+# physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
+# physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
 
 # Add a process that merges the MCParticles
 physics.producers.largeant: @local::sbnd_merge_sim_sources
@@ -63,9 +63,9 @@ physics.producers.pdfastsim.FillSimPhotons: true
 physics.producers.pdfastsim.InputSourcesLabels: [ "pdfastsimintime", "pdfastsimouttime"]
 
 # Add a process that merges the SimPhotons outside the AV
-physics.producers.pdfastsimout: @local::sbnd_merge_sim_sources
-physics.producers.pdfastsimout.FillSimPhotons: true
-physics.producers.pdfastsimout.InputSourcesLabels: [ "pdfastsimoutintime", "pdfastsimoutouttime"]
+# physics.producers.pdfastsimout: @local::sbnd_merge_sim_sources
+# physics.producers.pdfastsimout.FillSimPhotons: true
+# physics.producers.pdfastsimout.InputSourcesLabels: [ "pdfastsimoutintime", "pdfastsimoutouttime"]
 
 # Add all these new modules to the simulate path
 physics.simulate: [ rns
@@ -78,16 +78,16 @@ physics.simulate: [ rns
                   , pdfastsimouttime
                   , simdriftouttime
                   ### Simulate the light outside the AV
-                  , ionandscintoutintime
-                  , pdfastsimoutintime
-                  , ionandscintoutouttime
-                  , pdfastsimoutouttime
+                  # , ionandscintoutintime
+                  # , pdfastsimoutintime
+                  # , ionandscintoutouttime
+                  # , pdfastsimoutouttime
                   ### Merge the intime and outtime paths
                   , largeant
                   , ionandscint
                   , simdrift
                   , pdfastsim
-                  , pdfastsimout
+                  # , pdfastsimout
                   ### Do truth-level reconstruction
                   , mcreco
                   ]
@@ -110,11 +110,11 @@ outputs.out1.outputCommands: [ "keep *_*_*_*"
                              , "drop *_simdriftintime_*_*"
                              , "drop *_simdriftouttime_*_*"
                              # Drop IonAndScint Outside AV
-                             , "drop *_ionandscintoutintime_*_*"
-                             , "drop *_ionandscintoutouttime_*_*"
+                             # , "drop *_ionandscintoutintime_*_*"
+                             # , "drop *_ionandscintoutouttime_*_*"
                              # Drop PDFastSim Ouside AV
-                             , "drop *_pdfastsimoutintime_*_*"
-                             , "drop *_pdfastsimoutouttime_*_*"
+                             # , "drop *_pdfastsimoutintime_*_*"
+                             # , "drop *_pdfastsimoutouttime_*_*"
                              ]
 
 # Remove unnecesary processes

--- a/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
@@ -71,13 +71,15 @@ physics:
     ionandscint: @local::sbnd_ionandscint
 
     # Creation of ionization electrons and scintillation photons, outside the active volume
-    ionandscintout: @local::sbnd_ionandscint_out
+    # ionandscintout: @local::sbnd_ionandscint_out
 
     # Light propogation inside the active volume
     pdfastsim: @local::sbnd_pdfastsim_par
 
     # Light propogation outside the active volume
-    pdfastsimout: @local::sbnd_pdfastsim_pvs
+    # Nov 16th, 2021
+    # Temporarily disable light simulation in the OUT-TPC (sbndcode issue 219)
+    # pdfastsimout: @local::sbnd_pdfastsim_pvs
 
     # Electron propogation
     simdrift: @local::sbnd_simdrift
@@ -92,9 +94,9 @@ physics:
             , loader
             , largeant
             , ionandscint
-            , ionandscintout
+            # , ionandscintout
             , pdfastsim
-            , pdfastsimout
+            # , pdfastsimout
             , simdrift
             , mcreco
           ]


### PR DESCRIPTION
This PR turns off optical simulation in the OUT-TPC volume (issue #219)