### PR TITLE
Issue 142 on LArSoft View

### DIFF
--- a/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
@@ -61390,11 +61390,11 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_V"/>
-				<positionref ref="posUPlane_E"/> <!-- WARNING: this should be posV, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posUPlane_E"/> <!-- Plane V is placed at U position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_U"/>
-				<positionref ref="posVPlane_E"/> <!-- WARNING: this should be posU, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posVPlane_E"/> <!-- Plane U is placed at V position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlaneVert"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
@@ -5887,11 +5887,11 @@
 
 			<physvol>
 				<volumeref ref="volTPCPlane_V"/>
-				<positionref ref="posUPlane_E"/> <!-- WARNING: this should be posV, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posUPlane_E"/> <!-- Plane V is placed at U position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_U"/>
-				<positionref ref="posVPlane_E"/> <!-- WARNING: this should be posU, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posVPlane_E"/> <!-- Plane U is placed at V position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlaneVert"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
@@ -15694,11 +15694,11 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_V"/>
-				<positionref ref="posUPlane_E"/> <!-- WARNING: this should be posV, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posUPlane_E"/> <!-- Plane V is placed at U position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_U"/>
-				<positionref ref="posVPlane_E"/> <!-- WARNING: this should be posU, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posVPlane_E"/> <!-- Plane U is placed at V position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlaneVert"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_withshielding.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_withshielding.gdml
@@ -61390,11 +61390,11 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_V"/>
-				<positionref ref="posUPlane_E"/> <!-- WARNING: this should be posV, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posUPlane_E"/> <!-- Plane V is placed at U position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_U"/>
-				<positionref ref="posVPlane_E"/> <!-- WARNING: this should be posU, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posVPlane_E"/> <!-- Plane U is placed at V position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlaneVert"/>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_withshielding_nowires.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_withshielding_nowires.gdml
@@ -15694,11 +15694,11 @@
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_V"/>
-				<positionref ref="posUPlane_E"/> <!-- WARNING: this should be posV, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posUPlane_E"/> <!-- Plane V is placed at U position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlane_U"/>
-				<positionref ref="posVPlane_E"/> <!-- WARNING: this should be posU, will have to be fixed once LArSoft View is fixed -->
+				<positionref ref="posVPlane_E"/> <!-- Plane U is placed at V position as this wire plane is rotated w.r.t. TPC West -->
 			</physvol>
 			<physvol>
 				<volumeref ref="volTPCPlaneVert"/>


### PR DESCRIPTION
When we switched to the new geometry v2.0, plane 0 and 1 in TPC 0 were swapped compared to the previous version of the geometry v1.5. This caused problems with the larsoft `View` being assigned incorrectly (see #139 by @absolution1, @etyley, @henrylay97, and #128 by @wforeman).

With PR #141, we swapped the planes back as a temporary fix in order to give us time to work on the `View` issue in LArSoft. After a re-evaluation of the SBND wire design, it turns out that the wire orientation in geometry v1.5 was correct, and v2.0 was introducing a mistake. The good news is that PR #141 is not a temporary fix anymore, but it gives the right configuration.

This PR just removes a comment in the GDML file saying that plane order is wrong, and so resolves #142.

And to summarize, this is the SBND wire orientation that we have and the LArSoft `View`, which matches the design (ThetaZ is angle in radiant w.r.t. Z axis):

| Plane, TPC   |         `ThetaZ`    |       `View`   |
|:-------------:|:-----------------:|:-------------:|
| 0, 0 | 0.52 |  U |
| 1, 0  | 2.62 | V |
| 2, 0 | 1.57 |  Y |
| 0, 1  | 2.62 |  U |
| 1, 1  | 0.52 |  V |
| 2, 1 | 1.57 | Y |