### PR TITLE
Improvements to fcl checks

### DIFF
--- a/test/ci/fcl_checks.sh
+++ b/test/ci/fcl_checks.sh
@@ -62,7 +62,10 @@ else
     exit_code=${?}
     echo -e "\nCannot find reference tar: ${ACCESS_REF_DIR}/${REF_FILE}"
     echo "Exiting with exit code: ${exit_code}"
-    exit 1
+    EXITSTATUS=F
+    ERRORSTRING="Failure accessing reference tar file~Check the log"
+    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $CWD/data_production_stats${ci_cur_exp_name}.log
+    exit $exit_code
 fi
 
 echo -e "\nList of reference files in: ${LOCAL_REF_DIR}"
@@ -161,13 +164,13 @@ fi
 exit_code=0
 
 if [[ $exit_code_parsing -ne 0 && $exit_code_dump -ne 0 ]]; then
-    ERRORSTRING="Error parsing fcl file and differences in fhicl dump outputs"
+    ERRORSTRING="Error parsing fcl file and differences in fhicl dump outputs~Check error in log"
     let exit_code=201
 elif [[ $exit_code_parsing -ne 0 ]]; then
-    ERRORSTRING="Error parsing fcl file"
+    ERRORSTRING="Error parsing fcl file~Check error in log"
     let exit_code=201
 elif [[ $exit_code_dump -ne 0 ]]; then
-    ERRORSTRING="Differences in fhicl dump outputs"
+    ERRORSTRING="Differences in fhicl dump outputs~Update reference files"
     let exit_code=201
 else
     ERRORSTRING="All checks successful"
@@ -175,5 +178,11 @@ fi
 
 echo "Exiting with exit code: $exit_code"
 echo "$ERRORSTRING"
+
+
+if [[ $exit_code -ne 0 ]]; then
+    EXITSTATUS=W
+    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $CWD/data_production_stats${ci_cur_exp_name}.log
+fi
 
 exit $exit_code

--- a/test/ci/fcl_checks.sh
+++ b/test/ci/fcl_checks.sh
@@ -54,35 +54,35 @@ exit_code_dump=0
 
 echo -e "\nRemote Reference Directory: ${ACCESS_REF_DIR}"
 
-if IFDH_DEBUG=0 ifdh ll --force=root ${ACCESS_REF_DIR}/${REF_FILE}
-then
-    echo -e "\nFound reference tar: ${ACCESS_REF_DIR}/${REF_FILE}"
-    echo "ifdh cp ${ACCESS_REF_DIR}/${REF_FILE} ${LOCAL_REF_DIR}/${REF_FILE}"
-    ifdh cp ${ACCESS_REF_DIR}/${REF_FILE} ${LOCAL_REF_DIR}/${REF_FILE}
-    echo -e "\nExtract tar to local references directory"
-    echo "tar -xzvf references/${REF_FILE} -C ${LOCAL_REF_DIR}"
-    tar -xzvf references/${REF_FILE} -C ${LOCAL_REF_DIR}
-else
-    exit_code=${?}
-    echo -e "\nCannot find reference tar: ${ACCESS_REF_DIR}/${REF_FILE}"
-    echo "Exiting with exit code: ${exit_code}"
-    EXITSTATUS=F
-    ERRORSTRING="Failure accessing reference tar file~Check the log"
-    echo "`basename $CWD`~${exit_code}~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
-    exit $exit_code
-fi
+if [[ ${UPDATE_REF_FILE_ON} -gt 0 ]]; then
+    echo -e "\nUpdating ref files for fcl checks"
+    export datestamp=$(date +"%Y%m%d%H%M")
 
-echo -e "\nList of reference files in: ${LOCAL_REF_DIR}"
-echo "$(ls ${LOCAL_REF_DIR}/*)"
+else
+    if IFDH_DEBUG=0 ifdh ll --force=root ${ACCESS_REF_DIR}/${REF_FILE}
+    then
+	echo -e "\nFound reference tar: ${ACCESS_REF_DIR}/${REF_FILE}"
+	echo "ifdh cp ${ACCESS_REF_DIR}/${REF_FILE} ${LOCAL_REF_DIR}/${REF_FILE}"
+	ifdh cp ${ACCESS_REF_DIR}/${REF_FILE} ${LOCAL_REF_DIR}/${REF_FILE}
+	echo -e "\nExtract tar to local references directory"
+	echo "tar -xzvf references/${REF_FILE} -C ${LOCAL_REF_DIR}"
+	tar -xzvf references/${REF_FILE} -C ${LOCAL_REF_DIR}
+    else
+	exit_code=${?}
+	echo -e "\nCannot find reference tar: ${ACCESS_REF_DIR}/${REF_FILE}"
+	echo "Exiting with exit code: ${exit_code}"
+	EXITSTATUS=F
+	ERRORSTRING="Failure accessing reference tar file~Check the log"
+	echo "`basename $CWD`~${exit_code}~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
+	exit $exit_code
+    fi
+
+    echo -e "\nList of reference files in: ${LOCAL_REF_DIR}"
+    echo "$(ls ${LOCAL_REF_DIR}/*)"
+fi
 
 echo -e "\nList of files from: ${SBNDCODE_DIR}/test/fcl_file_checks.list"
 echo "$(cat ${SBNDCODE_DIR}/test/fcl_file_checks.list)"
-
-export datestamp=$(date +"%Y%m%d%H%M")
-
-if [[ ${UPDATE_REF_FILE_ON} -gt 0 ]]; then
-    echo -e "\nUpdating ref files for fcl checks"
-fi
 
 for fcl in `cat ${SBNDCODE_DIR}/test/fcl_file_checks.list`
 
@@ -180,8 +180,8 @@ else
     ERRORSTRING="All checks successful"
 fi
 
-echo "Exiting with exit code: $exit_code"
-echo "$ERRORSTRING"
+echo -e "\nExiting with exit code: $exit_code"
+echo $ERRORSTRING | cut -d~ -f 1
 
 
 if [[ $exit_code -ne 0 ]]; then

--- a/test/ci/fcl_checks.sh
+++ b/test/ci/fcl_checks.sh
@@ -68,7 +68,7 @@ else
     echo "Exiting with exit code: ${exit_code}"
     EXITSTATUS=F
     ERRORSTRING="Failure accessing reference tar file~Check the log"
-    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
+    echo "`basename $CWD`~${exit_code}~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
     exit $exit_code
 fi
 
@@ -186,7 +186,7 @@ echo "$ERRORSTRING"
 
 if [[ $exit_code -ne 0 ]]; then
     EXITSTATUS=W
-    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
+    echo "`basename $CWD`~${exit_code}~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
 fi
 
 exit $exit_code

--- a/test/ci/fcl_checks.sh
+++ b/test/ci/fcl_checks.sh
@@ -11,6 +11,10 @@ echo "args: ${@}"
 #########################################################################
 
 CWD="$(pwd)"
+
+WORKSPACE=${WORKSPACE:-$PWD}
+ci_cur_exp_name=${ci_cur_exp_name:-${EXPERIMENT}}
+
 WORK_DIR="${CWD}/fcl_tests"
 LOCAL_REF_DIR="${WORK_DIR}/references"
 
@@ -64,7 +68,7 @@ else
     echo "Exiting with exit code: ${exit_code}"
     EXITSTATUS=F
     ERRORSTRING="Failure accessing reference tar file~Check the log"
-    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $CWD/data_production_stats${ci_cur_exp_name}.log
+    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
     exit $exit_code
 fi
 
@@ -182,7 +186,7 @@ echo "$ERRORSTRING"
 
 if [[ $exit_code -ne 0 ]]; then
     EXITSTATUS=W
-    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $CWD/data_production_stats${ci_cur_exp_name}.log
+    echo "`basename $CWD`~${EXITSTATUS}~$ERRORSTRING" >> $WORKSPACE/data_production_stats${ci_cur_exp_name}.log
 fi
 
 exit $exit_code


### PR DESCRIPTION
Having run it for a couple of weeks now I have a couple of improvements that I want to make to the `fcl_checks_sbndcode` CI checks. This PR:

- Adds the correctly formatted error strings to pass to the data_production_stats` log file. This will mean the dashboard and email responses will contain a reason for failure / warning now like the other regression tests. I have tested that [here](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/7987&platform=Linux%203.10.0-1160.45.1.el7.x86_64&phase=ci_tests&buildtype=slf7%20e20:prof). 
![image](https://user-images.githubusercontent.com/68423730/142472846-a35e7668-75b3-4138-aa14-45fd4d7c4d0a.png)

- Cleans up the log file output slightly

- Ensures the scripts doesn't fetch the old references when creating new ones (it doesn't need to).