### PR TITLE
XArapucas Gauss filter+tunned hitfinder+amplitude variations

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
@@ -55,5 +55,26 @@ SBNDDecoOpHitFinderXArapuca:               @local::SBNDDecoOpHitFinderPMT
 SBNDDecoOpHitFinderXArapuca.InputModule:   "opdecoxarapuca"
 SBNDDecoOpHitFinderXArapuca.Electronics:   "Daphne"
 SBNDDecoOpHitFinderXArapuca.PD:            ["xarapuca_vis","xarapuca_vuv"]
+SBNDDecoOpHitFinderXArapuca.SPEArea: 500
+
+#HitAlgoPset
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.ADCThreshold: 8
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.NSigmaThreshold: 3
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.EndADCThreshold: 8
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.EndNSigmaThreshold: 0.2
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.MinPulseWidth: 1
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.Name: "SlidingWindow"
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.NumPreSample:  3
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.NumPostSample: 6
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.PositivePolarity: true
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.TailADCThreshold: 2
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.TailNSigmaThreshold: 2
+SBNDDecoOpHitFinderXArapuca.HitAlgoPset.Verbosity: false
+
+#BaselinePset
+SBNDDecoOpHitFinderXArapuca.PedAlgoPset.Name:"Edges"
+SBNDDecoOpHitFinderXArapuca.PedAlgoPset.NumSampleFront:50
+SBNDDecoOpHitFinderXArapuca.PedAlgoPset.NumSampleTail:500
+SBNDDecoOpHitFinderXArapuca.PedAlgoPset.Method:0
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/opdeconvolution_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/opdeconvolution_sbnd.fcl
@@ -21,5 +21,10 @@ SBNDOpDeconvolutionXARAPUCA.PDTypes: ["xarapuca_vuv", "xarapuca_vis"]
 SBNDOpDeconvolutionXARAPUCA.Electronics: ["daphne"]
 SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.OpDetDataFile: "OpDetSim/digi_arapuca_sbnd.root"
 SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.Electronics: "Daphne"
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.UseParamFilter: true
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))" #Gauss filter, remove DC component F(0)=0;
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.FilterParams: [0.002558, 2] #Freq in GHz
+SBNDOpDeconvolutionXARAPUCA.OpDecoAlg.DecoWaveformPrecision: 0.002 #Scale deco waves by factor x500
+
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
@@ -104,7 +104,7 @@ namespace lightana{
             std::cerr << "Length of OpChannel array parameter is 0..." << std::endl;
             throw std::exception();
         }
-        // std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
+        std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
         /*
         if(_pe_baseline_v.size() != duplicate.size()) {
           std::cout << "PEBaseline array length (" << _pe_baseline_v.size()

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
@@ -104,7 +104,7 @@ namespace lightana{
             std::cerr << "Length of OpChannel array parameter is 0..." << std::endl;
             throw std::exception();
         }
-        std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
+        // std::cout << "Number of opch used to construct flashes: " << _index_to_opch_v.size() << std::endl;
         /*
         if(_pe_baseline_v.size() != duplicate.size()) {
           std::cout << "PEBaseline array length (" << _pe_baseline_v.size()

--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.hh
@@ -59,6 +59,8 @@ namespace opdet {
       double DecayTXArapucaVIS;// Decay time of EJ280 in ns
       std::string ArapucaDataFile; //File containing timing structure for arapucas
       bool ArapucaSinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
+      bool MakeAmpFluctuations;  //Add amplitude fluctuations to the simulation
+      double AmpFluctuation; //Model for single pe response, false for ideal, true for test bench meas
 
       detinfo::LArProperties const* larProp = nullptr; ///< LarProperties service provider.
       double frequency; ///< Optical-clock frequency
@@ -91,6 +93,7 @@ namespace opdet {
                                bool is_daphne,
                                double start_time,
                                unsigned n_samples);
+  // double P_truth=0;
 
   private:
 
@@ -136,7 +139,7 @@ namespace opdet {
     void AddSPE(size_t time_bin, std::vector<double>& wave, const std::vector<double>& fWaveformSP, int nphotons); // add single pulse to auxiliary waveform
     void Pulse1PE(std::vector<double>& wave,const double sampling);
     void AddLineNoise(std::vector<double>& wave);
-    void AddDarkNoise(std::vector<double>& wave);
+    void AddDarkNoise(std::vector<double>& wave , std::vector<double>& WaveformSP);
     double FindMinimumTime(sim::SimPhotons const& simphotons);
     double FindMinimumTimeLite(std::map< int, int > const& photonMap);
     void CreateSaturation(std::vector<double>& wave);//Including saturation effects
@@ -242,6 +245,16 @@ namespace opdet {
       fhicl::Atom<double> DaphneFrequency {
         Name("DaphneFrequency"),
         Comment("Sampling Frequency of the XArapucas with Daphne readouts (SBND Light detection system has 2 readout frequencies). Apsaia readouts read the frec value from LArSoft.")
+      };
+
+      fhicl::Atom<bool> makeAmpFluctuations {
+        Name("MakeAmpFluctuations"),
+        Comment("Include amplitude fluctuations to the simulated wvfs. For each PE, roll a rand number(gaussian distributed) with std=AmpFluctuation.")
+      };
+
+      fhicl::Atom<double> ampFluctuation {
+        Name("AmpFluctuation"),
+        Comment("Std of the gaussian fit (from data) to the 1PE distribution. Relative units i.e.: AmpFluctuation=0.1-> Amp(1PE)= 18+-1.8 ADC counts")
       };
 
 

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -22,11 +22,13 @@ sbnd_digiarapuca_alg:
   ArapucaVUVEff:             0.014   #Arapuca VUV efficiency (taking into account 70% mesh transparency 0.02*0.7)
   ArapucaVISEff:             0.0189  #Arapuca VIS efficiency (taking into account 70% mesh transparency 0.027*0.7)
   XArapucaVUVEff:            0.021   #XArapuca VUV efficiency (taking into account 70% mesh transparency 0.03*0.7)
-  XArapucaVISEff:            0.014  #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
+  XArapucaVISEff:            0.014   #XArapuca VIS efficiency (taking into account 70% mesh transparency 0.02*0.7)
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
-  ArapucaSinglePEmodel:      true  # false for ideal response true for response from XTDBoard cold tests
-  DaphneFrequency:           80.0  #in MHz. Frequency of the Daphne Readouts
+  ArapucaSinglePEmodel:      true    # false for ideal response true for response from XTDBoard cold tests
+  DaphneFrequency:           80.0    #in MHz. Frequency of the Daphne Readouts
+  MakeAmpFluctuations:       true
+  AmpFluctuation:            0.099   #STD of the first PE Gaussian
 }
 
 END_PROLOG


### PR DESCRIPTION
2 Updates in this PR:

1. Added a gaussian filter + tuned hitfinder for Daphne XArapucas test SER(with overshoot).
2. Added amplitude fluctuations at detsim level (for each photon, roll a rand number following a gaussian distribution with std = 10% 1PE amplitude (fitted from data, see [docdb 25332](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=25332))
