### PR TITLE
Feature/lnguyen cone shape feature bdt

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
@@ -30,7 +30,7 @@
     </CosmicRayTaggingTools>
     <SliceIdTools>
       <tool type = "LArBdtNeutrinoId">
-        <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
+        <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
         <MvaName>NeutrinoId</MvaName>
         <MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
         <MaximumNeutrinos>999</MaximumNeutrinos>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -101,7 +101,7 @@
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     <OutputVertexListName>NeutrinoVertices3D</OutputVertexListName>
     <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
     <RegionMvaName>VertexBDTRegion</RegionMvaName>
     <VertexMvaName>VertexBDTVertex</VertexMvaName>
     <FeatureTools>
@@ -318,9 +318,9 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT1</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo1</MvaNameNoChargeInfo>
     <MinProbabilityCut>0.51</MinProbabilityCut>
     <FeatureTools>
@@ -420,9 +420,9 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
+    <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT2</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo2</MvaNameNoChargeInfo>
     <MinProbabilityCut>0.51</MinProbabilityCut>
     <FeatureTools>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -328,6 +328,7 @@
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
       <tool type = "LArThreeDChargeFeatureTool"/>
+      <tool type = "LArLArConeChargeFeatureTool"/>
     </FeatureTools>
     <FeatureToolsNoChargeInfo>
       <tool type = "LArThreeDLinearFitFeatureTool"/>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -319,9 +319,10 @@
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
     <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
-    <MvaName>PfoCharBDT</MvaName>
+    <MvaName>PfoCharBDT1</MvaName>
     <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
-    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
+    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo1</MvaNameNoChargeInfo>
+    <MinProbabilityCut>0.51</MinProbabilityCut>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>
@@ -420,9 +421,10 @@
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
     <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
-    <MvaName>PfoCharBDT</MvaName>
+    <MvaName>PfoCharBDT2</MvaName>
     <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
-    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
+    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo2</MvaNameNoChargeInfo>
+    <MinProbabilityCut>0.51</MinProbabilityCut>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -329,7 +329,7 @@
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
       <tool type = "LArThreeDChargeFeatureTool"/>
-      <tool type = "LArLArConeChargeFeatureTool"/>
+      <tool type = "LArConeChargeFeatureTool"/>  
     </FeatureTools>
     <FeatureToolsNoChargeInfo>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
@@ -431,7 +431,7 @@
       <tool type = "LArThreeDPCAFeatureTool"/>
       <tool type = "LArThreeDOpeningAngleFeatureTool"/>
       <tool type = "LArThreeDChargeFeatureTool"/>
-      <tool type = "LArLArConeChargeFeatureTool"/>
+      <tool type = "LArConeChargeFeatureTool"/>
     </FeatureTools>
     <FeatureToolsNoChargeInfo>
       <tool type = "LArThreeDLinearFitFeatureTool"/>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -393,30 +393,6 @@
     </MopUpAlgorithms>
   </algorithm>
 
-  <!-- Re-run the PFO Characterisation to recalculate the scores after recursive mop up -->
-  <algorithm type = "LArBdtPfoCharacterisation">
-    <TrackPfoListName>TrackParticles3D</TrackPfoListName>
-    <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
-    <UseThreeDInformation>true</UseThreeDInformation>
-    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
-    <MvaName>PfoCharBDT</MvaName>
-    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
-    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
-    <FeatureTools>
-      <tool type = "LArThreeDLinearFitFeatureTool"/>
-      <tool type = "LArThreeDVertexDistanceFeatureTool"/>
-      <tool type = "LArThreeDPCAFeatureTool"/>
-      <tool type = "LArThreeDOpeningAngleFeatureTool"/>
-      <tool type = "LArThreeDChargeFeatureTool"/>
-    </FeatureTools>
-    <FeatureToolsNoChargeInfo>
-      <tool type = "LArThreeDLinearFitFeatureTool"/>
-      <tool type = "LArThreeDVertexDistanceFeatureTool"/>
-      <tool type = "LArThreeDPCAFeatureTool"/>
-      <tool type = "LArThreeDOpeningAngleFeatureTool"/>
-    </FeatureToolsNoChargeInfo>
-  </algorithm>
-
   <!-- NeutrinoAlgorithms -->
   <algorithm type = "LArNeutrinoCreation">
     <InputVertexListName>NeutrinoVertices3D</InputVertexListName>
@@ -435,6 +411,31 @@
   <algorithm type = "LArNeutrinoDaughterVertices">
     <NeutrinoPfoListName>NeutrinoParticles3D</NeutrinoPfoListName>
     <OutputVertexListName>DaughterVertices3D</OutputVertexListName>
+  </algorithm>
+
+  <!-- Re-run the PFO Characterisation to recalculate the scores after recursive mop up -->
+  <algorithm type = "LArBdtPfoCharacterisation">
+    <TrackPfoListName>TrackParticles3D</TrackPfoListName>
+    <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
+    <UseThreeDInformation>true</UseThreeDInformation>
+    <MvaFileName>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileName>
+    <MvaName>PfoCharBDT</MvaName>
+    <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml</MvaFileNameNoChargeInfo>
+    <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo</MvaNameNoChargeInfo>
+    <FeatureTools>
+      <tool type = "LArThreeDLinearFitFeatureTool"/>
+      <tool type = "LArThreeDVertexDistanceFeatureTool"/>
+      <tool type = "LArThreeDPCAFeatureTool"/>
+      <tool type = "LArThreeDOpeningAngleFeatureTool"/>
+      <tool type = "LArThreeDChargeFeatureTool"/>
+      <tool type = "LArLArConeChargeFeatureTool"/>
+    </FeatureTools>
+    <FeatureToolsNoChargeInfo>
+      <tool type = "LArThreeDLinearFitFeatureTool"/>
+      <tool type = "LArThreeDVertexDistanceFeatureTool"/>
+      <tool type = "LArThreeDPCAFeatureTool"/>
+      <tool type = "LArThreeDOpeningAngleFeatureTool"/>
+    </FeatureToolsNoChargeInfo>
   </algorithm>
 
   <algorithm type = "LArShowerHierarchyMopUp">

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,7 @@ fwdir   product_dir scripts
 
 product          version
 sbncode          v09_48_01
-sbnd_data        v01_12_00 - optional
+sbnd_data        v01_13_00 - optional
 sbndutil         v09_48_01 - optional
 
 # list products required ONLY for the build


### PR DESCRIPTION
Add a new cone shape feature for PFO Characterisation in PandoraNu. This PR is dependent on LArContent PR 191 (https://github.com/PandoraPFA/LArContent/pull/191)
The document is available at: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=25950

The changes include:
- Enable Cone Charge Feature Tools to run at PfoCharBDT1&2
- Rename PfoCharBDT appropriately since now there are two trees at stage 1 and 2
- Set <MinProbabilityCut>0.51</MinProbabilityCut> to match the cut value of each BDT.
- Neutrino Algorithms are moved from after to before the PfoCharBDT2.

TO DO:
-update the `/cvmfs/sbnd.opensciencegrid.org/products/sbnd/sbnd_data/v01_11_00/PandoraMVAs/PandoraBdt_v09_32_00_SBND.xml` to include the two new PfoCharBDT1&2 --> DONE
-point the xml to the updated xml, if the name of the xml changes? -->DONE