### PR TITLE
Add photon propagation times to hybrid model and re-enable by default

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_3drift_faketrigger_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_3drift_faketrigger_filter.fcl
@@ -8,9 +8,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  # , ionandscintout
+                  , ionandscintout
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_dirt_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_dirt_filter.fcl
@@ -4,9 +4,9 @@
 
 physics.simulate: [ rns
                   , ionandscint
-                  # , ionandscintout
+                  , ionandscintout
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , simdrift
                   , mcreco
                   , genericcrt

--- a/sbndcode/JobConfigurations/standard/g4/g4_enterstpc_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_enterstpc_filter.fcl
@@ -6,9 +6,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  # , ionandscintout
+                  , ionandscintout
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_michelelectron_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_michelelectron_filter.fcl
@@ -5,9 +5,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  # , ionandscintout
+                  , ionandscintout
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_mu_crt_filter_base.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_mu_crt_filter_base.fcl
@@ -7,9 +7,9 @@ physics.simulate: [ rns
                   , loader
                   , largeant
                   , ionandscint
-                  # , ionandscintout
+                  , ionandscintout
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , simdrift
                   , filter # Adding filter
                   , mcreco

--- a/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_simphotontime_filter.fcl
@@ -30,16 +30,16 @@ physics.producers.simdriftouttime.SimulationLabel: "ionandscintouttime:priorSCE"
 physics.producers.genericcrtouttime.LArG4Label: "larg4outtime"
 
 # Add processes for light simulation outside the active volume (AV) for the intimes
-# physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
-# physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
-# physics.producers.ionandscintoutintime.InputModuleLabels: ["larg4intime"]
-# physics.producers.pdfastsimoutintime.SimulationLabel: "ionandscintoutintime"
+physics.producers.ionandscintoutintime: @local::sbnd_ionandscint_out
+physics.producers.pdfastsimoutintime: @local::sbnd_pdfastsim_pvs
+physics.producers.ionandscintoutintime.InputModuleLabels: ["larg4intime"]
+physics.producers.pdfastsimoutintime.SimulationLabel: "ionandscintoutintime"
 
 # Add processes for light simulation outside the active volume (AV) for the outtimes
-# physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
-# physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
-# physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
-# physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
+physics.producers.ionandscintoutouttime: @local::sbnd_ionandscint_out
+physics.producers.pdfastsimoutouttime: @local::sbnd_pdfastsim_pvs
+physics.producers.ionandscintoutouttime.InputModuleLabels: ["larg4outtime"]
+physics.producers.pdfastsimoutouttime.SimulationLabel: "ionandscintoutouttime"
 
 # Add a process that merges the MCParticles
 physics.producers.largeant: @local::sbnd_merge_sim_sources
@@ -67,9 +67,9 @@ physics.producers.pdfastsim.FillSimPhotons: true
 physics.producers.pdfastsim.InputSourcesLabels: [ "pdfastsimintime", "pdfastsimouttime"]
 
 # Add a process that merges the SimPhotons outside the AV
-# physics.producers.pdfastsimout: @local::sbnd_merge_sim_sources
-# physics.producers.pdfastsimout.FillSimPhotons: true
-# physics.producers.pdfastsimout.InputSourcesLabels: [ "pdfastsimoutintime", "pdfastsimoutouttime"]
+physics.producers.pdfastsimout: @local::sbnd_merge_sim_sources
+physics.producers.pdfastsimout.FillSimPhotons: true
+physics.producers.pdfastsimout.InputSourcesLabels: [ "pdfastsimoutintime", "pdfastsimoutouttime"]
 
 # Add all these new modules to the simulate path
 physics.simulate: [ rns
@@ -84,16 +84,16 @@ physics.simulate: [ rns
                   , simdriftouttime
                   , genericcrtouttime
                   ### Simulate the light outside the AV
-                  # , ionandscintoutintime
-                  # , pdfastsimoutintime
-                  # , ionandscintoutouttime
-                  # , pdfastsimoutouttime
+                  , ionandscintoutintime
+                  , pdfastsimoutintime
+                  , ionandscintoutouttime
+                  , pdfastsimoutouttime
                   ### Merge the intime and outtime paths
                   , largeant
                   , ionandscint
                   , simdrift
                   , pdfastsim
-                  # , pdfastsimout
+                  , pdfastsimout
                   , genericcrt
                   ### Do truth-level reconstruction
                   , mcreco
@@ -117,11 +117,11 @@ outputs.out1.outputCommands: [ "keep *_*_*_*"
                              , "drop *_simdriftintime_*_*"
                              , "drop *_simdriftouttime_*_*"
                              # Drop IonAndScint Outside AV
-                             # , "drop *_ionandscintoutintime_*_*"
-                             # , "drop *_ionandscintoutouttime_*_*"
+                             , "drop *_ionandscintoutintime_*_*"
+                             , "drop *_ionandscintoutouttime_*_*"
                              # Drop PDFastSim Ouside AV
-                             # , "drop *_pdfastsimoutintime_*_*"
-                             # , "drop *_pdfastsimoutouttime_*_*"
+                             , "drop *_pdfastsimoutintime_*_*"
+                             , "drop *_pdfastsimoutouttime_*_*"
                              # Drop LArG4 AuxDetHits, now replaced by AuxDetSimChannels
                              , "drop sim::AuxDetHits_*_*_*"
                              ]

--- a/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
@@ -74,15 +74,13 @@ physics:
     ionandscint: @local::sbnd_ionandscint
 
     # Creation of ionization electrons and scintillation photons, outside the active volume
-    # ionandscintout: @local::sbnd_ionandscint_out
+    ionandscintout: @local::sbnd_ionandscint_out
 
     # Light propogation inside the active volume
     pdfastsim: @local::sbnd_pdfastsim_par
 
     # Light propogation outside the active volume
-    # Nov 16th, 2021
-    # Temporarily disable light simulation in the OUT-TPC (sbndcode issue 219)
-    # pdfastsimout: @local::sbnd_pdfastsim_pvs
+    pdfastsimout: @local::sbnd_pdfastsim_pvs
 
     # Electron propogation
     simdrift: @local::sbnd_simdrift
@@ -100,9 +98,9 @@ physics:
             , loader
             , largeant
             , ionandscint
-            # , ionandscintout
+            , ionandscintout
             , pdfastsim
-            # , pdfastsimout
+            , pdfastsimout
             , simdrift
             , mcreco
             , genericcrt

--- a/sbndcode/LArSoftConfigurations/PDFastSim_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/PDFastSim_sbnd.fcl
@@ -42,6 +42,9 @@ sbnd_pdfastsim_pvs.IncludePropTime: true
 sbnd_pdfastsim_pvs.StoreReflected: true
 sbnd_pdfastsim_pvs.ScintTimeTool.SlowDecayTime: 1300.0
 
+# propagation times
+sbnd_pdfastsim_pvs.VUVTiming: 			@local::sbnd_vuv_timing_parameterization_fast
+sbnd_pdfastsim_pvs.VISTiming: 			@local::sbnd_vis_timing_parameterization
 
 
 END_PROLOG

--- a/sbndcode/LArSoftConfigurations/opticalsimparameterisations_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalsimparameterisations_sbnd.fcl
@@ -62,6 +62,11 @@ sbnd_vuv_timing_parameterization:
   angle_bin_timing_vuv: 45
 }
 
+// faster, lower precision case for external argon volume (hybrid model)
+sbnd_vuv_timing_parameterization_fast: @local::sbnd_vuv_timing_parameterization
+sbnd_vuv_timing_parameterization_fast.step_size: 5.
+sbnd_vuv_timing_parameterization_fast.angle_bin_timing_vuv: 90
+
 
 # VUV/DIRECT LIGHT: NUMBER OF HITS CORRECTIONS
 # SBND Gaisser-Hillas      


### PR DESCRIPTION
Adds photon propagation times calculation for external regions in hybrid model and re-enables hybrid model by default. Requires https://github.com/LArSoft/larsim/pull/84. Resolves https://github.com/SBNSoftware/sbndcode/issues/219.