### PR TITLE
Persist Neutrino ID Features

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
@@ -34,6 +34,7 @@
         <MvaName>NeutrinoId</MvaName>
         <MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
         <MaximumNeutrinos>999</MaximumNeutrinos>
+        <PersistFeatures>true</PersistFeatures>
       </tool>
     </SliceIdTools>
     <InputHitListName>CaloHitList2D</InputHitListName>


### PR DESCRIPTION
This PR makes the required change to the pandora settings file to use the functionality in PandoraPFA/LArContent#189. **NOTE** it should not be merged until the LArContent PR has been merged but I thought I'd get it done so it was waiting here.

It goes hand in hand with SBNSoftware/sbncode#234 and sbnsoftware/sbnanaobj#43 such that with all 4 of these PRs merged then, thanks to @brucehoward-physics, the features will also be picked up by CAFMaker and end up in the caf files.