### PR TITLE
Update pandora settings to persist neutrino id features

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
@@ -34,6 +34,7 @@
         <MvaName>NeutrinoId</MvaName>
         <MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
         <MaximumNeutrinos>999</MaximumNeutrinos>
+        <PersistFeatures>true</PersistFeatures>
       </tool>
     </SliceIdTools>
     <InputHitListName>CaloHitList2D</InputHitListName>


### PR DESCRIPTION
Updated from SBNSoftware/sbndcode#254 in order to be based on the release branch.

> This PR makes the required change to the pandora settings file to use the functionality in https://github.com/PandoraPFA/LArContent/pull/189. **NOTE** it should not be merged until the LArContent PR has been merged but I thought I'd get it done so it was waiting here.
> 
> It goes hand in hand with https://github.com/SBNSoftware/sbncode/pull/234 and https://github.com/SBNSoftware/sbnanaobj/pull/43 such that with all 4 of these PRs merged then, thanks to @brucehoward-physics, the features will also be picked up by CAFMaker and end up in the caf files.