### PR TITLE
Reduce n-universes for weights in the CI

### DIFF
--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -7,6 +7,18 @@ services.NuRandomService.policy: "perEvent"
 
 physics.producers.cafmaker.CAFFilename: "nucosmics_caf_test_sbndcode_Current.caf.root"
 
-physics.producers.genieweight.genie_sbnd_multisim.number_of_multisims: 5
-physics.producers.genieweight.genie_sbnd_multisim_exclusive.number_of_multisims: 5
-physics.producers.genieweight.genie_ub_multisim.number_of_multisims: 5
+physics.producers.genieweight.multisim.number_of_multisims: 5
+
+physics.producers.fluxweight.horncurrent.number_of_multisims: 5
+physics.producers.fluxweight.expskin.number_of_multisims: 5
+physics.producers.fluxweight.pioninexsec.number_of_multisims: 5
+physics.producers.fluxweight.pionqexsec.number_of_multisims: 5
+physics.producers.fluxweight.piontotxsec.number_of_multisims: 5
+physics.producers.fluxweight.nucleoninexsec.number_of_multisims: 5
+physics.producers.fluxweight.nucleonqexsec.number_of_multisims: 5
+physics.producers.fluxweight.nucleontotxsec.number_of_multisims: 5
+physics.producers.fluxweight.kplus.number_of_multisims: 5
+physics.producers.fluxweight.kminus.number_of_multisims: 5
+physics.producers.fluxweight.kzero.number_of_multisims: 5
+physics.producers.fluxweight.piplus.number_of_multisims: 5
+physics.producers.fluxweight.piminus.number_of_multisims: 5


### PR DESCRIPTION
Since the extra flux weights were added to CAFMaker the nucosmics CAF test has been taking a very long time to complete. As was decided when this test was originally added we opted to reduce the number of universes to 5 for the CI so it tests the functionality without spending a huge amount of time setting up the job.

It would be nice if there was a neater way of doing this but for now this is all that I know of.

Note this will still appear to be a significant increase in elapsed time for the CAF test (some of this time increase is fundamental to setting up the different weights) but should be more like 15mins rather than over an hour as it is currently.