### PR TITLE
Fix for CRT detsim and reco

### DIFF
--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -96,6 +96,11 @@ std::pair<double, double> CRTHitRecoAlg::DistanceBetweenSipms(art::Ptr<sbnd::crt
   
   uint32_t channel = sipm1->Channel();
   std::string stripName = fCrtGeo.ChannelToStripName(channel);
+  if (stripName.empty()) {
+    throw cet::exception("CRTHitRecoAlg")
+        << "Cannot find strip name for channel " << channel << std::endl;
+  }
+
   double width = fCrtGeo.GetStrip(stripName).width;
 
   // Calculate the number of photoelectrons at each SiPM


### PR DESCRIPTION
With PR #207 we are using a CRT geometry that uses the same logical volumes for CRT strips of the same type. This caused the CRT detsim and reco to always pick the first CRT strip declared in the GDML. 

This PR fixes this problem by changing the logic in which the CRT geometry nodes are found. Now, the unique `AuxDet` volume is identified first, and then the code descends from it to find the strip (`AuxDetSensitive`).