### PR TITLE
Set RootOutput parameter saveMemoryObjectThreshold=0.

### DIFF
--- a/sbndcode/JobConfigurations/base/prodcosmics_corsika_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodcosmics_corsika_sbnd.fcl
@@ -112,6 +112,7 @@ outputs:
     fileName:         "prodcosmics_corsika_sbnd_%p-%tc.root"
     dataTier:         "generated"
     compressionLevel:  1
+    saveMemoryObjectThreshold: 0
   }
 } # outputs
 

--- a/sbndcode/JobConfigurations/base/prodgenie_common_cosmic_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_common_cosmic_sbnd.fcl
@@ -106,6 +106,7 @@ outputs:
     fileName:    "prodgenie_common_cosmic_sbnd_%p-%tc.root" # default file name, can override from command line with -o or --output
     dataTier:    "generated"
     compressionLevel: 1
+    saveMemoryObjectThreshold: 0
   }
 } # outputs
 

--- a/sbndcode/JobConfigurations/base/prodgenie_rockbox_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_rockbox_sbnd.fcl
@@ -110,5 +110,6 @@ outputs:
     fileName:    "prodgenie_sbnd_%p-%tc.root" # default file name, can override from command line with -o or --output
     dataTier:    "generated"
     SelectEvents: [ simulatetpc, simulatedirt ]
+    saveMemoryObjectThreshold: 0
   }
 }

--- a/sbndcode/JobConfigurations/base/prodgenie_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodgenie_sbnd.fcl
@@ -85,6 +85,7 @@ outputs:
     module_type: RootOutput
     fileName:    "prodgenie_sbnd_%p-%tc.root" # default file name, can override from command line with -o or --output
     dataTier:    "generated"
+    saveMemoryObjectThreshold: 0
   }
 }
 

--- a/sbndcode/LArSoftConfigurations/rootoutput_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/rootoutput_sbnd.fcl
@@ -47,6 +47,7 @@ sbnd_rootoutput: {
   
   fileName:         "%ifb_%p-%tc.root"
   compressionLevel:  1  # minimum compression, but some
+  saveMemoryObjectThreshold: 0
   
 } # sbnd_rootoutput
 


### PR DESCRIPTION
Set RootOutput fcl parameter saveMemoryObjectThreshold=0 in several standard fcl files.