### PR TITLE
More CRT Segfaults

### DIFF
--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -154,6 +154,12 @@ void CRTDetSim::produce(art::Event & e) {
 
   // Loop through truth AD channels
   for (auto& adsc : *channels) {
+    if(adsc.AuxDetID() == UINT_MAX) {
+      mf::LogWarning("CRTDetSim") << "AuxDetSimChannel with ID: UINT_MAX\n"
+                                  << "skipping channel...";
+      continue;
+    }
+
     const geo::AuxDetGeo& adGeo =
         geoService->AuxDet(adsc.AuxDetID());
 

--- a/sbndcode/Geometry/ChannelMapSBNDAlg.cxx
+++ b/sbndcode/Geometry/ChannelMapSBNDAlg.cxx
@@ -50,6 +50,9 @@ namespace geo {
 
     size_t auxDetIdx = this->NearestAuxDet(point, auxDets, tolerance);
 
+    if(auxDetIdx == UINT_MAX)
+      return UINT_MAX;
+
     geo::AuxDetGeo const& adg = auxDets[auxDetIdx];
 
     for(size_t a = 0; a < adg.NSensitiveVolume(); ++a) {


### PR DESCRIPTION
This further patches CRT segfaults related to those addressed in #240. These segfaults originated in the introduction of the refactored larg4 for the CRT (#207). These are "rare" segfaults, hence they were discovered in production where the volume of events was high enough to see this occur regularly.

This has been 'tested' in production by using a tarred version of the code. It fixes the issue we were seeing.