### PR TITLE
Change caf module label to cafmaker not mycafmaker

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -105,8 +105,8 @@ physics:
             pandoraTrackCRTHit, pandoraTrackCRTTrack, vertexCharge, vertexStub,
             pandoraTrackClosestApproach, pandoraTrackStoppingChi2, pandoraTrackDazzle,
             pandoraShowerCosmicDist, pandoraShowerRazzle,
-            mycafmaker ]
-# makecaf: [mycafmaker] #list the modules for this path, order matters, filters reject all following items
+            cafmaker ]
+# makecaf: [cafmaker] #list the modules for this path, order matters, filters reject all following items
 # stream1: [metadata]
   stream1:       [ ]
   trigger_paths: [ runprod ]
@@ -116,14 +116,14 @@ physics:
 physics.producers.vertexCharge.CaloAlg: @local::sbnd_calorimetryalgmc
 physics.producers.vertexStub.CaloAlg: @local::sbnd_calorimetryalgmc
 
-physics.producers.mycafmaker: @local::standard_cafmaker
-physics.producers.mycafmaker.CosmicGenLabel: "corsika"
+physics.producers.cafmaker: @local::standard_cafmaker
+physics.producers.cafmaker.CosmicGenLabel: "corsika"
 
 # Overwrite weight_functions label:
 physics.producers.genieweight.weight_functions: @local::physics.producers.genieweight.weight_functions_genie
 physics.producers.fluxweight.weight_functions: @local::physics.producers.fluxweight.weight_functions_flux
 
 # input art file.
-physics.producers.mycafmaker.SystWeightLabels: []
+physics.producers.cafmaker.SystWeightLabels: []
 
 services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_3drift_sce_runfmatch_geniewgt.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_3drift_sce_runfmatch_geniewgt.fcl
@@ -1,4 +1,4 @@
 #include "cafmakerjob_sbnd_3drift_sce_runfmatch.fcl"
 
 physics.runprod: [rns, genieweight, @sequence::physics.runprod]
-physics.producers.mycafmaker.SystWeightLabels: ["genieweight"]
+physics.producers.cafmaker.SystWeightLabels: ["genieweight"]

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_genie_and_fluxwgt.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_genie_and_fluxwgt.fcl
@@ -1,4 +1,4 @@
 #include "cafmakerjob_sbnd.fcl"
 
 physics.runprod: [rns, genieweight, fluxweight, @sequence::physics.runprod]
-physics.producers.mycafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
+physics.producers.cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_geniewgt.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_geniewgt.fcl
@@ -1,4 +1,4 @@
 #include "cafmakerjob_sbnd.fcl"
 
 physics.runprod: [rns, genieweight, @sequence::physics.runprod]
-physics.producers.mycafmaker.SystWeightLabels: ["genieweight"]
+physics.producers.cafmaker.SystWeightLabels: ["genieweight"]

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -3,15 +3,15 @@
 #include "cafmakerjob_sbnd.fcl"
 
 # change all the labels we need to
-physics.producers.mycafmaker.PandoraTagSuffixes: []
-physics.producers.mycafmaker.PFParticleLabel: "pandoraSCE"
-physics.producers.mycafmaker.RecoShowerLabel: "pandoraSCEShowerSBN"
-physics.producers.mycafmaker.RecoTrackLabel: "pandoraSCETrack"
-physics.producers.mycafmaker.TrackCaloLabel: "pandoraSCECalo"
-physics.producers.mycafmaker.TrackChi2PidLabel:  "pandoraSCEPid"
-physics.producers.mycafmaker.CRTHitMatchLabel: "pandoraSCETrackCRTHit"
-physics.producers.mycafmaker.CRTTrackMatchLabel: "pandoraSCETrackCRTTrack"
-physics.producers.mycafmaker.FlashMatchLabel:  "fmatchSCE"
+physics.producers.cafmaker.PandoraTagSuffixes: []
+physics.producers.cafmaker.PFParticleLabel: "pandoraSCE"
+physics.producers.cafmaker.RecoShowerLabel: "pandoraSCEShowerSBN"
+physics.producers.cafmaker.RecoTrackLabel: "pandoraSCETrack"
+physics.producers.cafmaker.TrackCaloLabel: "pandoraSCECalo"
+physics.producers.cafmaker.TrackChi2PidLabel:  "pandoraSCEPid"
+physics.producers.cafmaker.CRTHitMatchLabel: "pandoraSCETrackCRTHit"
+physics.producers.cafmaker.CRTTrackMatchLabel: "pandoraSCETrackCRTTrack"
+physics.producers.cafmaker.FlashMatchLabel:  "fmatchSCE"
 
 physics.producers.pandoraTrackMCS.TrackLabel: "pandoraSCETrack"
 physics.producers.pandoraTrackRange.TrackLabel: "pandoraSCETrack"
@@ -49,10 +49,10 @@ physics.runprod: [ pandoraTrackMCS, pandoraTrackRange,
             pandoraSCETrackCRTHit, pandoraSCETrackCRTTrack, fmatchSCE, vertexCharge, vertexStub,
             pandoraTrackClosestApproach, pandoraTrackStoppingChi2, pandoraTrackDazzle,
             pandoraShowerSelectionVars,pandoraShowerCosmicDist, pandoraShowerRazzle,
-            mycafmaker ]
+            cafmaker ]
 
 # Enable the Space-Charge service
 #include "enable_spacecharge_services_sbnd.fcl"
 
 services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"
-physics.producers.mycafmaker.SimChannelLabel: "simdrift"
+physics.producers.cafmaker.SimChannelLabel: "simdrift"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce_genie_and_fluxwgt.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce_genie_and_fluxwgt.fcl
@@ -1,4 +1,4 @@
 #include "cafmakerjob_sbnd_sce.fcl"
 
 physics.runprod: [rns, genieweight, fluxweight, @sequence::physics.runprod]
-physics.producers.mycafmaker.SystWeightLabels: ["genieweight", "fluxweight"]
+physics.producers.cafmaker.SystWeightLabels: ["genieweight", "fluxweight"]

--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -5,7 +5,7 @@ services.NuRandomService.policy: "perEvent"
 # Have to specify the caf name to match what the CI expects,
 # currently no way of controlling this from the command line
 
-physics.producers.mycafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"
+physics.producers.cafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"
 
 physics.producers.genieweight.genie_sbnd_multisim.number_of_multisims: 1
 physics.producers.genieweight.genie_sbnd_multisim_exclusive.number_of_multisims: 1

--- a/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
@@ -5,4 +5,4 @@ services.NuRandomService.policy: "perEvent"
 # Have to specify the fcl name to match what the CI expects,
 # currently no way of controlling this from the command line
 
-physics.producers.mycafmaker.CAFFilename: "single_caf_test_sbndcode_Current.caf.root"
+physics.producers.cafmaker.CAFFilename: "single_caf_test_sbndcode_Current.caf.root"


### PR DESCRIPTION
Production team are moving towards using a common set of scripts in sbnutil. One issue I came across during this migration is that ICARUS use the module name `cafmaker` whilst we use `mycafmaker` for CAFMaker. This PR moves us to use the same as ICARUS such that the scripts don't need extra logic for sbnd files. 

I don't think any other changes should be needed as cafs aren't ever used as art inputs via the module name but I'm willing to be corrected by those who know more.