### PR TITLE
Change voxelization scheme for hybrid model

### DIFF
--- a/sbndcode/LArSoftConfigurations/photpropservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/photpropservices_sbnd.fcl
@@ -95,17 +95,17 @@ sbnd_library_for_hybrid_mode_photonvisibilityservice:
 {
    @table::sbnd_library_vuv_vis_prop_timing_photonvisibilityservice
    LibraryFile: "OpticalLibrary/SBND_OpLibOUT_v2.00.root"
-   NX: 66
-   NY: 56
+   NX: 104
+   NY: 54
    NZ: 71
    UseCryoBoundary: false
    # IF UseCryoBoundary is set to false, so use the following parameters.
-   XMin:  -264
-   XMax:  264
-   YMin:  -280
-   YMax:  280
-   ZMin:  -60
-   ZMax:  650
+   XMin:  -261.69
+   XMax:  261.69
+   YMin:  -275.0382
+   YMax:  275.0382
+   ZMin:  -59.9294
+   ZMax:  649.2353
 }
 
 


### PR DESCRIPTION
This PR changes the voxelization scheme used by the optical library (hybrid mode). The voxel boundaries in the previous library didn’t match the active volume edges (mismatch ~4 cm). This can lead to an overestimation in the number of detected photons produced by `pdfastsimout`.

A new library using a redefined voxelization scheme has been generated by @ggamezdiego. The wrong visibilities reported in issue #243 were fixed by hand (taking advantage of the detector symmetry along the drift direction). A comparison of the visibility map at X~-208 cm and its symmetric configuration for the corrected library can be seen in the following figure:

<img width="1423" alt="Captura de pantalla 2021-12-19 a las 19 57 17" src="https://user-images.githubusercontent.com/66068208/147087373-5076c193-20d0-496e-a428-27e21fed2f2c.png">


NB: the new optical library can be found in ‘/sbnd/app/users/gamez/SBND/New-LibHybrid/SBND_OpLibOUT_v2.00New.root’. **The library in ‘sbnd_data/OpticalLibrary’ needs to be replaced** with the new version.