### PR TITLE
CAF tests for the CI system

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_genie_and_fluxwgt.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_genie_and_fluxwgt.fcl
@@ -1,0 +1,4 @@
+#include "cafmakerjob_sbnd.fcl"
+
+physics.runprod: [rns, genieweight, fluxweight, @sequence::physics.runprod]
+physics.producers.mycafmaker.SystWeightLabels: ["genieweight", "fluxweight"]

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -374,7 +374,7 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=100:150
+cpu_usage_range=130:180
 mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
@@ -420,7 +420,7 @@ output1=%(TFILENAME)s
 
 
 [suite single_quick_test_sbndcode]
-testlist=single_gen_quick_test_sbndcode single_g4_quick_test_sbndcode single_detsim_quick_test_sbndcode single_reco1_quick_test_sbndcode single_reco2_quick_test_sbndcode single_anatree_quick_test_sbndcode
+testlist=single_gen_quick_test_sbndcode single_g4_quick_test_sbndcode single_detsim_quick_test_sbndcode single_reco1_quick_test_sbndcode single_reco2_quick_test_sbndcode single_caf_quick_test_sbndcode
 
 
 
@@ -557,7 +557,7 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=100:150
+cpu_usage_range=130:180
 mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
@@ -603,10 +603,10 @@ output1=%(TFILENAME)s
 
 
 [suite single_seq_test_sbndcode]
-testlist=single_gen_seq_test_sbndcode single_g4_seq_test_sbndcode single_detsim_seq_test_sbndcode single_reco1_seq_test_sbndcode single_reco2_seq_test_sbndcode single_anatree_seq_test_sbndcode
+testlist=single_gen_seq_test_sbndcode single_g4_seq_test_sbndcode single_detsim_seq_test_sbndcode single_reco1_seq_test_sbndcode single_reco2_seq_test_sbndcode single_caf_seq_test_sbndcode
 
 [suite generate_reference_single_test_sbndcode]
-testlist=single_gen_seq_test_sbndcode single_g4_seq_test_sbndcode single_detsim_seq_test_sbndcode single_reco1_seq_test_sbndcode single_reco2_seq_test_sbndcode
+testlist=single_seq_test_sbndcode
 
 
 
@@ -742,8 +742,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=500:800
-mem_usage_range=3000000:5000000
+cpu_usage_range=800:1200
+mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_quick_test_sbndcode.fcl
@@ -789,7 +789,7 @@ output1=%(TFILENAME)s
 
 
 [suite nucosmics_quick_test_sbndcode]
-testlist=nucosmics_gen_quick_test_sbndcode nucosmics_g4_quick_test_sbndcode nucosmics_detsim_quick_test_sbndcode nucosmics_reco1_quick_test_sbndcode nucosmics_reco2_quick_test_sbndcode nucosmics_anatree_quick_test_sbndcode
+testlist=nucosmics_gen_quick_test_sbndcode nucosmics_g4_quick_test_sbndcode nucosmics_detsim_quick_test_sbndcode nucosmics_reco1_quick_test_sbndcode nucosmics_reco2_quick_test_sbndcode nucosmics_caf_quick_test_sbndcode
 
 
 
@@ -925,8 +925,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=500:800
-mem_usage_range=3000000:5000000
+cpu_usage_range=800:1200
+mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -971,10 +971,10 @@ output1=%(TFILENAME)s
 
 
 [suite nucosmics_seq_test_sbndcode]
-testlist=nucosmics_gen_seq_test_sbndcode nucosmics_g4_seq_test_sbndcode nucosmics_detsim_seq_test_sbndcode nucosmics_reco1_seq_test_sbndcode nucosmics_reco2_seq_test_sbndcode nucosmics_anatree_seq_test_sbndcode
+testlist=nucosmics_gen_seq_test_sbndcode nucosmics_g4_seq_test_sbndcode nucosmics_detsim_seq_test_sbndcode nucosmics_reco1_seq_test_sbndcode nucosmics_reco2_seq_test_sbndcode nucosmics_caf_seq_test_sbndcode
 
 [suite generate_reference_nucosmics_test_sbndcode]
-testlist=nucosmics_gen_seq_test_sbndcode nucosmics_g4_seq_test_sbndcode nucosmics_detsim_seq_test_sbndcode nucosmics_reco1_seq_test_sbndcode nucosmics_reco2_seq_test_sbndcode
+testlist=nucosmics_seq_test_sbndcode
 
 
 

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -156,6 +156,13 @@ NEVENTS_SEQ_NUCOSMICS_SBNDCODE=5
 RUN_TEST_SBNDCODE=1
 CHECK_PRODUCTS_SBNDCODE=1
 CHECK_PRODUCT_SIZE_SBNDCODE=1
+CHECK_CAF_DIFF_SBNDCODE=0
+
+# enable running the test jobs and the caf diff check
+RUN_TEST_SBNDCODE_CAFS=1
+CHECK_PRODUCTS_SBNDCODE_CAFS=0
+CHECK_PRODUCT_SIZE_SBNDCODE_CAFS=0
+CHECK_CAF_DIFF_SBNDCODE_CAFS=1
 
 # this prefix is common to all FHiCL configuration files of SBND C.I. tests
 CI_FHICL_PREFIX_SBNDCODE=sbnd_ci_
@@ -182,7 +189,8 @@ NUCOSMICS_INPUT_DIRNAME_SBNDCODE=standard
 FCLCHECK_INPUT_DIRNAME_SBNDCODE=standard
 
 # the test mask collects check requests in a single string
-TESTMASK_SBNDCODE=%(RUN_TEST_SBNDCODE)s%(CHECK_PRODUCTS_SBNDCODE)s%(CHECK_PRODUCT_SIZE_SBNDCODE)s
+TESTMASK_SBNDCODE=%(RUN_TEST_SBNDCODE)s%(CHECK_PRODUCTS_SBNDCODE)s%(CHECK_PRODUCT_SIZE_SBNDCODE)s%(CHECK_CAF_DIFF_SBNDCODE)s
+TESTMASK_SBNDCODE_CAFS=%(RUN_TEST_SBNDCODE_CAFS)s%(CHECK_PRODUCTS_SBNDCODE_CAFS)s%(CHECK_PRODUCT_SIZE_SBNDCODE_CAFS)s%(CHECK_CAF_DIFF_SBNDCODE_CAFS)s
 
 # this is the script we use for most of the tests
 # (lookup in `PATH` environment variable directories; provided by `lar_ci`)
@@ -192,6 +200,11 @@ EXPSCRIPT_SBNDCODE=ci_regression_test_template.sh
 BASE_STDARGS_SBNDCODE=--executable lar --nevents %(NEVENTS)s --stage-name %(STAGE_NAME)s --fhicl %(FHiCL_FILE)s --testmask %(TESTMASK_SBNDCODE)s
 STDARGS_NOOUTPUT_SBNDCODE=%(BASE_STDARGS_SBNDCODE)s
 STDARGS_SBNDCODE=%(BASE_STDARGS_SBNDCODE)s --outputs %(OUTPUT_STREAM)s
+
+# arguments used by EXPSCRIPT_SBNDCODE for CAF tests
+BASE_STDARGS_SBNDCODE_CAFS=--executable lar --nevents %(NEVENTS)s --stage-name %(STAGE_NAME)s --fhicl %(FHiCL_FILE)s --testmask %(TESTMASK_SBNDCODE_CAFS)s
+STDARGS_NOOUTPUT_SBNDCODE_CAFS=%(BASE_STDARGS_SBNDCODE_CAFS)s
+STDARGS_SBNDCODE_CAFS=%(BASE_STDARGS_SBNDCODE_CAFS)s --outputs %(OUTPUT_STREAM)s
 
 # this is the tag we append to the SBND-specific test configuration variable names
 # (e.g. "TESTMASK_SBNDCODE"); it is used by the C.I. system
@@ -356,6 +369,26 @@ args=%(STDARGS_SBNDCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFE
 parse_art_output=True
 output1=%(TFILENAME)s
 
+[test single_caf_quick_test_sbndcode]
+STAGE_NAME=caf
+INPUT_STAGE_NAME=reco2
+NEVENTS=2
+# calibrated on sbndbuild01.fnal.gov on 20180306
+cpu_usage_range=20:50
+mem_usage_range=300000:700000
+
+script=%(EXPSCRIPT_SBNDCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)ssingle_%(STAGE_NAME)s_quick_test_sbndcode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_sbndcode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_sbndcode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_SBNDCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.caf.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.caf.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_SBNDCODE_CAFS)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
 
 [test single_anatree_quick_test_sbndcode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
@@ -516,6 +549,28 @@ OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.root
 REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.root
 TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
 args=%(STDARGS_SBNDCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test single_caf_seq_test_sbndcode]
+STAGE_NAME=caf
+INPUT_STAGE_NAME=reco2
+NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
+# calibrated on sbndbuild01.fnal.gov on 20180306
+cpu_usage_range=20:50
+mem_usage_range=300000:700000
+
+script=%(EXPSCRIPT_SBNDCODE)s
+requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
+FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)ssingle_%(STAGE_NAME)s_seq_test_sbndcode.fcl
+INPUT_BASE_FILE_NAME=single_%(INPUT_STAGE_NAME)s_test_sbndcode
+OUTPUT_BASE_FILE_NAME=single_%(STAGE_NAME)s_test_sbndcode
+EXTRA_DIR=%(SINGLE_INPUT_DIRNAME_SBNDCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.caf.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.caf.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_SBNDCODE_CAFS)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
 parse_art_output=True
 output1=%(TFILENAME)s
 
@@ -682,6 +737,27 @@ args=%(STDARGS_SBNDCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFE
 parse_art_output=True
 output1=%(TFILENAME)s
 
+[test nucosmics_caf_quick_test_sbndcode]
+STAGE_NAME=caf
+INPUT_STAGE_NAME=reco2
+NEVENTS=2
+# calibrated on sbndbuild01.fnal.gov on 20180305
+cpu_usage_range=20:80
+mem_usage_range=300000:900000
+
+script=%(EXPSCRIPT_SBNDCODE)s
+FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_quick_test_sbndcode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_sbndcode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_sbndcode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_SBNDCODE)s
+INPUT_STREAM=%(XROOTD_INPUTFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(INPUT_STAGE_NAME)s/%(INPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.caf.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.caf.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_SBNDCODE_CAFS)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
 
 [test nucosmics_anatree_quick_test_sbndcode]
 # no reference art ROOT output for this one, but we have analysis tree reference (the "--extra-function" option)
@@ -841,6 +917,28 @@ OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.root
 REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.root
 TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
 args=%(STDARGS_SBNDCODE)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
+parse_art_output=True
+output1=%(TFILENAME)s
+
+[test nucosmics_caf_seq_test_sbndcode]
+STAGE_NAME=caf
+INPUT_STAGE_NAME=reco2
+NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
+# calibrated on sbndbuild01.fnal.gov on 20180305
+cpu_usage_range=20:80
+mem_usage_range=300000:900000
+
+script=%(EXPSCRIPT_SBNDCODE)s
+requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
+FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_seq_test_sbndcode.fcl
+INPUT_BASE_FILE_NAME=nucosmics_%(INPUT_STAGE_NAME)s_test_sbndcode
+OUTPUT_BASE_FILE_NAME=nucosmics_%(STAGE_NAME)s_test_sbndcode
+EXTRA_DIR=%(NUCOSMICS_INPUT_DIRNAME_SBNDCODE)s
+INPUT_STREAM=../%(requires)s/%(INPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.root
+OUTPUT_STREAM=%(OUTPUT_BASE_FILE_NAME)s_%(CUR_SBNDCODE)s.caf.root
+REFERENCE_FILES=%(XROOTD_REFERENCEFILEDIR_SBNDCODE)s/%(EXTRA_DIR)s/%(STAGE_NAME)s/%(OUTPUT_BASE_FILE_NAME)s_%(REF_SBNDCODE)s.caf.root
+TFILENAME=hist-%(OUTPUT_BASE_FILE_NAME)s.root
+args=%(STDARGS_SBNDCODE_CAFS)s --input-file %(INPUT_STREAM)s --reference-files %(REFERENCE_FILES)s --extra-options --TFileName,%(TFILENAME)s
 parse_art_output=True
 output1=%(TFILENAME)s
 

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -374,8 +374,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=20:50
-mem_usage_range=300000:700000
+cpu_usage_range=100:150
+mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)ssingle_%(STAGE_NAME)s_quick_test_sbndcode.fcl
@@ -557,8 +557,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=20:50
-mem_usage_range=300000:700000
+cpu_usage_range=100:150
+mem_usage_range=2000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -742,8 +742,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=2
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=20:80
-mem_usage_range=300000:900000
+cpu_usage_range=500:800
+mem_usage_range=3000000:5000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_quick_test_sbndcode.fcl
@@ -925,8 +925,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=20:80
-mem_usage_range=300000:900000
+cpu_usage_range=500:800
+mem_usage_range=3000000:5000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode

--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -1,0 +1,8 @@
+#include "cafmakerjob_sbnd.fcl"
+
+services.NuRandomService.policy: "perEvent"
+
+# Have to specify the fcl name to match what the CI expects,
+# currently no way of controlling this from the command line
+
+physics.producers.mycafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"

--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -2,7 +2,7 @@
 
 services.NuRandomService.policy: "perEvent"
 
-# Have to specify the fcl name to match what the CI expects,
+# Have to specify the caf name to match what the CI expects,
 # currently no way of controlling this from the command line
 
 physics.producers.mycafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"

--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -1,4 +1,4 @@
-#include "cafmakerjob_sbnd.fcl"
+#include "cafmakerjob_sbnd_genie_and_fluxwgt.fcl"
 
 services.NuRandomService.policy: "perEvent"
 
@@ -6,3 +6,7 @@ services.NuRandomService.policy: "perEvent"
 # currently no way of controlling this from the command line
 
 physics.producers.mycafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"
+
+physics.producers.genieweight.genie_sbnd_multisim.number_of_multisims: 1
+physics.producers.genieweight.genie_sbnd_multisim_exclusive.number_of_multisims: 1
+physics.producers.genieweight.genie_ub_multisim.number_of_multisims: 1

--- a/test/ci/sbnd_ci_nucosmics_caf_seq_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_seq_test_sbndcode.fcl
@@ -1,0 +1,1 @@
+#include "sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl"

--- a/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
@@ -1,0 +1,8 @@
+#include "cafmakerjob_sbnd.fcl"
+
+services.NuRandomService.policy: "perEvent"
+
+# Have to specify the fcl name to match what the CI expects,
+# currently no way of controlling this from the command line
+
+physics.producers.mycafmaker.CAFFilename: "single_caf_test_sbndcode_Current.caf.root"

--- a/test/ci/sbnd_ci_single_caf_seq_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_caf_seq_test_sbndcode.fcl
@@ -1,0 +1,1 @@
+#include "sbnd_ci_single_caf_quick_test_sbndcode.fcl"


### PR DESCRIPTION
_N.B. This PR depends on [this](https://cdcvs.fnal.gov/redmine/projects/lar_ci/repository?utf8=%E2%9C%93&rev=feature%2Fhlay_caf_tests) branch in `lar_ci` and so this will need approving and merging before the `trigger build` command can be used. @vitodb if you wouldn't mind taking a look at this that would be great._

This PR introduces the CAF stage to the standard regression tests. These are the simple tests run on **every** PR and push to develop. At the moment we test [gen, g4, detsim, reco1, reco2, anatree]. This PR _replaces_ the anatree stage with a caf stage. I don't think the anatree is widely used anymore and the CI test for it only checks that it can be built and not anything inside it. I have retained the functionality for the anatree test but replaced in the suites that are automatically run.

There are huge benefits to a caf test. The obvious is that we test the CAFMaker infrastructure which is currently not covered by the CI at all (other than it compiles). The real extra benefit compared to the other stages is that in the simple inexpensive test we are able to test physics quantities without running the full validation. Thanks to the lovely `diff_cafs` script we will see if any value in the CAF has changed.

Something I haven't addressed in this PR is that the production workflow is currently using `*_sce` fcls. We should probably swap to this going forward (in place of the `standard_*.fcl` we currently use) but this will be addressed separately.

The fcl use for the CI test isn't as simple as the other stages so for completeness I'll document why:
- There doesn't currently exist a file that runs the flux & genie weighting system without space charge effects, I have introduced this fcl in this PR.
- To use the weighting functionality without making the run time too long for a regression test I've then reduced the multisims to 1 universe, thus testing the mechanics without wasting time.
- We can't run weighting on the prodsingle version of the test so it has to inherit from a different fcl.

Examples of this test in action can be found [with](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/8102&platform=Linux%203.10.0-1160.45.1.el7.x86_64&phase=ci_tests&buildtype=slf7%20e20:prof) and [without](https://dbweb8.fnal.gov:8443/LarCI/app/ns:sbnd/build_detail/phase_details?build_id=sbnd_ci/8103&platform=Linux%203.10.0-1160.45.1.el7.x86_64&phase=ci_tests&buildtype=slf7%20e20:prof) warnings. To run cleanly this test requires SBNSoftware/sbnanaobj#33