### PR TITLE
Patch for CRT error where AuxDets can't be found

### DIFF
--- a/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
+++ b/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
@@ -328,6 +328,10 @@ namespace sbnd {
     for (auto& adsc : *channels) {
       // Get the IDEs from the Aux Det channels
       const geo::AuxDetGeo& adGeo = fGeometryService->AuxDet(adsc.AuxDetID());
+
+      if(adsc.AuxDetSensitiveID() == UINT_MAX)
+        continue;
+
       const geo::AuxDetSensitiveGeo& adsGeo = adGeo.SensitiveVolume(adsc.AuxDetSensitiveID());
       std::string stripName = adsGeo.TotalVolume()->GetName();
       stripName.append("_0");

--- a/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
+++ b/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
@@ -329,8 +329,11 @@ namespace sbnd {
       // Get the IDEs from the Aux Det channels
       const geo::AuxDetGeo& adGeo = fGeometryService->AuxDet(adsc.AuxDetID());
 
-      if(adsc.AuxDetSensitiveID() == UINT_MAX)
+      if(adsc.AuxDetSensitiveID() == UINT_MAX) {
+        mf::LogWarning("CRTDetSimAna") << "AuxDetSimChannel with ID: UINT_MAX\n"
+                                       << "skipping channel...";
         continue;
+      }
 
       const geo::AuxDetSensitiveGeo& adsGeo = adGeo.SensitiveVolume(adsc.AuxDetSensitiveID());
       std::string stripName = adsGeo.TotalVolume()->GetName();

--- a/sbndcode/CRT/CRTChannelMapAlg.cxx
+++ b/sbndcode/CRT/CRTChannelMapAlg.cxx
@@ -123,10 +123,11 @@ namespace geo {
     }
 
     if (channel == UINT_MAX) {
-      throw cet::exception("CRTChannelMapAlg")
-      << "position ("
-      << worldLoc[0] << "," << worldLoc[1] << "," << worldLoc[2]
-      << ") does not correspond to any AuxDet";
+      mf::LogDebug("CRTChannelMapAlg") << "Can't find AuxDet for position ("
+                                       << worldLoc[0] << "," 
+                                       << worldLoc[1] << "," 
+                                       << worldLoc[2]
+                                       << ")\n";
     }
 
     return channel;

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -157,8 +157,11 @@ void CRTDetSim::produce(art::Event & e) {
     const geo::AuxDetGeo& adGeo =
         geoService->AuxDet(adsc.AuxDetID());
 
-    if(adsc.AuxDetSensitiveID() == UINT_MAX)
+    if(adsc.AuxDetSensitiveID() == UINT_MAX) {
+      mf::LogWarning("CRTDetSim") << "AuxDetSimChannel with ID: UINT_MAX\n"
+                                  << "skipping channel...";
       continue;
+    }
 
     const geo::AuxDetSensitiveGeo& adsGeo =
         adGeo.SensitiveVolume(adsc.AuxDetSensitiveID());

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -156,6 +156,10 @@ void CRTDetSim::produce(art::Event & e) {
   for (auto& adsc : *channels) {
     const geo::AuxDetGeo& adGeo =
         geoService->AuxDet(adsc.AuxDetID());
+
+    if(adsc.AuxDetSensitiveID() == UINT_MAX)
+      continue;
+
     const geo::AuxDetSensitiveGeo& adsGeo =
         adGeo.SensitiveVolume(adsc.AuxDetSensitiveID());
 

--- a/sbndcode/Geometry/ChannelMapSBNDAlg.cxx
+++ b/sbndcode/Geometry/ChannelMapSBNDAlg.cxx
@@ -1,11 +1,81 @@
 /**
  * @file ChannelMappingSBNDAlg.cxx
  *
- * Currently empty.
+ * Overrides ChannelMapAlg in larcorealg to change exceptions to messages
  */
 
 #include "sbndcode/Geometry/ChannelMapSBNDAlg.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 namespace geo {
   
+  size_t ChannelMapSBNDAlg::NearestAuxDet(const double* point, std::vector<geo::AuxDetGeo> const& auxDets, double tolerance) const
+  {
+    double HalfCenterWidth = 0.;
+    double localPoint[3] = {0.};
+
+
+    for(size_t a = 0; a < auxDets.size(); ++a) {
+
+      auxDets[a].WorldToLocal(point, localPoint);
+
+      HalfCenterWidth = 0.5 * (auxDets[a].HalfWidth1() + auxDets[a].HalfWidth2());
+      
+      if( localPoint[2] >= - (auxDets[a].Length()/2 + tolerance) &&
+          localPoint[2] <=   (auxDets[a].Length()/2 + tolerance) &&
+          localPoint[1] >= - auxDets[a].HalfHeight() - tolerance &&
+          localPoint[1] <=   auxDets[a].HalfHeight() + tolerance &&
+          // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
+          localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length()) - tolerance &&
+          localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length()) + tolerance
+          ) return a;
+
+    }// for loop over AudDet a
+
+    // log a message because we couldn't find the aux det volume, exception in base class
+    mf::LogDebug("ChannelMapSBND") << "Can't find AuxDet for position ("
+                                   << point[0] << ","
+                                   << point[1] << ","
+                                   << point[2] << ")\n";
+    
+    return UINT_MAX;
+
+  }
+
+  //----------------------------------------------------------------------------
+  size_t ChannelMapSBNDAlg::NearestSensitiveAuxDet(const double* point, std::vector<geo::AuxDetGeo> const& auxDets, double tolerance) const
+  {
+    double HalfCenterWidth = 0.;
+    double localPoint[3] = {0.};
+
+    size_t auxDetIdx = this->NearestAuxDet(point, auxDets, tolerance);
+
+    geo::AuxDetGeo const& adg = auxDets[auxDetIdx];
+
+    for(size_t a = 0; a < adg.NSensitiveVolume(); ++a) {
+
+      geo::AuxDetSensitiveGeo const& adsg = adg.SensitiveVolume(a);
+      adsg.WorldToLocal(point, localPoint);
+
+      HalfCenterWidth = 0.5 * (adsg.HalfWidth1() + adsg.HalfWidth2());
+
+      if( localPoint[2] >= - (adsg.Length()/2 + tolerance) &&
+          localPoint[2] <=   (adsg.Length()/2 + tolerance) &&
+          localPoint[1] >= - adsg.HalfHeight() - tolerance &&
+          localPoint[1] <=   adsg.HalfHeight() + tolerance &&
+          // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
+          localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length()) - tolerance &&
+          localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length()) + tolerance 
+          ) return a;
+    }// for loop over AuxDetSensitive a
+
+    // log a message because we couldn't find the sensitive aux det volume, exception in base class
+    mf::LogDebug("ChannelMapSBND") << "Can't find AuxDetSensitive for position ("
+                                   << point[0] << ","
+                                   << point[1] << ","
+                                   << point[2] << ")\n";
+    
+    return UINT_MAX;
+  }
+
 } // namespace geo

--- a/sbndcode/Geometry/ChannelMapSBNDAlg.h
+++ b/sbndcode/Geometry/ChannelMapSBNDAlg.h
@@ -44,10 +44,16 @@ namespace geo {
     virtual geo::GeoObjectSorter const& Sorter() const override 
       { return fSBNDsorter; }
     
-    
+    /// Returns the auxiliary detector closest to the specified point
+    virtual size_t NearestAuxDet
+      (const double* point, std::vector<geo::AuxDetGeo> const& auxDets, double tolerance = 0) const override;
+
+    /// Returns sensitive auxiliary detector closest to specified point
+    virtual size_t NearestSensitiveAuxDet
+      (const double* point, std::vector<geo::AuxDetGeo> const& auxDets, double tolerance = 0) const override;
+
   }; // class ChannelMapSBNDAlg
 
 } // namespace geo
 
 #endif // SBNDCODE_GEOMETYR_CHANNELMAPSBNDALG_H
-


### PR DESCRIPTION
**Very** intermittent error found by @jzennamo. Also thanks to @marcodeltutto and @wesketchum for help with debugging.

```
---- ChannelMap BEGIN
  Can't find AuxDet for position (132.794,-376.746,-8.4112)
  The above exception was thrown while processing module GenericCRT/genericcrt run: 1 subRun: 0 event: 84
---- ChannelMap END
```

This error is being thrown in the [ChannelMapAlg](https://github.com/LArSoft/larcorealg/blob/develop/larcorealg/Geometry/ChannelMapAlg.cxx) but this PR overrides the relevant functions in sbndcode's ChannelMapSBNDAlg.

Instead of throwing an exception the same error message is now outputted as a debugging message and the function returns `UINT_MAX` as the channel ID.

A catch is added at the detsim stage and in a detsim analysis module to skip channels with the ID `UINT_MAX`.

The underlying bug is worth investigating further and @ilepetic can probably comment further.

Due the rare nature of this bug I haven't been able to consistently reproduce it to test these changes on, however I have made some tests of the detsim stage where I forcibly return `UINT_MAX` and the catch works fine. 