### PR TITLE
CRUMBS

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -162,6 +162,8 @@ physics:
   crttrack:            @local::standard_crttrackproducer
   crthitt0:            @local::sbnd_crthitt0producer
   crttrackt0:          @local::sbnd_crttrackt0producer
+  crthitt0SCE:         @local::sbnd_crthitt0producer
+  crttrackt0SCE:       @local::sbnd_crttrackt0producer
 
   ### flash-matching
   fmatch:              @local::sbnd_simple_flashmatch
@@ -317,6 +319,11 @@ physics.producers.fmatchSCE.PandoraProducer: "pandoraSCE"
 physics.producers.fmatchSCE.TrackProducer: "pandoraSCETrack"
 physics.producers.fmatchSCE.CaloProducer: "pandoraSCECalo"
 physics.producers.fmatchSCE.SpacePointProducer: "pandoraSCE"
+
+physics.producers.crthitt0SCE.TpcTrackModuleLabel: "pandoraSCETrack"
+physics.producers.crthitt0SCE.T0Alg.TPCTrackLabel: "pandoraSCETrack"
+physics.producers.crttrackt0SCE.TpcTrackModuleLabel: "pandoraSCETrack"
+physics.producers.crttrackt0SCE.CrtTrackAlg.TPCTrackLabel: "pandoraSCETrack"
 
 #physics.producers.trackkalmanhit.HitModuleLabel:   "gaushit"
 #physics.producers.trackkalmanhit.ClusterModuleLabel:   "fuzzycluster"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -17,6 +17,7 @@
 #include "showerselectionvarsproducer.fcl"
 #include "showercosmicdistanceproducer.fcl"
 #include "sbn_pid.fcl"
+#include "crumbs_producer.fcl"
 
 #include "crthitconverter_producer.fcl"
 #include "crtmatch_producer.fcl"
@@ -86,6 +87,8 @@ physics:
 
    vertexCharge: @local::vertex_charge_sbnd
    vertexStub: @local::vertex_stub_sbnd
+   crumbs: @local::crumbs_sbnd
+
    pandoraTrackClosestApproach:          @local::trackscatterclosestapproach_sbn
    pandoraTrackStoppingChi2: @local::trackstoppingchi2fitter_sbn
    pandoraTrackDazzle:       @local::dazzle_sbnd
@@ -104,7 +107,7 @@ physics:
  runprod: [ pandoraTrackMCS, pandoraTrackRange, pandoraShowerSelectionVars,
             pandoraTrackCRTHit, pandoraTrackCRTTrack, vertexCharge, vertexStub,
             pandoraTrackClosestApproach, pandoraTrackStoppingChi2, pandoraTrackDazzle,
-            pandoraShowerCosmicDist, pandoraShowerRazzle,
+            pandoraShowerCosmicDist, pandoraShowerRazzle, crumbs,
             cafmaker ]
 # makecaf: [cafmaker] #list the modules for this path, order matters, filters reject all following items
 # stream1: [metadata]

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -17,7 +17,7 @@
 #include "showerselectionvarsproducer.fcl"
 #include "showercosmicdistanceproducer.fcl"
 #include "sbn_pid.fcl"
-#include "crumbs_producer.fcl"
+#include "sbn_crumbs_producer.fcl"
 
 #include "crthitconverter_producer.fcl"
 #include "crtmatch_producer.fcl"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -44,11 +44,20 @@ physics.producers.pandoraTrackDazzle.Chi2Label: "pandoraSCEPid"
 
 physics.producers.fmatchSCE: @local::transfer_flashmatch_sce_sbnd
 
+physics.producers.crumbs.PFParticleModuleLabel:  "pandoraSCE"
+physics.producers.crumbs.TrackModuleLabel: 	 "pandoraSCETrack"
+physics.producers.crumbs.SliceModuleLabel:	 "pandoraSCE"
+physics.producers.crumbs.FlashMatchModuleLabel:  "fmatchSCE"
+physics.producers.crumbs.CalorimetryModuleLabel: "pandoraSCECalo"
+
+physics.producers.crumbs.Chi2FitParams.TrackLabel: "pandoraSCETrack"
+physics.producers.crumbs.Chi2FitParams.CaloLabel:  "pandoraSCECalo"
+
 physics.runprod: [ pandoraTrackMCS, pandoraTrackRange,
             pandoraTrackCRTHit, pandoraTrackCRTTrack,
             pandoraSCETrackCRTHit, pandoraSCETrackCRTTrack, fmatchSCE, vertexCharge, vertexStub,
             pandoraTrackClosestApproach, pandoraTrackStoppingChi2, pandoraTrackDazzle,
-            pandoraShowerSelectionVars,pandoraShowerCosmicDist, pandoraShowerRazzle,
+            pandoraShowerSelectionVars,pandoraShowerCosmicDist, pandoraShowerRazzle, crumbs,
             cafmaker ]
 
 # Enable the Space-Charge service

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -44,11 +44,13 @@ physics.producers.pandoraTrackDazzle.Chi2Label: "pandoraSCEPid"
 
 physics.producers.fmatchSCE: @local::transfer_flashmatch_sce_sbnd
 
-physics.producers.crumbs.PFParticleModuleLabel:  "pandoraSCE"
-physics.producers.crumbs.TrackModuleLabel: 	 "pandoraSCETrack"
-physics.producers.crumbs.SliceModuleLabel:	 "pandoraSCE"
-physics.producers.crumbs.FlashMatchModuleLabel:  "fmatchSCE"
-physics.producers.crumbs.CalorimetryModuleLabel: "pandoraSCECalo"
+physics.producers.crumbs.PFParticleModuleLabel:    "pandoraSCE"
+physics.producers.crumbs.TrackModuleLabel: 	   "pandoraSCETrack"
+physics.producers.crumbs.SliceModuleLabel:	   "pandoraSCE"
+physics.producers.crumbs.FlashMatchModuleLabel:    "fmatchSCE"
+physics.producers.crumbs.CalorimetryModuleLabel:   "pandoraSCECalo"
+physics.producers.crumbs.CRTHitMatchModuleLabel:   "crthitt0SCE"
+physics.producers.crumbs.CRTTrackMatchModuleLabel: "crttrackt0SCE"
 
 physics.producers.crumbs.Chi2FitParams.TrackLabel: "pandoraSCETrack"
 physics.producers.crumbs.Chi2FitParams.CaloLabel:  "pandoraSCECalo"

--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
@@ -13,7 +13,7 @@
 process_name: Reco2
 
 physics.reco2_sce: [@sequence::physics.reco2, #opt0finder,
-            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, fmatchSCE]#, opt0finderSCE]
+            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, crthitt0SCE, crttrackt0SCE, fmatchSCE]#, opt0finderSCE]
 
 physics.trigger_paths: [ reco2_sce ]
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,7 @@ fwdir   product_dir scripts
 
 product          version
 sbncode          v09_37_01_03
-sbnd_data        v01_10_00 - optional
+sbnd_data        v01_12_00 - optional
 sbndutil         v09_37_01_01 - optional
 
 # list products required ONLY for the build


### PR DESCRIPTION
The functionality in sbndcode to run the new CRUMBS tool which lives in sbncode.

- CRUMBS is added as a producer to the standard and standard+sce caf workflows
- SCE versions of the crt hit and track matching are added as they are needed as inputs
- sbndcode is pointed to a new version of sbnd_data (v1_12_00) containing the weights file for CRUMBS's BDT

Note this PR assumed that #255 and #256 had already been merged into `release/SBN2021C`. Once this occurs then these extra commits should be removed from the diff.

Links to main PR SBNSoftware/sbncode#250