### PR TITLE
Adding fcl to drop mcreco for intime cosmics

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/g4_sce_simphotontime_filter_no_shower_rollup_no_mcreco.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_sce_simphotontime_filter_no_shower_rollup_no_mcreco.fcl
@@ -1,0 +1,29 @@
+#include "g4_sce_simphotontime_filter_no_shower_rollup.fcl"
+
+# Add all these new modules to the simulate path                                                                                                                                 
+physics.simulate: [ rns
+                  ### Complete intime drift simulation and generic CRT                                                                                                           
+                  , simdriftintime
+                  , genericcrtintime
+                  ### Do full Geant4 simulation for the outtimes                                                                                                                 
+                  , loader
+                  , larg4outtime
+                  , ionandscintouttime
+                  , pdfastsimouttime
+                  , simdriftouttime
+                  , genericcrtouttime
+                  ### Simulate the light outside the AV                                                                                                                          
+                  # , ionandscintoutintime                                                                                                                                       
+                  # , pdfastsimoutintime                                                                                                                                         
+                  # , ionandscintoutouttime                                                                                                                                      
+                  # , pdfastsimoutouttime                                                                                                                                        
+                  ### Merge the intime and outtime paths                                                                                                                         
+                  , largeant
+                  , ionandscint
+                  , simdrift
+                  , pdfastsim
+                  # , pdfastsimout                                                                                                                                               
+                  , genericcrt
+                  ### Don't truth-level reconstruction                                                                                                                              
+                  #, mcreco
+                  ]


### PR DESCRIPTION
Running MCReco for in-time cosmics isn't needed by physics groups and it is very very slow to run without shower-rollup.