### PR TITLE
CRT Plane Index and Commissioning Samples

### DIFF
--- a/sbndcode/CRT/CRTChannelMapAlg.cxx
+++ b/sbndcode/CRT/CRTChannelMapAlg.cxx
@@ -91,8 +91,6 @@ namespace geo {
       size_t& ad,
       size_t& sv) const {
 
-    std::cout << "CRTChannelMapAlg::PositionToAuxDetChannel" << std::endl;
-
     // Set the default to be that we don't find the position in any AuxDet
     uint32_t channel = UINT_MAX;
 

--- a/sbndcode/CRT/CRTUtils/CRTCommonUtils.cc
+++ b/sbndcode/CRT/CRTUtils/CRTCommonUtils.cc
@@ -182,14 +182,17 @@ std::pair<TVector3, TVector3> CRTCommonUtils::CubeIntersection(TVector3 min, TVe
 
 enum CRTPlane CRTCommonUtils::GetPlaneIndex(std::string tagger) {
 
-  if      (tagger == "volTaggerBot_0"      ) return kCRTBot;
-  else if (tagger == "volTaggerFaceFront_0") return kCRTFaceFront;
-  else if (tagger == "volTaggerFaceBack_0" ) return kCRTFaceBack;
-  else if (tagger == "volTaggerWest_0"     ) return kCRTSideWest;
-  else if (tagger == "volTaggerEast_0"     ) return kCRTSideEast;
-  else if (tagger == "volTaggerTopLow_0"   ) return kCRTTopLow;
-  else if (tagger == "volTaggerTopHigh_0"  ) return kCRTTopHigh;
-  else                                       return kCRTNotDefined;
+  if      (tagger == "volTaggerBot_0"     ) return kCRTBot;
+  else if (tagger == "volTaggerSouth_0"   ) return kCRTFaceSouth;
+  else if (tagger == "volTaggerNorth_0"   ) return kCRTFaceNorth;
+  else if (tagger == "volTaggerWest_0"    ) return kCRTSideWest;
+  else if (tagger == "volTaggerEast_0"    ) return kCRTSideEast;
+  else if (tagger == "volTaggerTopLow_0"  ) return kCRTTopLow;
+  else if (tagger == "volTaggerTopHigh_0" ) return kCRTTopHigh;
+  else {
+    mf::LogWarning("CRTCommonUtils") << "CRT tagger unkown: " << tagger << std::endl;
+    return kCRTNotDefined;
+  }
 
 }
 }

--- a/sbndcode/CRT/CRTUtils/CRTCommonUtils.cc
+++ b/sbndcode/CRT/CRTUtils/CRTCommonUtils.cc
@@ -180,5 +180,17 @@ std::pair<TVector3, TVector3> CRTCommonUtils::CubeIntersection(TVector3 min, TVe
 
 }
 
+enum CRTPlane CRTCommonUtils::GetPlaneIndex(std::string tagger) {
+
+  if      (tagger == "volTaggerBot_0"      ) return kCRTBot;
+  else if (tagger == "volTaggerFaceFront_0") return kCRTFaceFront;
+  else if (tagger == "volTaggerFaceBack_0" ) return kCRTFaceBack;
+  else if (tagger == "volTaggerWest_0"     ) return kCRTSideWest;
+  else if (tagger == "volTaggerEast_0"     ) return kCRTSideEast;
+  else if (tagger == "volTaggerTopLow_0"   ) return kCRTTopLow;
+  else if (tagger == "volTaggerTopHigh_0"  ) return kCRTTopHigh;
+  else                                       return kCRTNotDefined;
+
+}
 }
 

--- a/sbndcode/CRT/CRTUtils/CRTCommonUtils.h
+++ b/sbndcode/CRT/CRTUtils/CRTCommonUtils.h
@@ -8,6 +8,9 @@
 // Common functions for CRT reconstruction
 ///////////////////////////////////////////////
 
+// framework includes
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
 // sbndcode includes
 #include "sbnobj/Common/CRT/CRTHit.hh"
 
@@ -22,10 +25,10 @@ namespace sbnd {
   enum CRTPlane {
     kCRTNotDefined = -1,   ///< Not defined
     kCRTBot = 0,           ///< Bottom
-    kCRTFaceFront = 1,     ///< Face Front (South)
-    kCRTFaceBack,          ///< Face Back (North)
-    kCRTSideWest,          ///< SideLeft
-    kCRTSideEast,          ///< SideRight
+    kCRTFaceSouth = 1,     ///< Face South (Front)
+    kCRTFaceNorth,         ///< Face North (Back)
+    kCRTSideWest,          ///< Side Weast (Left)
+    kCRTSideEast,          ///< Side East (Right)
     kCRTTopLow,            ///< Top Low
     kCRTTopHigh,           ///< Top High
     kCRTPosMax

--- a/sbndcode/CRT/CRTUtils/CRTCommonUtils.h
+++ b/sbndcode/CRT/CRTUtils/CRTCommonUtils.h
@@ -18,9 +18,23 @@
 // ROOT
 #include "TVector3.h"
 
+namespace sbnd {
+  enum CRTPlane {
+    kCRTNotDefined = -1,   ///< Not defined
+    kCRTBot = 0,           ///< Bottom
+    kCRTFaceFront = 1,     ///< Face Front (South)
+    kCRTFaceBack,          ///< Face Back (North)
+    kCRTSideWest,          ///< SideLeft
+    kCRTSideEast,          ///< SideRight
+    kCRTTopLow,            ///< Top Low
+    kCRTTopHigh,           ///< Top High
+    kCRTPosMax
+  };
+}
+
 namespace sbnd{
 namespace CRTCommonUtils{
-  
+
   // Simple distance of closest approach between infinite track and centre of hit
   double SimpleDCA(sbn::crt::CRTHit hit, TVector3 start, TVector3 direction);
 
@@ -35,6 +49,8 @@ namespace CRTCommonUtils{
   // (https://www.scratchapixel.com/lessons/3d-basic-rendering/minimal-ray-tracer-rendering-simple-shapes/ray-box-intersection)
   std::pair<TVector3, TVector3> CubeIntersection(TVector3 min, TVector3 max, TVector3 start, TVector3 end);
 
+  // Returns the CRT plane index given the tagger name
+  enum ::sbnd::CRTPlane GetPlaneIndex(std::string tagger);
 }
 }
 

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -179,9 +179,10 @@ std::vector<std::pair<sbn::crt::CRTHit, std::vector<int>>> CRTHitRecoAlg::Create
             double time = (t0_1 + t0_2)/2;
             //double pes = tagStrip.second[hit_i].pes + taggerStrips[otherPlane][hit_j].pes;
             double pes = CorrectNpe(tagStrip.second[hit_i], taggerStrips[otherPlane][hit_j], mean);
+            int plane = sbnd::CRTCommonUtils::GetPlaneIndex(tagStrip.first.first);
 
             // Create a CRT hit
-            sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, 0, mean.X(), error.X(), 
+            sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, plane, mean.X(), error.X(), 
                                             mean.Y(), error.Y(), mean.Z(), error.Z(), tagStrip.first.first);
             std::vector<int> dataIds;
             dataIds.push_back(tagStrip.second[hit_i].dataID);
@@ -205,9 +206,10 @@ std::vector<std::pair<sbn::crt::CRTHit, std::vector<int>>> CRTHitRecoAlg::Create
 
         double time = tagStrip.second[hit_i].t0;
         double pes = tagStrip.second[hit_i].pes;
+        int plane = sbnd::CRTCommonUtils::GetPlaneIndex(tagStrip.first.first);
 
         // Just use the single plane limits as the crt hit
-        sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, 0, mean.X(), error.X(), 
+        sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, plane, mean.X(), error.X(), 
                                         mean.Y(), error.Y(), mean.Z(), error.Z(), tagStrip.first.first);
         std::vector<int> dataIds;
         dataIds.push_back(tagStrip.second[hit_i].dataID);
@@ -232,9 +234,10 @@ std::vector<std::pair<sbn::crt::CRTHit, std::vector<int>>> CRTHitRecoAlg::Create
 
         double time = taggerStrips[otherPlane][hit_j].t0;
         double pes = taggerStrips[otherPlane][hit_j].pes;
+        int plane = sbnd::CRTCommonUtils::GetPlaneIndex(otherPlane.first);
 
         // Just use the single plane limits as the crt hit
-        sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, 0, mean.X(), error.X(), 
+        sbn::crt::CRTHit crtHit = FillCrtHit(tfeb_id, tpesmap, pes, time, plane, mean.X(), error.X(), 
                                         mean.Y(), error.Y(), mean.Z(), error.Z(), otherPlane.first);
         std::vector<int> dataIds;
         dataIds.push_back(taggerStrips[otherPlane][hit_j].dataID);

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -38,6 +38,7 @@ namespace detinfo {
 
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/SBND/CRT/CRTData.hh"
+#include "sbndcode/CRT/CRTUtils/CRTCommonUtils.h"
 #include "sbndcode/Geometry/GeometryWrappers/TPCGeoAlg.h"
 #include "sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h"
 

--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -579,7 +579,7 @@ void Hitdumper::analyze(const art::Event& evt)
         int  nh1y = 0, nh2y = 0;
         float adc1x = 0, adc2x = 0;
         float adc1y = 0, adc2y = 0;
-        if (_crt_plane[i] == sbnd::kCRTFaceFront) { // 1
+        if (_crt_plane[i] == sbnd::kCRTFaceSouth) { // 1
           if (_crt_orient[i] == kCRTVertical && _crt_adc[i] > 500) { // < 500 hardcoded
             if (nh1x == 0 || (_crt_module[i] == plane1xm)) {
               nh1x++;
@@ -631,7 +631,7 @@ void Hitdumper::analyze(const art::Event& evt)
           float tdiff = fabs(_crt_time[i]-_crt_time[j]);
           if (tdiff<0.1) {
             iflag[j]=1;
-            if (_crt_plane[j]==sbnd::kCRTFaceFront) {
+            if (_crt_plane[j]==sbnd::kCRTFaceSouth) {
               if (_crt_orient[j]==kCRTVertical && _crt_adc[j]>1000) {
                 if (nh1x==0 ||  (_crt_module[j]==plane1xm)) {
                   nh1x++;

--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -43,6 +43,7 @@
 #include "sbnobj/SBND/CRT/CRTData.hh"
 #include "sbnobj/Common/CRT/CRTHit.hh"
 #include "sbnobj/Common/CRT/CRTTrack.hh"
+#include "sbndcode/CRT/CRTUtils/CRTCommonUtils.h"
 #include "sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h"
 #include "sbndcode/OpDetSim/sbndPDMapAlg.hh"
 #include "sbnobj/SBND/Commissioning/MuonTrack.hh"
@@ -78,18 +79,6 @@
 const int MAX_INT = std::numeric_limits<int>::max();
 const long int TIME_CORRECTION = (long int) std::numeric_limits<int>::max() * 2;
 const int DEFAULT_VALUE = -9999;
-
-enum CRTPos {
-  kNotDefined = -1,   ///< Not defined
-  kBot = 0,           ///< Bot
-  kFaceFront = 1,     ///< FaceFront
-  kFaceBack,          ///< FaceBack
-  kSideLeft,          ///< SideLeft
-  kSideRight,         ///< SideRight
-  kTopLow,            ///< TopLow
-  kTopHigh,           ///< TopHigh
-  kCRTPosMax
-};
 
 enum CRTOrientation {
   kCRTNotDefined = -1,   ///< Not defined
@@ -524,14 +513,7 @@ void Hitdumper::analyze(const art::Event& evt)
 
     //    std::pair<std::string,unsigned> tagger = CRTHitRecoAlg::ChannelToTagger(chan);
     std::pair<std::string,unsigned> tagger = hitAlg.ChannelToTagger(chan);
-    CRTPos ip = kNotDefined;
-    if  (tagger.first=="volTaggerFaceFront_0" )    ip = kFaceFront;
-    else if (tagger.first=="volTaggerFaceBack_0")  ip = kFaceBack;
-    else if (tagger.first=="volTaggerSideLeft_0")  ip = kSideLeft;
-    else if (tagger.first=="volTaggerSideRight_0") ip = kSideRight;
-    else if (tagger.first=="volTaggerTopLow_0")    ip = kTopLow;
-    else if (tagger.first=="volTaggerTopHigh_0")   ip = kTopHigh;
-    else if (tagger.first=="volTaggerBot_0")       ip = kBot;
+    sbnd::CRTPlane ip = sbnd::CRTCommonUtils::GetPlaneIndex(tagger.first);
 
     bool keep_tagger = false;
     for (auto t : fKeepTaggerTypes) {
@@ -541,7 +523,7 @@ void Hitdumper::analyze(const art::Event& evt)
     }
     // std::cout << "Tagger name " << tagger.first << ", ip " << ip << ", kept? " << (keep_tagger ? "yes" : "no") << std::endl;
 
-    if (ip != kNotDefined && keep_tagger) {
+    if (ip != sbnd::kCRTNotDefined && keep_tagger) {
 
       uint32_t ttime = striplist[i]->T0();
       float ctime = (int)ttime * 0.001; // convert form ns to us
@@ -597,7 +579,7 @@ void Hitdumper::analyze(const art::Event& evt)
         int  nh1y = 0, nh2y = 0;
         float adc1x = 0, adc2x = 0;
         float adc1y = 0, adc2y = 0;
-        if (_crt_plane[i] == kFaceFront) { // 1
+        if (_crt_plane[i] == sbnd::kCRTFaceFront) { // 1
           if (_crt_orient[i] == kCRTVertical && _crt_adc[i] > 500) { // < 500 hardcoded
             if (nh1x == 0 || (_crt_module[i] == plane1xm)) {
               nh1x++;
@@ -649,7 +631,7 @@ void Hitdumper::analyze(const art::Event& evt)
           float tdiff = fabs(_crt_time[i]-_crt_time[j]);
           if (tdiff<0.1) {
             iflag[j]=1;
-            if (_crt_plane[j]==kFaceFront) {
+            if (_crt_plane[j]==sbnd::kCRTFaceFront) {
               if (_crt_orient[j]==kCRTVertical && _crt_adc[j]>1000) {
                 if (nh1x==0 ||  (_crt_module[j]==plane1xm)) {
                   nh1x++;
@@ -752,18 +734,8 @@ void Hitdumper::analyze(const art::Event& evt)
     ResetCRTHitsVars(_nchits);
 
     for (int i = 0; i < _nchits; ++i){
-      int ip = kNotDefined;
-      if  (chitlist[i]->tagger=="volTaggerFaceFront_0" )    ip = kFaceFront;
-      else if (chitlist[i]->tagger=="volTaggerFaceBack_0")  ip = kFaceBack;
-      else if (chitlist[i]->tagger=="volTaggerSideLeft_0")  ip = kSideLeft;
-      else if (chitlist[i]->tagger=="volTaggerSideRight_0") ip = kSideRight;
-      else if (chitlist[i]->tagger=="volTaggerTopLow_0")    ip = kTopLow;
-      else if (chitlist[i]->tagger=="volTaggerTopHigh_0")   ip = kTopHigh;
-      else if (chitlist[i]->tagger=="volTaggerBot_0")       ip = kBot;
-      else {
-        mf::LogWarning("HitDumper") << "Cannot identify tagger of type "
-                                    << chitlist[i]->tagger << std::endl;
-      }
+      // int ip = kNotDefined;
+      sbnd::CRTPlane ip = sbnd::CRTCommonUtils::GetPlaneIndex(chitlist[i]->tagger);
 
       _chit_time[i]=chitlist[i]->ts1_ns*0.001;
       if (chitlist[i]->ts1_ns > MAX_INT) {

--- a/sbndcode/Commissioning/fcls/detsim_comm_sbnd.fcl
+++ b/sbndcode/Commissioning/fcls/detsim_comm_sbnd.fcl
@@ -4,8 +4,10 @@
 #include "standard_detsim_sbnd.fcl"
 
 # Raise the arapuca threshold to avoid saving arapucas (temporary)
-physics.producers.opdaq.TriggerThresholdADCArapuca: 500
+# physics.producers.opdaq.TriggerThresholdADCArapuca: 500
 
 # Lower the PMT threshold to save the full waveform
-physics.producers.opdaq.TriggerThresholdADCPMT: 0
+# physics.producers.opdaq.TriggerThresholdADCPMT: 0
 
+# Do not apply optical triggers (done to save the full waveform)
+physics.producers.opdaq.ApplyTriggers: false

--- a/sbndcode/Commissioning/fcls/reco1_sce_comm.fcl
+++ b/sbndcode/Commissioning/fcls/reco1_sce_comm.fcl
@@ -16,3 +16,7 @@ outputs.out1.outputCommands: [ "keep *_*_*_*"
                              , "drop *_linecluster_*_*"
                              # , "drop *_fasthit_*_*"
                              ]
+
+
+# HitDumper configuration
+physics.analyzers.hitdumper.keepCRTstrips: true

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
@@ -104,7 +104,7 @@ namespace lightana{
             std::cerr << "Length of OpChannel array parameter is 0..." << std::endl;
             throw std::exception();
         }
-        std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
+        // std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
         /*
         if(_pe_baseline_v.size() != duplicate.size()) {
           std::cout << "PEBaseline array length (" << _pe_baseline_v.size()


### PR DESCRIPTION
This PR:
- From Michelle: adds a `GetPlaneIndex` function in `CRTCommonUtils` to retrieve the CRT plane index. This is also saved in the CRT Hit dataproduct.
- Fixes the CRT plane names: Front, Back, Left, Right -> South, North, West, East
- Makes sure that the commissioning detsim fhicl saves the full optical waveforms 

This PR is also needed to generate the commissioning samples for the current 2021C production.