### PR TITLE
CRT Geometry Mapping BugFix

### DIFF
--- a/sbndcode/CRT/CRTAna/crtanamodules_sbnd.fcl
+++ b/sbndcode/CRT/CRTAna/crtanamodules_sbnd.fcl
@@ -13,13 +13,14 @@ sbnd_crtdetsimana:
       module_type:     "sbndcode/CRT/CRTAna/CRTDetSimAna"
 
       # The input parameters
-      SimModuleLabel:       "largeant"    # Simulation producer module label
-      CRTSimLabel:          "crt"         # CRT producer module label
-      Verbose:              false         # Print extra information about what's going on
-      QPed:                 @local::sbnd_crtsim.QPed
-      QSlope:               @local::sbnd_crtsim.QSlope
-      ClockSpeedCRT:        @local::sbnd_crtsim.ClockSpeedCRT
-      CrtBackTrack:         @local::standard_crtbacktracker
+      SimModuleLabel:           "largeant"    # Simulation producer module label (for MCParticles)
+      SimChannelModuleLabel:    "genericcrt"  # Sim Channel producer module label
+      CRTSimLabel:              "crt"         # CRT producer module label
+      Verbose:                  false         # Print extra information about what's going on
+      QPed:                     @local::sbnd_crtsim.QPed
+      QSlope:                   @local::sbnd_crtsim.QSlope
+      ClockSpeedCRT:            @local::sbnd_crtsim.ClockSpeedCRT
+      CrtBackTrack:             @local::standard_crtbacktracker
 }
 
 sbnd_crthitrecoana:

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -168,7 +168,7 @@ CRTGeoAlg::CRTGeoAlg(geo::GeometryCore const *geometry, geo::AuxDetGeometryCore 
         strip.minZ = std::min(limitsWorld[2], limitsWorld2[2]);
         strip.maxZ = std::max(limitsWorld[2], limitsWorld2[2]);
         strip.normal = auxDetSensitive.GetNormalVector();
-        strip.width = halfWidth * 2.;
+        strip.width = halfHeight * 2.;
         strip.null = false;
         strip.module = moduleName;
 
@@ -176,12 +176,12 @@ CRTGeoAlg::CRTGeoAlg(geo::GeometryCore const *geometry, geo::AuxDetGeometryCore 
         uint32_t channel0 = 32 * ad_i + 2 * sv_i + 0;
         uint32_t channel1 = 32 * ad_i + 2 * sv_i + 1;
         // Sipm0 is on the left in local coords
-        double sipm0X = -halfWidth;
-        double sipm1X = halfWidth;
-        // In local coordinates the Y position is at half height (top if top) (bottom if not)
-        double sipmY = halfHeight;
-        if(!fModules[moduleName].top) sipmY = - halfHeight;
-        double sipm0XYZ[3] = {sipm0X, sipmY, 0};
+        double sipm0Y = -halfHeight;
+        double sipm1Y = halfHeight;
+        // In local coordinates the X position is at half width (top if top) (bottom if not)
+        double sipmX = halfWidth;
+        if(!fModules[moduleName].top) sipmX = - halfWidth;
+        double sipm0XYZ[3] = {sipmX, sipm0Y, 0};
         double sipm0XYZWorld[3];
         auxDetSensitive.LocalToWorld(sipm0XYZ, sipm0XYZWorld);
 
@@ -194,7 +194,7 @@ CRTGeoAlg::CRTGeoAlg(geo::GeometryCore const *geometry, geo::AuxDetGeometryCore 
         sipm0.null = false;
         fSipms[channel0] = sipm0;
 
-        double sipm1XYZ[3] = {sipm1X, sipmY, 0};
+        double sipm1XYZ[3] = {sipmX, sipm1Y, 0};
         double sipm1XYZWorld[3];
         auxDetSensitive.LocalToWorld(sipm1XYZ, sipm1XYZWorld);
 
@@ -380,12 +380,12 @@ std::vector<double> CRTGeoAlg::StripLimitsWithChargeSharing(std::string stripNam
   double halfLength = sensitiveGeo.HalfLength();
 
   // Get the maximum strip limits in world coordinates
-  double l1[3] = {-halfWidth + x + ex, halfHeight, halfLength};
+  double l1[3] = {halfWidth, -halfHeight + x + ex, halfLength};
   double w1[3];
   sensitiveGeo.LocalToWorld(l1, w1);
 
   // Get the minimum strip limits in world coordinates
-  double l2[3] = {-halfWidth + x - ex, -halfHeight, -halfLength};
+  double l2[3] = {-halfWidth, -halfHeight + x - ex, -halfLength};
   double w2[3];
   sensitiveGeo.LocalToWorld(l2, w2);
 

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -472,11 +472,8 @@ bool CRTGeoAlg::IsInsideCRT(TVector3 point){
 
 bool CRTGeoAlg::IsInsideCRT(geo::Point_t point){
   std::vector<double> limits = CRTLimits();
-  if(point.X() > limits[0] && point.Y() > limits[1] && point.Z() > limits[2]
-     && point.X() < limits[3] && point.Y() < limits[4] && point.Z() < limits[5]){
-    return true;
-  }
-  return false;
+  return point.X() > limits[0] && point.Y() > limits[1] && point.Z() > limits[2]
+    && point.X() < limits[3] && point.Y() < limits[4] && point.Z() < limits[5];
 }
 
 // ----------------------------------------------------------------------------------
@@ -497,8 +494,8 @@ bool CRTGeoAlg::IsInsideTagger(const CRTTaggerGeo& tagger, geo::Point_t point){
   double xmax = tagger.maxX;
   double ymax = tagger.maxY;
   double zmax = tagger.maxZ;
-  if(x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax) return true;
-  return false;
+
+  return x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax;
 }
 
 // ----------------------------------------------------------------------------------
@@ -519,12 +516,8 @@ bool CRTGeoAlg::IsInsideModule(const CRTModuleGeo& module, geo::Point_t point){
   double xmax = module.maxX;
   double ymax = module.maxY;
   double zmax = module.maxZ;
-  // Make the width limits a bit more generous to account for steps in true trajectory
-  /*if(std::abs(xmax-xmin)==1){ xmin-=1; xmax+=1; }
-  if(std::abs(ymax-ymin)==1){ ymin-=1; ymax+=1; }
-  if(std::abs(zmax-zmin)==1){ zmin-=1; zmax+=1; }*/
-  if(x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax) return true;
-  return false;
+
+  return x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax;
 }
 
 // ----------------------------------------------------------------------------------
@@ -545,12 +538,8 @@ bool CRTGeoAlg::IsInsideStrip(const CRTStripGeo& strip, geo::Point_t point){
   double xmax = strip.maxX;
   double ymax = strip.maxY;
   double zmax = strip.maxZ;
-  // Make the width limits a bit more generous to account for steps in true trajectory
-  /*if(std::abs(xmax-xmin)==1){ xmin-=0.5; xmax+=0.5; }
-  if(std::abs(ymax-ymin)==1){ ymin-=0.5; ymax+=0.5; }
-  if(std::abs(zmax-zmin)==1){ zmin-=0.5; zmax+=0.5; }*/
-  if(x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax) return true;
-  return false;
+
+  return x > xmin && x < xmax && y > ymin && y < ymax && z > zmin && z < zmax;
 }
 
 // ----------------------------------------------------------------------------------
@@ -565,9 +554,7 @@ bool CRTGeoAlg::CheckOverlap(const CRTModuleGeo& module1, const CRTModuleGeo& mo
   double maxZ = std::min(module1.maxZ, module2.maxZ);
 
   // If the two strips overlap in 2 dimensions then return true
-  if ((minX<maxX && minY<maxY) || (minX<maxX && minZ<maxZ) || (minY<maxY && minZ<maxZ)) return true;
-  // Otherwise return a "null" value
-  return false;
+  return (minX<maxX && minY<maxY) || (minX<maxX && minZ<maxZ) || (minY<maxY && minZ<maxZ);
 }
 
 // ----------------------------------------------------------------------------------
@@ -838,8 +825,7 @@ bool CRTGeoAlg::CrossesVolume(const simb::MCParticle& particle){
     else if(i == 0) startOutside = true;
     else if(i == particle.NumberTrajectoryPoints()-1) endOutside = true;
   }
-  if(startOutside && enters && endOutside) return true;
-  return false;
+  return startOutside && enters && endOutside;
 }
 
 

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -343,6 +343,17 @@ CRTStripGeo CRTGeoAlg::GetStrip(std::string stripName) const{
   return nullStrip;
 }
 
+// Get the strip geometry object by global index
+CRTStripGeo CRTGeoAlg::GetStrip(size_t strip_i) const{
+  size_t index = 0;
+  for(auto const& strip : fStrips){
+    if(strip_i == index) return strip.second;
+    index++;
+  }
+  CRTStripGeo nullStrip = {};
+  nullStrip.null = true;
+  return nullStrip;
+}
 
 
 // Get the tagger name from strip or module name

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -276,7 +276,6 @@ size_t CRTGeoAlg::NumModules() const{
 }
 
 
-
 // ----------------------------------------------------------------------------------
 // Get the total number of strips in the geometry
 size_t CRTGeoAlg::NumStrips() const{
@@ -477,12 +476,7 @@ bool CRTGeoAlg::IsInsideCRT(geo::Point_t point){
 }
 
 // ----------------------------------------------------------------------------------
-// Determine if a point is inside a tagger by name
-bool CRTGeoAlg::IsInsideTagger(std::string taggerName, geo::Point_t point){
-  CRTTaggerGeo tagger = GetTagger(taggerName);
-  return IsInsideTagger(tagger, point);
-}
-
+// Determine if a point is inside a tagger
 bool CRTGeoAlg::IsInsideTagger(const CRTTaggerGeo& tagger, geo::Point_t point){
   if(tagger.null) return false;
   double x = point.X();
@@ -499,12 +493,7 @@ bool CRTGeoAlg::IsInsideTagger(const CRTTaggerGeo& tagger, geo::Point_t point){
 }
 
 // ----------------------------------------------------------------------------------
-// Determine if a point is inside a module by name
-bool CRTGeoAlg::IsInsideModule(std::string moduleName, geo::Point_t point){
-  CRTModuleGeo module = GetModule(moduleName);
-  return IsInsideModule(module, point);
-}
-
+// Determine if a point is inside a module
 bool CRTGeoAlg::IsInsideModule(const CRTModuleGeo& module, geo::Point_t point){
   if(module.null) return false;
   double x = point.X();
@@ -521,12 +510,7 @@ bool CRTGeoAlg::IsInsideModule(const CRTModuleGeo& module, geo::Point_t point){
 }
 
 // ----------------------------------------------------------------------------------
-// Determine if a point is inside a strip by name
-bool CRTGeoAlg::IsInsideStrip(std::string stripName, geo::Point_t point){
-  CRTStripGeo strip = GetStrip(stripName);
-  return IsInsideStrip(strip, point);
-}
-
+// Determine if a point is inside a strip
 bool CRTGeoAlg::IsInsideStrip(const CRTStripGeo& strip, geo::Point_t point){
   if(strip.null) return false;
   double x = point.X();
@@ -576,26 +560,6 @@ bool CRTGeoAlg::HasOverlap(const CRTModuleGeo& module){
 
 bool CRTGeoAlg::StripHasOverlap(std::string stripName){
   return HasOverlap(fModules.at(fStrips.at(stripName).module));
-}
-
-std::vector<double> CRTGeoAlg::StripOverlap(std::string strip1Name, std::string strip2Name){
-  auto const& strip1 = fStrips.at(strip1Name);
-  auto const& strip2 = fStrips.at(strip2Name);
-
-  double minX = std::max(strip1.minX, strip2.minX);
-  double maxX = std::min(strip1.maxX, strip2.maxY);
-  double minY = std::max(strip1.minY, strip2.minY);
-  double maxY = std::min(strip1.maxY, strip2.maxY);
-  double minZ = std::max(strip1.minZ, strip2.minZ);
-  double maxZ = std::min(strip1.maxZ, strip2.maxZ);
-
-  std::vector<double> null = {-99999, -99999, -99999, -99999, -99999, -99999};
-  std::vector<double> overlap = {minX, maxX, minY, maxY, minZ, maxZ};
-
-  // If the two strips overlap in 2 dimensions then return the overlap
-  if ((minX<maxX && minY<maxY) || (minX<maxX && minZ<maxZ) || (minY<maxY && minZ<maxZ)) return overlap;
-  // Otherwise return a "null" value
-  return null;
 }
 
 // ----------------------------------------------------------------------------------

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -820,8 +820,7 @@ bool CRTGeoAlg::EntersVolume(const simb::MCParticle& particle){
     else if(i == 0) startOutside = true;
     else if(i == particle.NumberTrajectoryPoints()-1) endOutside = true;
   }
-  if(enters && (startOutside || endOutside)) return true;
-  return false;
+  return enters && (startOutside || endOutside);
 }
 
 // ----------------------------------------------------------------------------------

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -144,6 +144,10 @@ CRTGeoAlg::CRTGeoAlg(geo::GeometryCore const *geometry, geo::AuxDetGeometryCore 
         usedStrips.push_back(stripName);
 
         // Get the limits in local coordinates
+	// Note that these dimensions DO NOT conform to the expected mapping
+	// width  = conventional strip length (one end to another)
+	// height = conventional strip width (distance between the two SiPMs)
+	// length = conventional thickness
         double halfWidth = auxDetSensitive.HalfWidth1();
         double halfHeight = auxDetSensitive.HalfHeight();
         double halfLength = auxDetSensitive.Length()/2;
@@ -178,7 +182,8 @@ CRTGeoAlg::CRTGeoAlg(geo::GeometryCore const *geometry, geo::AuxDetGeometryCore 
         // Sipm0 is on the left in local coords
         double sipm0Y = -halfHeight;
         double sipm1Y = halfHeight;
-        // In local coordinates the X position is at half width (top if top) (bottom if not)
+        // In local coordinates the X position is at half width (remembering width is actually length)
+	// (top if top) (bottom if not)
         double sipmX = halfWidth;
         if(!fModules[moduleName].top) sipmX = - halfWidth;
         double sipm0XYZ[3] = {sipmX, sipm0Y, 0};
@@ -388,6 +393,9 @@ std::vector<double> CRTGeoAlg::StripLimitsWithChargeSharing(std::string stripNam
   double halfWidth = sensitiveGeo.HalfWidth1();
   double halfHeight = sensitiveGeo.HalfHeight();
   double halfLength = sensitiveGeo.HalfLength();
+
+  // Note that for the purpose of this reconstruction the "height" coordinates (in y)
+  // is the dimension we would conventionally think of as width (distance between the SiPMs)
 
   // Get the maximum strip limits in world coordinates
   double l1[3] = {halfWidth, -halfHeight + x + ex, halfLength};

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.cc
@@ -275,19 +275,6 @@ size_t CRTGeoAlg::NumModules() const{
   return fModules.size();
 }
 
-// Get the number of modules in a tagger by name
-size_t CRTGeoAlg::NumModules(std::string taggerName) const{
-  CRTTaggerGeo tagger = GetTagger(taggerName);
-  if(!tagger.null) return tagger.modules.size();
-  return 0;
-}
-
-// Get the number of modules in a tagger by index
-size_t CRTGeoAlg::NumModules(size_t tagger_i) const{
-  CRTTaggerGeo tagger = GetTagger(tagger_i);
-  if(!tagger.null) return tagger.modules.size();
-  return 0;
-}
 
 
 // ----------------------------------------------------------------------------------
@@ -296,26 +283,6 @@ size_t CRTGeoAlg::NumStrips() const{
   return fStrips.size();
 }
 
-// Get the number of strips in module by name
-size_t CRTGeoAlg::NumStrips(std::string moduleName) const{
-  CRTModuleGeo module = GetModule(moduleName);
-  if(!module.null) return module.strips.size();
-  return 0;
-}
-
-// Get the number of strips in  module by global index
-size_t CRTGeoAlg::NumStrips(size_t module_i) const{
-  CRTModuleGeo module = GetModule(module_i);
-  if(!module.null) return module.strips.size();
-  return 0;
-}
-
-// Get the number of strips in module by tagger index and local module index
-size_t CRTGeoAlg::NumStrips(size_t tagger_i, size_t module_i) const{
-  CRTModuleGeo module = GetModule(tagger_i, module_i);
-  if(!module.null) return module.strips.size();
-  return 0;
-}
 
 // ----------------------------------------------------------------------------------
 // Get the tagger geometry object by name
@@ -364,21 +331,6 @@ CRTModuleGeo CRTGeoAlg::GetModule(size_t module_i) const{
   return nullModule;
 }
 
-// Get the module geometry object by tagger index and local module index
-CRTModuleGeo CRTGeoAlg::GetModule(size_t tagger_i, size_t module_i) const{
-  CRTModuleGeo nullModule = {};
-  nullModule.null = true;
-
-  CRTTaggerGeo tagger = GetTagger(tagger_i);
-  if(tagger.null) return nullModule;
-
-  size_t index = 0;
-  for(auto const& module : tagger.modules){
-    if(module_i == index) return module.second;
-    index++;
-  }
-  return nullModule;
-}
 
 
 // ----------------------------------------------------------------------------------
@@ -392,49 +344,6 @@ CRTStripGeo CRTGeoAlg::GetStrip(std::string stripName) const{
   return nullStrip;
 }
 
-// Get the strip geometry object by global index
-CRTStripGeo CRTGeoAlg::GetStrip(size_t strip_i) const{
-  size_t index = 0;
-  for(auto const& strip : fStrips){
-    if(strip_i == index) return strip.second;
-    index++;
-  }
-  CRTStripGeo nullStrip = {};
-  nullStrip.null = true;
-  return nullStrip;
-}
-
-// Get the strip geometry object by global module index and local strip index
-CRTStripGeo CRTGeoAlg::GetStrip(size_t module_i, size_t strip_i) const{
-  CRTStripGeo nullStrip = {};
-  nullStrip.null = true;
-
-  CRTModuleGeo module = GetModule(module_i);
-  if(module.null) return nullStrip;
-
-  size_t index = 0;
-  for(auto const& strip : module.strips){
-    if(strip_i == index) return strip.second;
-    index++;
-  }
-  return nullStrip;
-}
-
-// Get the strip geometry object by tagger index, local module index and local strip index
-CRTStripGeo CRTGeoAlg::GetStrip(size_t tagger_i, size_t module_i, size_t strip_i) const{
-  CRTStripGeo nullStrip = {};
-  nullStrip.null = true;
-
-  CRTModuleGeo module = GetModule(tagger_i, module_i);
-  if(module.null) return nullStrip;
-
-  size_t index = 0;
-  for(auto const& strip : module.strips){
-    if(strip_i == index) return strip.second;
-    index++;
-  }
-  return nullStrip;
-}
 
 
 // Get the tagger name from strip or module name

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
@@ -127,6 +127,8 @@ namespace sbnd{
 
     // Get the strip geometry object by name
     CRTStripGeo GetStrip(std::string stripName) const;
+    // Get the strip geometry object by global index
+    CRTStripGeo GetStrip(size_t strip_i) const;
 
     // Get tagger name from strip or module name
     std::string GetTaggerName(std::string name) const;

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
@@ -154,13 +154,10 @@ namespace sbnd{
     bool IsInsideCRT(TVector3 point);
     bool IsInsideCRT(geo::Point_t point);
     // Determine if a point is inside a tagger by name
-    bool IsInsideTagger(std::string taggerName, geo::Point_t point);
     bool IsInsideTagger(const CRTTaggerGeo& tagger, geo::Point_t point);
     // Determine if a point is inside a module by name
-    bool IsInsideModule(std::string moduleName, geo::Point_t point);
     bool IsInsideModule(const CRTModuleGeo& module, geo::Point_t point);
     // Determine if a point is inside a strip by name
-    bool IsInsideStrip(std::string stripName, geo::Point_t point);
     bool IsInsideStrip(const CRTStripGeo& strip, geo::Point_t point);
 
     // Check if two modules overlap in 2D
@@ -168,7 +165,6 @@ namespace sbnd{
     // Check is a module overlaps with a perpendicual module in the same tagger
     bool HasOverlap(const CRTModuleGeo& module);
     bool StripHasOverlap(std::string stripName);
-    std::vector<double> StripOverlap(std::string strip1Name, std::string strip2Name);
 
     // Find the average of the tagger entry and exit points of a true particle trajectory
     geo::Point_t TaggerCrossingPoint(std::string taggerName, const simb::MCParticle& particle);

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
@@ -111,19 +111,9 @@ namespace sbnd{
 
     // Get the total number of modules in the geometry
     size_t NumModules() const;
-    // Get the number of modules in a tagger by name
-    size_t NumModules(std::string taggerName) const;
-    // Get the number of modules in a tagger by index
-    size_t NumModules(size_t tagger_i) const;
 
     // Get the total number of strips in the geometry
     size_t NumStrips() const;
-    // Get the number of strips in module by name
-    size_t NumStrips(std::string moduleName) const;
-    // Get the number of strips in  module by global index
-    size_t NumStrips(size_t module_i) const;
-    // Get the number of strips in module by tagger index and local module index
-    size_t NumStrips(size_t tagger_i, size_t module_i) const;
 
     // Get the tagger geometry object by name
     CRTTaggerGeo GetTagger(std::string taggerName) const;
@@ -134,17 +124,9 @@ namespace sbnd{
     CRTModuleGeo GetModule(std::string moduleName) const;
     // Get the module geometry object by global index
     CRTModuleGeo GetModule(size_t module_i) const;
-    // Get the module geometry object by tagger index and local module index
-    CRTModuleGeo GetModule(size_t tagger_i, size_t module_i) const;
 
     // Get the strip geometry object by name
     CRTStripGeo GetStrip(std::string stripName) const;
-    // Get the strip geometry object by global index
-    CRTStripGeo GetStrip(size_t strip_i) const;
-    // Get the strip geometry object by global module index and local strip index
-    CRTStripGeo GetStrip(size_t module_i, size_t strip_i) const;
-    // Get the strip geometry object by tagger index, local module index and local strip index
-    CRTStripGeo GetStrip(size_t tagger_i, size_t module_i, size_t strip_i) const;
 
     // Get tagger name from strip or module name
     std::string GetTaggerName(std::string name) const;


### PR DESCRIPTION
When we adopted geometry v02_00 we inverted how the x & y dimensions are defined for CRT strips and modules. This caused some issues with the CRT reconstruction which made assumptions about the directions of quantities like width and height.

I presented a more detailed explanation of this changes in a recent [SBND Reco](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=24687) meeting. The critical commit is 7b49c61. This makes the changes to fix the reconstruction. I have also taken the time to check all other uses of CRTGeoAlg to ensure it is correct in other places, in doing this I found lots of unused functions and have taken the opinion we can remove them. Happy to remove any of these more cosmetic changes if the reviewers feel it would be better.

Note this has been rebased onto the 2021C release branch.