### PR TITLE
Feature/rodrigoa split s ers

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/reco_deco_sbnd/standard_detsim_sbnd_testbench.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/reco_deco_sbnd/standard_detsim_sbnd_testbench.fcl
@@ -1,4 +1,5 @@
 #include "standard_detsim_sbnd.fcl"
 
-physics.producers.opdaq.SinglePEmodel: true
+physics.producers.opdaq.PMTSinglePEmodel: true
+physics.producers.opdaq.ArapucaSinglePEmodel: true
 physics.producers.opdaq.PMTChargeToADC: -51.9

--- a/sbndcode/OpDetReco/OpFlash/job/run_flashfinder.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/run_flashfinder.fcl
@@ -97,7 +97,8 @@ physics:
 }
 
 ## Uncomment these if you switch to test bench response
-# physics.producers.opdaq.SinglePEmodel: true
+# physics.producers.opdaq.PMTSinglePEmodel: true
+# physics.producers.opdaq.ArapucaSinglePEmodel: true
 # physics.producers.opdaq.PMTChargeToADC: -51.9
 # physics.producers.ophit.SPEArea: 317.1
 # physics.producers.ophit.PedAlgoPset.SampleSize: 10

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -50,7 +50,7 @@ namespace opdet {
     size_t pulseSize_Daphne = fParams.PulseLength * fSampling_Daphne;
 	  fWaveformSP_Daphne.resize(pulseSize_Daphne);
 	
-    if(fParams.SinglePEmodel) {
+    if(fParams.ArapucaSinglePEmodel) {
       mf::LogDebug("DigiArapucaSBNDAlg") << " using testbench pe response";
       TFile* file =  TFile::Open(fname.c_str(), "READ");
       std::vector<double>* SinglePEVec_40ftCable_Daphne;
@@ -345,23 +345,23 @@ namespace opdet {
   (Config const& config)
   {
     // settings
-    fBaseConfig.ADC               = config.voltageToADC();
-    fBaseConfig.Baseline          = config.baseline();
-    fBaseConfig.Saturation        = config.saturation();
-    fBaseConfig.XArapucaVUVEff    = config.xArapucaVUVEff();
-    fBaseConfig.XArapucaVISEff    = config.xArapucaVISEff();
-    fBaseConfig.RiseTime          = config.riseTime();
-    fBaseConfig.FallTime          = config.fallTime();
-    fBaseConfig.MeanAmplitude     = config.meanAmplitude();
-    fBaseConfig.DarkNoiseRate     = config.darkNoiseRate();
-    fBaseConfig.BaselineRMS       = config.baselineRMS();
-    fBaseConfig.CrossTalk         = config.crossTalk();
-    fBaseConfig.PulseLength       = config.pulseLength();
-    fBaseConfig.PeakTime          = config.peakTime();
-    fBaseConfig.DecayTXArapucaVIS = config.decayTXArapucaVIS();
-    fBaseConfig.ArapucaDataFile   = config.arapucaDataFile();
-    fBaseConfig.SinglePEmodel     = config.singlePEmodel();
-    fBaseConfig.frequency_Daphne  = config.DaphneFrequency();
+    fBaseConfig.ADC                   = config.voltageToADC();
+    fBaseConfig.Baseline              = config.baseline();
+    fBaseConfig.Saturation            = config.saturation();
+    fBaseConfig.XArapucaVUVEff        = config.xArapucaVUVEff();
+    fBaseConfig.XArapucaVISEff        = config.xArapucaVISEff();
+    fBaseConfig.RiseTime              = config.riseTime();
+    fBaseConfig.FallTime              = config.fallTime();
+    fBaseConfig.MeanAmplitude         = config.meanAmplitude();
+    fBaseConfig.DarkNoiseRate         = config.darkNoiseRate();
+    fBaseConfig.BaselineRMS           = config.baselineRMS();
+    fBaseConfig.CrossTalk             = config.crossTalk();
+    fBaseConfig.PulseLength           = config.pulseLength();
+    fBaseConfig.PeakTime              = config.peakTime();
+    fBaseConfig.DecayTXArapucaVIS     = config.decayTXArapucaVIS();
+    fBaseConfig.ArapucaDataFile       = config.arapucaDataFile();
+    fBaseConfig.ArapucaSinglePEmodel  = config.ArapucasinglePEmodel();
+    fBaseConfig.frequency_Daphne      = config.DaphneFrequency();
   }
 
   std::unique_ptr<DigiArapucaSBNDAlg> DigiArapucaSBNDAlgMaker::operator()(

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -58,7 +58,7 @@ namespace opdet {
       double XArapucaVISEff;    //XArapucaVIS efficiency (optical window + cavity)
       double DecayTXArapucaVIS;// Decay time of EJ280 in ns
       std::string ArapucaDataFile; //File containing timing structure for arapucas
-      bool SinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
+      bool ArapucaSinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
 
       detinfo::LArProperties const* larProp = nullptr; ///< LarProperties service provider.
       double frequency; ///< Optical-clock frequency
@@ -234,8 +234,8 @@ namespace opdet {
         Comment("File containing timing distribution for ArapucaVUV (optical window + cavity), ArapucaVIS (optical window + cavity), XArapuca VUV (optical window)")
       };
       
-      fhicl::Atom<bool> singlePEmodel {
-        Name("SinglePEmodel"),
+      fhicl::Atom<bool> ArapucasinglePEmodel {
+        Name("ArapucaSinglePEmodel"),
         Comment("Model used for single PE response of PMT. =0 is ideal, =1 is from X-TDBoard data (with overshoot)")
       };
 

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
@@ -42,7 +42,7 @@ namespace opdet {
       (*fEngine, timeTPB_p->data(), timeTPB_p->size());
 
     //shape of single pulse
-    if (fParams.SinglePEmodel) {
+    if (fParams.PMTSinglePEmodel) {
       mf::LogDebug("DigiPMTSBNDAlg") << " using testbench pe response";
       std::vector<double>* SinglePEVec_p;
       file->GetObject("SinglePEVec", SinglePEVec_p);
@@ -463,7 +463,7 @@ namespace opdet {
     fBaseConfig.PMTSaturation            = config.pmtsaturation();
     fBaseConfig.QEDirect                 = config.qEDirect();
     fBaseConfig.QERefl                   = config.qERefl();
-    fBaseConfig.SinglePEmodel            = config.singlePEmodel();
+    fBaseConfig.PMTSinglePEmodel         = config.PMTsinglePEmodel();
     fBaseConfig.PMTRiseTime              = config.pmtriseTime();
     fBaseConfig.PMTFallTime              = config.pmtfallTime();
     fBaseConfig.PMTMeanAmplitude         = config.pmtmeanAmplitude();

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -62,7 +62,7 @@ namespace opdet {
       double QEDirect; //PMT quantum efficiency for direct (VUV) light
       double QERefl; //PMT quantum efficiency for reflected (TPB converted) light
       std::string PMTDataFile; //File containing timing emission structure for TPB, and single PE profile from data
-      bool SinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
+      bool PMTSinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
       bool MakeGainFluctuations; //Fluctuate PMT gain
       fhicl::ParameterSet GainFluctuationsParams;
 
@@ -252,8 +252,8 @@ namespace opdet {
         Comment("PMT quantum efficiency for reflected (TPB emitted)light")
       };
 
-      fhicl::Atom<bool> singlePEmodel {
-        Name("SinglePEmodel"),
+      fhicl::Atom<bool> PMTsinglePEmodel {
+        Name("PMTSinglePEmodel"),
         Comment("Model used for single PE response of PMT. =0 is ideal, =1 is testbench")
       };
 

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -25,7 +25,7 @@ sbnd_digiarapuca_alg:
   XArapucaVISEff:            0.014  #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
-  SinglePEmodel:             false   # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
+  ArapucaSinglePEModel       true  # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
   DaphneFrequency:             80.0  #in MHz. Frequency of the Daphne Readouts
 }
 

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -11,13 +11,13 @@ sbnd_digiarapuca_alg:
   ArapucaVoltageToADC:       151.5   #mV to ADC   
   ArapucaBaselineRMS:        2.6     #in ADC counts (underestimate?)
   ArapucaDarkNoiseRate:      10.0    #in Hz
-  CrossTalk:          0.2     #20% probability
+  CrossTalk:                 0.2     #20% probability
   ArapucaBaseline:           1500    #ADC counts
   ArapucaPulseLength:        4000.0  #ns
   ArapucaPeakTime:           260.0   #ns
   ArapucaMeanAmplitude:      0.12    #mV 
   ArapucaRiseTime:           9.0     #ns
-  ArapucaFallTime:	     476.0   #ns
+  ArapucaFallTime:	         476.0   #ns
   ArapucaSaturation:         300     #in number of p.e. to see saturation effects in the signal
   ArapucaVUVEff:             0.014   #Arapuca VUV efficiency (taking into account 70% mesh transparency 0.02*0.7)
   ArapucaVISEff:             0.0189  #Arapuca VIS efficiency (taking into account 70% mesh transparency 0.027*0.7)
@@ -25,8 +25,8 @@ sbnd_digiarapuca_alg:
   XArapucaVISEff:            0.014  #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
-  ArapucaSinglePEModel       true  # false for ideal XArapuca response, true for response from XTDBoard data (with overshoot)
-  DaphneFrequency:             80.0  #in MHz. Frequency of the Daphne Readouts
+  ArapucaSinglePEmodel:      true  # false for ideal response true for response from XTDBoard cold tests
+  DaphneFrequency:           80.0  #in MHz. Frequency of the Daphne Readouts
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -30,7 +30,7 @@ sbnd_digipmt_alg:
 
   QEDirect:                  0.03    #PMT quantum efficiency for direct (VUV) light
   QERefl:                    0.03    #PMT quantum efficiency for reflected (TPB converted) light
-  PMTSinglePEModedel:        false   # false for ideal PMT response, true for test bench measured response
+  PMTSinglePEmodel:        false   # false for ideal PMT response, true for test bench measured response
   PMTDataFile:               "OpDetSim/digi_pmt_sbnd.root" # located in sbnd_data
 
   MakeGainFluctuations: true

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -30,7 +30,7 @@ sbnd_digipmt_alg:
 
   QEDirect:                  0.03    #PMT quantum efficiency for direct (VUV) light
   QERefl:                    0.03    #PMT quantum efficiency for reflected (TPB converted) light
-  SinglePEmodel:             false   # false for ideal PMT response, true for test bench measured response
+  PMTSinglePEModedel:        false   # false for ideal PMT response, true for test bench measured response
   PMTDataFile:               "OpDetSim/digi_pmt_sbnd.root" # located in sbnd_data
 
   MakeGainFluctuations: true

--- a/sbndcode/OpDetSim/ophit_wvfana_sbnd.fcl
+++ b/sbndcode/OpDetSim/ophit_wvfana_sbnd.fcl
@@ -125,7 +125,8 @@ physics:
 #physics.producers.ophit.Area1pePMT:  1.3266    #in ADC*ns
 #physics.producers.opdaq.QEDirect: 0.03
 #physics.producers.opdaq.QERefl: 0.03
-#physics.producers.opdaq.SinglePEmodel: true
+#physics.producers.opdaq.PMTSinglePEmodel: true
+#physics.producers.opdaq.ArapucaSinglePEmodel: true
 #physics.producers.opdaq.PMTChargeToADC: -51.9
 
 #physics.analyzers.wvfana.  OpDetsToPlot: ["pmt_coated", "pmt_uncoated"]


### PR DESCRIPTION
Small update to the parameter that switches between Ideal and test(data driven) simulation of optical waveforms (detsim).
With this PR we can tune XArapucas and PMTs separately as each one has its own variable (replaced SinglePEmodel with ArapucaSinglePEmodel and PMTSinglePEmodel).

As the ideal response is outdated for XArapucas, I've switched the test response to default for the upcoming production. This will likely trigger warnings in the CI tests at ophit level from XArapucas. This is expected as the [test ser shape is thinner and presents overshooting](https://user-images.githubusercontent.com/70945401/128691609-24112902-21fb-4510-8b9c-0c022e55908a.png) (I expect ophits to decrease).

Ideal response for PMTs remains as default.