### PR TITLE
OpT0Finder with new LArG4

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -211,13 +211,9 @@ physics:
          , crthitt0
          , crttrackt0
          , fmatch
+         , opt0finder
 	 , caloskimCalorimetry
  ]
-
- # The new flashmatching will eventually be part of reco2, but for now
- # we are keeping it separate here so we can easily remove if from the
- # reco fcl files.
- opticalt0: [ opt0finder ]
 
  # Run caloskimmer to produce ntuples for calibration as part of reco2 chain
  
@@ -265,10 +261,7 @@ outputs:
 #Here we tell ART that we want to run both sequences of paths.  This has to be done here as ART is not able to find the sequences while still wrapped in physics{ }
 physics.fullreco: [ @sequence::physics.reco1,
                     @sequence::physics.reco2
-		    #,opt0finder
-		  ]
-physics.fullreco_noflashmatch: [ @sequence::physics.reco1,
-                                 @sequence::physics.reco2]
+		          ]
 
 physics.trigger_paths: [ fullreco ]
 

--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
@@ -12,8 +12,8 @@
 
 process_name: Reco2
 
-physics.reco2_sce: [@sequence::physics.reco2, #opt0finder,
-            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, fmatchSCE]#, opt0finderSCE]
+physics.reco2_sce: [@sequence::physics.reco2,
+            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, fmatchSCE, opt0finderSCE]
 
 physics.trigger_paths: [ reco2_sce ]
 

--- a/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco2_sbnd.fcl
@@ -12,6 +12,5 @@
 
 process_name: Reco2
 
-physics.trigger_paths: [reco2 #, opticalt0
-			]
+physics.trigger_paths: [ reco2 ]
 physics.end_paths: [stream1, caloskimana]

--- a/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
+++ b/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
@@ -314,20 +314,20 @@ void SBNDOpT0Finder::DoMatch(art::Event& e,
 
   // Don't waste time if there are no flashes
   if (n_flashes == 0) {
-    mf::LogWarning("SBNDOpT0Finder") << "Zero good flashes in this event." << std::endl;
+    mf::LogInfo("SBNDOpT0Finder") << "Zero good flashes in this event." << std::endl;
     return;
   }
 
   // Get all the ligh clusters
   // auto light_cluster_v = GetLighClusters(e);
   if (!ConstructLightClusters(e, tpc)) {
-    mf::LogWarning("SBNDOpT0Finder") << "Cannot construct Light Clusters." << std::endl;
+    mf::LogInfo("SBNDOpT0Finder") << "Cannot construct Light Clusters." << std::endl;
     return;
   }
 
   // Don't waste time if there are no clusters
   if (!_light_cluster_v.size()) {
-    mf::LogWarning("SBNDOpT0Finder") << "No slices to work with." << std::endl;
+    mf::LogInfo("SBNDOpT0Finder") << "No slices to work with in TPC " << tpc << "." << std::endl;
     return;
   }
 
@@ -356,6 +356,7 @@ void SBNDOpT0Finder::DoMatch(art::Event& e,
 
     mf::LogInfo("SBNDOpT0Finder") << "Matched TPC object " << _tpcid
                                   << " with flash number " << _flashid
+                                  << " in TPC " << tpc
                                   << " -> score: " << _score
                                   << ", qll xmin: " << _qll_xmin << std::endl;
 

--- a/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
+++ b/sbndcode/OpT0Finder/SBNDOpT0Finder_module.cc
@@ -33,6 +33,8 @@
 #include "lardataobj/AnalysisBase/T0.h"
 #include "larcore/Geometry/Geometry.h"
 
+#include "larsim/PhotonPropagation/SemiAnalyticalModel.h"
+
 #include "larpandora/LArPandoraInterface/LArPandoraHelper.h"
 
 #include "sbncode/OpT0Finder/flashmatch/Base/OpT0FinderTypes.h"
@@ -87,6 +89,10 @@ private:
   /// Returns a list of uncoated PMTs that are a subset of those in ch_to_use
   std::vector<int> GetUncoatedPTMList(std::vector<int> ch_to_use);
 
+  std::unique_ptr<SemiAnalyticalModel> _semi_model;
+  fhicl::ParameterSet _vuv_params;
+  fhicl::ParameterSet _vis_params;
+
   ::flashmatch::FlashMatchManager _mgr; ///< The flash matching manager
   std::vector<flashmatch::FlashMatch_t> _result_v; ///< Matching result will be stored here
 
@@ -137,6 +143,10 @@ SBNDOpT0Finder::SBNDOpT0Finder(fhicl::ParameterSet const& p)
 
   ::art::ServiceHandle<geo::Geometry> geo;
 
+  _vuv_params = p.get<fhicl::ParameterSet>("VUVHits");
+  _vis_params = p.get<fhicl::ParameterSet>("VIVHits");
+  _semi_model = std::make_unique<SemiAnalyticalModel>(_vuv_params, _vis_params, true, false);
+
   _opflash_producer_v = p.get<std::vector<std::string>>("OpFlashProducers");
   _tpc_v = p.get<std::vector<unsigned int>>("TPCs");
   _slice_producer = p.get<std::string>("SliceProducer");
@@ -162,6 +172,7 @@ SBNDOpT0Finder::SBNDOpT0Finder(fhicl::ParameterSet const& p)
 
   _mgr.SetUncoatedPMTs(_uncoated_pmts);
 
+  _mgr.SetSemiAnalyticalModel(std::move(_semi_model));
 
   _flash_spec.resize(geo->NOpDets(), 0.);
   _hypo_spec.resize(geo->NOpDets(), 0.);

--- a/sbndcode/OpT0Finder/job/opt0finder_sbnd.fcl
+++ b/sbndcode/OpT0Finder/job/opt0finder_sbnd.fcl
@@ -1,4 +1,5 @@
 #include "flashmatchalg.fcl"
+#include "opticalsimparameterisations_sbnd.fcl"
 
 BEGIN_PROLOG
 
@@ -14,6 +15,9 @@ sbnd_opt0_finder:
 
   PhotoDetectors: ["pmt_coated", "pmt_uncoated"]
   TPC: 0
+
+  VUVHits: @local::sbnd_vuv_RS100cm_hits_parameterization
+  VIVHits: @local::sbnd_vis_RS100cm_hits_parameterization
 
   FlashMatchConfig: @local::flashmatch_config
 


### PR DESCRIPTION
This PR:
- Depends on SBNSoftware/sbncode#227.
- Enables running the `OpT0Finder` flash matching with the new larg4.
- Adds the `opt0finder` process back in the default reco chain.
- Fixes #163.

