### PR TITLE
Updated CRT Simulation

### DIFF
--- a/sbndcode/CRT/CMakeLists.txt
+++ b/sbndcode/CRT/CMakeLists.txt
@@ -5,6 +5,7 @@ include_directories( $ENV{IFDHX_FQ_DIR}/inc )
 add_subdirectory(CRTTools)
 add_subdirectory(CRTUtils)
 add_subdirectory(CRTAna)
+add_subdirectory(CRTSimulation)
 add_subdirectory(Examples)
 
 art_make( 
@@ -67,13 +68,14 @@ simple_plugin( CRTGeometryHelper service
 simple_plugin( CRTDetSim module
         larcorealg_Geometry
         sbndcode_CRT
+        sbndcode_CRT_CRTSimulation
         sbndcode_CRTData
         sbnobj_SBND_CRT
         sbnobj_Common_CRT
         art::Framework_Core
         art::Framework_IO_Sources
         art::Framework_Principal
-	art::Persistency_Provenance
+        art::Persistency_Provenance
         canvas::canvas
         cetlib_except::cetlib_except
         lardata_DetectorInfoServices_DetectorClocksServiceStandard_service

--- a/sbndcode/CRT/CMakeLists.txt
+++ b/sbndcode/CRT/CMakeLists.txt
@@ -13,6 +13,7 @@ art_make(
         CRTChannelMapAlg.cxx
         CRTGeometryHelper_service.cc
         CRTDetSim_module.cc
+        CRTSlimmer_module.cc
         CRTSimHitProducer_module.cc
         CRTTzeroProducer_module.cc
         CRTTrackProducer_module.cc
@@ -83,7 +84,31 @@ simple_plugin( CRTDetSim module
         art::Framework_Services_Registry
         art::Framework_Services_Optional_RandomNumberGenerator_service
         messagefacility::MF_MessageLogger
-        
+
+        ${ROOT_BASIC_LIB_LIST}
+        CLHEP::CLHEP
+        cetlib::cetlib
+)
+
+simple_plugin( CRTSlimmer module
+        larcorealg_Geometry
+        sbndcode_CRT
+        sbndcode_CRT_CRTSimulation
+        sbndcode_CRTData
+        sbnobj_SBND_CRT
+        sbnobj_Common_CRT
+        art::Framework_Core
+        art::Framework_IO_Sources
+        art::Framework_Principal
+        art::Persistency_Provenance
+        canvas::canvas
+        cetlib_except::cetlib_except
+        lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
+        nurandom::RandomUtils_NuRandomService_service
+        art::Framework_Services_Registry
+        art::Framework_Services_Optional_RandomNumberGenerator_service
+        messagefacility::MF_MessageLogger
+
         ${ROOT_BASIC_LIB_LIST}
         CLHEP::CLHEP
         cetlib::cetlib

--- a/sbndcode/CRT/CRTAna/crtanamodules_sbnd.fcl
+++ b/sbndcode/CRT/CRTAna/crtanamodules_sbnd.fcl
@@ -16,9 +16,9 @@ sbnd_crtdetsimana:
       SimModuleLabel:       "largeant"    # Simulation producer module label
       CRTSimLabel:          "crt"         # CRT producer module label
       Verbose:              false         # Print extra information about what's going on
-      QPed:                 @local::sbnd_crtsim.QPed
-      QSlope:               @local::sbnd_crtsim.QSlope
-      ClockSpeedCRT:        @local::sbnd_crtsim.ClockSpeedCRT
+      QPed:                 @local::sbnd_crtsim.DetSimParams.QPed
+      QSlope:               @local::sbnd_crtsim.DetSimParams.QSlope
+      ClockSpeedCRT:        @local::sbnd_crtsim.DetSimParams.ClockSpeedCRT
       CrtBackTrack:         @local::standard_crtbacktracker
 }
 

--- a/sbndcode/CRT/CRTDetSim.h
+++ b/sbndcode/CRT/CRTDetSim.h
@@ -14,6 +14,8 @@
 
 #include "lardataalg/DetectorInfo/ElecClock.h"
 
+#include "sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h"
+
 #include <string>
 
 namespace sbnd {
@@ -33,49 +35,9 @@ public:
   std::string fG4ModuleLabel;
 
 private:
-  /**
-   * Get the channel trigger time relative to the start of the MC event.
-   *
-   * @param engine The random number generator engine
-   * @param clock The clock to count ticks on
-   * @param t0 The starting time (which delay is added to)
-   * @param npe Number of observed photoelectrons
-   * @param r Distance between the energy deposit and strip readout end [mm]
-   * @return Trigger clock ticks at this true hit time
-   */
-  uint32_t getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
-                                /*detinfo::ElecClock& clock,*/
-                                float t0, float npeMean, float r);
 
-  double fGlobalT0Offset;  //!< Time delay fit: Gaussian normalization
-  double fTDelayNorm;  //!< Time delay fit: Gaussian normalization
-  double fTDelayShift;  //!< Time delay fit: Gaussian x shift
-  double fTDelaySigma;  //!< Time delay fit: Gaussian width
-  double fTDelayOffset;  //!< Time delay fit: Gaussian baseline offset
-  double fTDelayRMSGausNorm;  //!< Time delay RMS fit: Gaussian normalization
-  double fTDelayRMSGausShift;  //!< Time delay RMS fit: Gaussian x shift
-  double fTDelayRMSGausSigma;  //!< Time delay RMS fit: Gaussian width
-  double fTDelayRMSExpNorm;  //!< Time delay RMS fit: Exponential normalization
-  double fTDelayRMSExpShift;  //!< Time delay RMS fit: Exponential x shift
-  double fTDelayRMSExpScale;  //!< Time delay RMS fit: Exponential scale
-  double fClockSpeedCRT; //!< Clock speed for the CRT system [MHz]
-  double fNpeScaleNorm;  //!< Npe vs. distance: 1/r^2 scale
-  double fNpeScaleShift;  //!< Npe vs. distance: 1/r^2 x shift
-  double fQ0;  //!< Average energy deposited for mips, for charge scaling [GeV]
-  double fQPed;  //!< ADC offset for the single-peak peak mean [ADC]
-  double fQSlope;  //!< Slope in mean ADC / Npe [ADC]
-  double fQRMS;  //!< ADC single-pe spectrum width [ADC]
-  double fQThreshold;  //!< ADC charge threshold [ADC]
-  double fTResInterpolator;  //!< Interpolator time resolution [ns]
-  double fPropDelay;  //!< Delay in pulse arrival time [ns/m]
-  double fPropDelayError;  //!< Delay in pulse arrival time, uncertainty [ns/m]
-  double fStripCoincidenceWindow;  //!< Time window for two-fiber coincidence [ns]
-  double fTaggerPlaneCoincidenceWindow;  //!< Time window for two-plane coincidence [ticks]
-  double fAbsLenEff;  //!< Effective abs. length for transverse Npe scaling [cm]
-  bool fUseEdep;  //!< Use the true G4 energy deposited, assume mip if false.
-  double fSipmTimeResponse; //!< Minimum time to resolve separate energy deposits [ns]
-  uint32_t fAdcSaturation; //!< Saturation limit per SiPM in ADC counts
   CLHEP::HepRandomEngine& fEngine; //!< Reference to art-managed random-number engine
+  CRTDetSimAlg fDetAlg; //!< Instance of the CRT detector simulation algorithm
 };
 
 }  // namespace crt

--- a/sbndcode/CRT/CRTDetSim.h
+++ b/sbndcode/CRT/CRTDetSim.h
@@ -1,4 +1,11 @@
-///////////////////////////////////////////////////////////////////////////////
+/**
+ * \brief LArSoft plugin for SBND CRT detector simulation parameters
+ *
+ * \author Andy Mastbaum
+ * \author Marco Del Tutto
+ */
+
+ ///////////////////////////////////////////////////////////////////////////////
 /// Class: CRTDetSim
 /// Module Type: producer
 /// File: CRTDetSim_module.cc
@@ -37,7 +44,7 @@ public:
 private:
 
   CLHEP::HepRandomEngine& fEngine; //!< Reference to art-managed random-number engine
-  double fG4RefTime;
+  double fG4RefTime; //!< Stores the G4 reference time
   CRTDetSimAlg fDetAlg; //!< Instance of the CRT detector simulation algorithm
 };
 

--- a/sbndcode/CRT/CRTDetSim.h
+++ b/sbndcode/CRT/CRTDetSim.h
@@ -37,6 +37,7 @@ public:
 private:
 
   CLHEP::HepRandomEngine& fEngine; //!< Reference to art-managed random-number engine
+  double fG4RefTime;
   CRTDetSimAlg fDetAlg; //!< Instance of the CRT detector simulation algorithm
 };
 

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -95,8 +95,10 @@ void CRTDetSim::produce(art::Event & e) {
       continue;
     }
 
-    if(adsc.AuxDetIDEs().size()>0) {
+    if(adsc.AuxDetIDEs().size() > 0) {
+      std::cout << "Adding AuxDetSimChannel with AuxDetID " << adsc.AuxDetID() << ", AuxDetSensitiveID " << adsc.AuxDetSensitiveID() << std::endl;
       fDetAlg.FillTaggers(adsc.AuxDetID(), adsc.AuxDetSensitiveID(), adsc.AuxDetIDEs());
+      std::cout << std::endl;
     }
 
   } // loop over AuxDetSimChannels
@@ -108,17 +110,17 @@ void CRTDetSim::produce(art::Event & e) {
 
   std::vector<std::pair<sbnd::crt::CRTData, std::vector<sim::AuxDetIDE>>> data = fDetAlg.CreateData();
 
-  for(auto const& dataPair : data){
+  // for(auto const& dataPair : data){
 
-    triggeredCRTHits->push_back(dataPair.first);
-    art::Ptr<CRTData> dataPtr = makeDataPtr(triggeredCRTHits->size()-1);
+  //   triggeredCRTHits->push_back(dataPair.first);
+  //   art::Ptr<CRTData> dataPtr = makeDataPtr(triggeredCRTHits->size()-1);
 
-    for(auto const& ide : dataPair.second){
-      auxDetIdes->push_back(ide);
-      art::Ptr<sim::AuxDetIDE> idePtr = makeIdePtr(auxDetIdes->size()-1);
-      Dataassn->addSingle(dataPtr, idePtr);
-    }
-  }
+  //   for(auto const& ide : dataPair.second){
+  //     auxDetIdes->push_back(ide);
+  //     art::Ptr<sim::AuxDetIDE> idePtr = makeIdePtr(auxDetIdes->size()-1);
+  //     Dataassn->addSingle(dataPtr, idePtr);
+  //   }
+  // }
 
 
   mf::LogInfo("CRT") << "CRT TRIGGERED HITS: " << triggeredCRTHits->size() << "\n";

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -81,6 +81,8 @@ void CRTDetSim::produce(art::Event & e) {
     mf::LogWarning("CRTDetSim") << "No AuxDetSimChannel..." << std::endl;
   }
 
+  fDetAlg.ClearTaggers();
+
 
   //
   // Step 1: Construct Taggers

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -115,9 +115,9 @@ void CRTDetSim::produce(art::Event & e) {
     }
 
     if(adsc.AuxDetIDEs().size() > 0) {
-      std::cout << "Adding AuxDetSimChannel with AuxDetID " << adsc.AuxDetID() << ", AuxDetSensitiveID " << adsc.AuxDetSensitiveID() << std::endl;
+      mf::LogDebug("CRTDetSim") << "Adding AuxDetSimChannel with AuxDetID " << adsc.AuxDetID()
+                                << ", AuxDetSensitiveID " << adsc.AuxDetSensitiveID() << std::endl;
       fDetAlg.FillTaggers(adsc.AuxDetID(), adsc.AuxDetSensitiveID(), adsc.AuxDetIDEs());
-      std::cout << std::endl;
     }
 
   } // loop over AuxDetSimChannels

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -45,41 +45,13 @@ namespace crt {
 
 void CRTDetSim::reconfigure(fhicl::ParameterSet const & p) {
   fG4ModuleLabel = p.get<std::string>("G4ModuleLabel");
-
-  fGlobalT0Offset = p.get<double>("GlobalT0Offset");
-  fTDelayNorm = p.get<double>("TDelayNorm");
-  fTDelayShift = p.get<double>("TDelayShift");
-  fTDelaySigma = p.get<double>("TDelaySigma");
-  fTDelayOffset = p.get<double>("TDelayOffset");
-  fTDelayRMSGausNorm = p.get<double>("TDelayRMSGausNorm");
-  fTDelayRMSGausShift = p.get<double>("TDelayRMSGausShift");
-  fTDelayRMSGausSigma = p.get<double>("TDelayRMSGausSigma");
-  fTDelayRMSExpNorm = p.get<double>("TDelayRMSExpNorm");
-  fTDelayRMSExpShift = p.get<double>("TDelayRMSExpShift");
-  fTDelayRMSExpScale = p.get<double>("TDelayRMSExpScale");
-  fClockSpeedCRT = p.get<double>("ClockSpeedCRT");
-  fPropDelay = p.get<double>("PropDelay");
-  fPropDelayError = p.get<double>("fPropDelayError");
-  fTResInterpolator = p.get<double>("TResInterpolator");
-  fNpeScaleNorm = p.get<double>("NpeScaleNorm");
-  fNpeScaleShift = p.get<double>("NpeScaleShift");
-  fUseEdep = p.get<bool>("UseEdep");
-  fQ0 = p.get<double>("Q0");
-  fQPed = p.get<double>("QPed");
-  fQSlope = p.get<double>("QSlope");
-  fQRMS = p.get<double>("QRMS");
-  fQThreshold = p.get<double>("QThreshold");
-  fStripCoincidenceWindow = p.get<double>("StripCoincidenceWindow");
-  fTaggerPlaneCoincidenceWindow = p.get<double>("TaggerPlaneCoincidenceWindow");
-  fAbsLenEff = p.get<double>("AbsLenEff");
-  fSipmTimeResponse = p.get<double>("SipmTimeResponse");
-  fAdcSaturation = p.get<uint32_t>("AdcSaturation");
 }
 
 
 CRTDetSim::CRTDetSim(fhicl::ParameterSet const & p)
   : EDProducer{p}
   , fEngine(art::ServiceHandle<rndm::NuRandomService>{}->createEngine(*this, "HepJamesRandom", "crt", p, "Seed"))
+  , fDetAlg(p.get<fhicl::ParameterSet>("DetSimParams"), fEngine)
 {
   this->reconfigure(p);
 
@@ -89,317 +61,63 @@ CRTDetSim::CRTDetSim(fhicl::ParameterSet const & p)
 }
 
 
-uint32_t CRTDetSim::getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
-                                         /*detinfo::ElecClock& clock,*/
-                                         float t0, float npeMean, float r) {
-  // Hit timing, with smearing and NPE dependence
-  double tDelayMean =
-    fTDelayNorm *
-      exp(-0.5 * pow((npeMean - fTDelayShift) / fTDelaySigma, 2)) +
-    fTDelayOffset;
-
-  double tDelayRMS =
-    fTDelayRMSGausNorm *
-      exp(-pow(npeMean - fTDelayRMSGausShift, 2) / fTDelayRMSGausSigma) +
-    fTDelayRMSExpNorm *
-      exp(-(npeMean - fTDelayRMSExpShift) / fTDelayRMSExpScale);
-
-  double tDelay = CLHEP::RandGauss::shoot(engine, tDelayMean, tDelayRMS);
-
-  // Time resolution of the interpolator
-  tDelay += CLHEP::RandGauss::shoot(engine, 0, fTResInterpolator);
-
-  // Propagation time
-  double tProp = CLHEP::RandGauss::shoot(fPropDelay, fPropDelayError) * r;
-
-  double t = t0 + tProp + tDelay;
-
-  // Get clock ticks
-  // FIXME no clock available for CRTs, have to do it by hand
-  //clock.SetTime(t / 1e3);  // SetTime takes microseconds
-  int time = (t / 1e3) * fClockSpeedCRT;
-
-  mf::LogInfo("CRT")
-    << "CRT TIMING: t0=" << t0
-    << ", tDelayMean=" << tDelayMean << ", tDelayRMS=" << tDelayRMS
-    << ", tDelay=" << tDelay << ", tDelay(interp)="
-    << tDelay << ", tProp=" << tProp << ", t=" << t << /*", ticks=" << clock.Ticks() <<*/ "\n";
-
-  return time;//clock.Ticks();
-}
-
-
-struct Tagger {
-  std::vector<std::pair<unsigned, uint32_t> > planesHit;
-  std::vector<sbnd::crt::CRTData> data;
-  std::vector<std::vector<sim::AuxDetIDE>> ides;
-};
-
 
 void CRTDetSim::produce(art::Event & e) {
-  // A list of hit taggers, before any coincidence requirement
-  std::map<std::string, Tagger> taggers;
 
-  // Services: Geometry, DetectorClocks, RandomNumberGenerator
-  art::ServiceHandle<geo::Geometry> geoService;
+  std::unique_ptr<std::vector<sbnd::crt::CRTData> > triggeredCRTHits(new std::vector<sbnd::crt::CRTData>);
+  art::PtrMaker<sbnd::crt::CRTData> makeDataPtr(e);
 
-  /*art::ServiceHandle<detinfo::DetectorClocksService> detClocks;
-  detinfo::ElecClock trigClock = detClocks->provider()->TriggerClock();*/
+  std::unique_ptr<std::vector<sim::AuxDetIDE> > auxDetIdes(new std::vector<sim::AuxDetIDE>);
+  art::PtrMaker<sim::AuxDetIDE> makeIdePtr(e);
+
+  std::unique_ptr< art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE> > Dataassn( new art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>);
+
 
   // Handle for (truth) AuxDetSimChannels
   art::Handle<std::vector<sim::AuxDetSimChannel> > channels;
   e.getByLabel(fG4ModuleLabel, channels);
 
-  if (!channels.isValid()) {std::cout << "No Channels!" << std::endl;}
+  if (!channels.isValid()) {
+    mf::LogWarning("CRTDetSim") << "No AuxDetSimChannel..." << std::endl;
+  }
 
-  // Loop through truth AD channels
-  for (auto& adsc : *channels) {
-    if(adsc.AuxDetID() == UINT_MAX) {
+
+  //
+  // Step 1: Construct Taggers
+  //
+  for(auto const& adsc : *channels) {
+
+    if(adsc.AuxDetID() == UINT_MAX || adsc.AuxDetSensitiveID() == UINT_MAX) {
       mf::LogWarning("CRTDetSim") << "AuxDetSimChannel with ID: UINT_MAX\n"
                                   << "skipping channel...";
       continue;
     }
 
-    const geo::AuxDetGeo& adGeo =
-        geoService->AuxDet(adsc.AuxDetID());
-
-    if(adsc.AuxDetSensitiveID() == UINT_MAX) {
-      mf::LogWarning("CRTDetSim") << "AuxDetSimChannel with ID: UINT_MAX\n"
-                                  << "skipping channel...";
-      continue;
+    if(adsc.AuxDetIDEs().size()>0) {
+      fDetAlg.FillTaggers(adsc.AuxDetID(), adsc.AuxDetSensitiveID(), adsc.AuxDetIDEs());
     }
 
-    const geo::AuxDetSensitiveGeo& adsGeo =
-        adGeo.SensitiveVolume(adsc.AuxDetSensitiveID());
+  } // loop over AuxDetSimChannels
 
-    // Return the vector of IDEs
-    std::vector<sim::AuxDetIDE> ides = adsc.AuxDetIDEs();
-    std::sort(ides.begin(), ides.end(),
-              [](const sim::AuxDetIDE & a, const sim::AuxDetIDE & b) -> bool{
-                return ((a.entryT + a.exitT)/2) < ((b.entryT + b.exitT)/2);
-              });
 
-    // std::set<std::string> volNames = { adsGeo.TotalVolume()->GetName() };
-    std::set<std::string> volNames = { adGeo.TotalVolume()->GetName() };
-    std::vector<std::vector<TGeoNode const*> > paths =
-      geoService->FindAllVolumePaths(volNames);
+  //
+  // Step 1: Apply Coincidence, deadtime, etc.
+  //
 
-    std::string path = "";
-    for (size_t inode=0; inode<paths.at(0).size(); inode++) {
-      path += paths.at(0).at(inode)->GetName();
-      if (inode < paths.at(0).size() - 1) {
-        path += "/";
-      }
-    }
+  std::vector<std::pair<sbnd::crt::CRTData, std::vector<sim::AuxDetIDE>>> data = fDetAlg.CreateData();
 
-    TGeoManager* manager = geoService->ROOTGeoManager();
-    manager->cd(path.c_str());
+  for(auto const& dataPair : data){
 
-    // We get the array of strips first, which is the AuxDet,
-    // then from the AuxDet, we get the strip by picking the
-    // daughter with the ID of the AuxDetSensitive, and finally
-    // from the AuxDet, we go up and pick the module and tagger
-    TGeoNode* nodeArray = manager->GetCurrentNode();
-    TGeoNode* nodeStrip = nodeArray->GetDaughter(adsc.AuxDetSensitiveID());
-    TGeoNode* nodeModule = manager->GetMother(1);
-    TGeoNode* nodeTagger = manager->GetMother(2);
+    triggeredCRTHits->push_back(dataPair.first);
+    art::Ptr<CRTData> dataPtr = makeDataPtr(triggeredCRTHits->size()-1);
 
-    // Module position in parent (tagger) frame
-    double origin[3] = {0, 0, 0};
-    double modulePosMother[3];
-    nodeModule->LocalToMaster(origin, modulePosMother);
-
-    // Determine plane ID (1 for z > 0, 0 for z < 0 in local coordinates)
-    unsigned planeID = (modulePosMother[2] > 0);
-
-    // Determine module orientation: which way is the top (readout end)?
-    bool top = (planeID == 1) ? (modulePosMother[1] > 0) : (modulePosMother[0] < 0);
-
-    // Simulate the CRT response for each hit
-    for (size_t ide_i = 0; ide_i < ides.size(); ide_i++) {
-
-      sim::AuxDetIDE ide = ides[ide_i];
-
-      // Finally, what is the distance from the hit (centroid of the entry
-      // and exit points) to the readout end?
-      double x = (ide.entryX + ide.exitX) / 2;
-      double y = (ide.entryY + ide.exitY) / 2;
-      double z = (ide.entryZ + ide.exitZ) / 2;
-      int nides = 1;
-
-      double tTrue = (ide.entryT + ide.exitT) / 2 + fGlobalT0Offset;
-      double tTrueLast = (ide.entryT + ide.exitT) / 2 + fGlobalT0Offset;
-      double eDep = ide.energyDeposited;
-
-      std::vector<sim::AuxDetIDE> trueIdes;
-      trueIdes.push_back(ide);
-
-      //ADD UP HITS AT THE SAME TIME - FIXME 2NS DIFF IS A GUESS -VERY APPROXIMATE
-      if(ide_i < ides.size() - 1){
-        while(ide_i < ides.size() - 1 && std::abs(tTrueLast-((ides[ide_i+1].entryT + ides[ide_i+1].exitT) / 2 + fGlobalT0Offset)) < fSipmTimeResponse){
-          ide_i++;
-          x += (ides[ide_i].entryX + ides[ide_i].exitX) / 2;
-          y += (ides[ide_i].entryY + ides[ide_i].exitY) / 2;
-          z += (ides[ide_i].entryZ + ides[ide_i].exitZ) / 2;
-          eDep += ides[ide_i].energyDeposited;
-          tTrue += (ides[ide_i].entryT + ides[ide_i].exitT) / 2;
-          tTrueLast = (ides[ide_i].entryT + ides[ide_i].exitT) / 2;
-
-          nides++;
-
-          trueIdes.push_back(ides[ide_i]);
-        }
-      }
-
-      x = x/nides;
-      y = y/nides;
-      z = z/nides;
-      tTrue = tTrue/nides;
-
-      double world[3] = {x, y, z};
-      double svHitPosLocal[3];
-      adsGeo.WorldToLocal(world, svHitPosLocal);
-
-      double distToReadout;
-      if (top) {
-        distToReadout = abs( adsGeo.HalfWidth1() - svHitPosLocal[0]);
-      }
-      else {
-        distToReadout = abs(-adsGeo.HalfWidth1() - svHitPosLocal[0]);
-      }
-
-      // The expected number of PE, using a quadratic model for the distance
-      // dependence, and scaling linearly with deposited energy.
-      double qr = fUseEdep ? 1.0 * eDep / fQ0 : 1.0;
-
-      double npeExpected =
-        fNpeScaleNorm / pow(distToReadout - fNpeScaleShift, 2) * qr;
-
-      // Put PE on channels weighted by transverse distance across the strip,
-      // using an exponential model
-      double d0 = abs(-adsGeo.HalfHeight() - svHitPosLocal[1]);  // L
-      double d1 = abs( adsGeo.HalfHeight() - svHitPosLocal[1]);  // R
-      double abs0 = exp(-d0 / fAbsLenEff);
-      double abs1 = exp(-d1 / fAbsLenEff);
-      double npeExp0 = npeExpected * abs0 / (abs0 + abs1);
-      double npeExp1 = npeExpected * abs1 / (abs0 + abs1);
-
-      // Observed PE (Poisson-fluctuated)
-      long npe0 = CLHEP::RandPoisson::shoot(&fEngine, npeExp0);
-      long npe1 = CLHEP::RandPoisson::shoot(&fEngine, npeExp1);
-
-      // Time relative to trigger, accounting for propagation delay and 'walk'
-      // for the fixed-threshold discriminator
-      uint32_t t0 =
-        getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
-      uint32_t t1 =
-        getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
-
-      // Time relative to PPS: Random for now! (FIXME)
-      uint32_t ppsTicks =
-        CLHEP::RandFlat::shootInt(&fEngine, /*trigClock.Frequency()*/ fClockSpeedCRT * 1e6);
-
-      // SiPM and ADC response: Npe to ADC counts
-      uint32_t q0 =
-        CLHEP::RandGauss::shoot(&fEngine, fQPed + fQSlope * npe0, fQRMS * sqrt(npe0));
-      if(q0 > fAdcSaturation) q0 = fAdcSaturation;
-      uint32_t q1 =
-        CLHEP::RandGauss::shoot(&fEngine, fQPed + fQSlope * npe1, fQRMS * sqrt(npe1));
-      if(q1 > fAdcSaturation) q1 = fAdcSaturation;
-
-      // Adjacent channels on a strip are numbered sequentially.
-      //
-      // In the AuxDetChannelMapAlg methods, channels are identified by an
-      // AuxDet name (retrievable given the hit AuxDet ID) which specifies a
-      // module, and a channel number from 0 to 32.
-      uint32_t moduleID = adsc.AuxDetID();
-      uint32_t stripID = adsc.AuxDetSensitiveID();
-      uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
-      uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
-
-      if (moduleID >= 127) {continue;}        //Ignoring MINOS modules for now.
-
-      // Apply ADC threshold and strip-level coincidence (both fibers fire)
-      if (q0 > fQThreshold &&
-          q1 > fQThreshold &&
-          util::absDiff(t0, t1) < fStripCoincidenceWindow) {
-        Tagger& tagger = taggers[nodeTagger->GetName()];
-        tagger.planesHit.push_back({planeID, t0});
-        tagger.data.push_back(sbnd::crt::CRTData(channel0ID, t0, ppsTicks, q0));
-        tagger.ides.push_back(trueIdes);
-        tagger.data.push_back(sbnd::crt::CRTData(channel1ID, t1, ppsTicks, q1));
-        tagger.ides.push_back(trueIdes);
-      }
-
-      double poss[3];
-      adsGeo.LocalToWorld(origin, poss);
-      mf::LogInfo("CRT")
-        << "CRT HIT in " << adsc.AuxDetID() << "/" << adsc.AuxDetSensitiveID() << "\n"
-        << "CRT HIT POS " << x << " " << y << " " << z << "\n"
-        << "CRT STRIP POS " << poss[0] << " " << poss[1] << " " << poss[2] << "\n"
-        << "CRT MODULE POS " << modulePosMother[0] << " "
-                             << modulePosMother[1] << " "
-                             << modulePosMother[2] << " "
-                             << "\n"
-        << "CRT PATH: " << path << "\n"
-        << "CRT level 0 (strip): " << nodeStrip->GetName() << "\n"
-        << "CRT level 1 (array): " << nodeArray->GetName() << "\n"
-        << "CRT level 2 (module): " << nodeModule->GetName() << "\n"
-        << "CRT level 3 (tagger): " << nodeTagger->GetName() << "\n"
-        << "CRT PLANE ID: " << planeID << "\n"
-        << "CRT distToReadout: " << distToReadout << " " << (top ? "top" : "bot") << "\n"
-        << "CRT q0: " << q0 << ", q1: " << q1 << ", t0: " << t0 << ", t1: " << t1 << ", dt: " << util::absDiff(t0,t1) << "\n";
+    for(auto const& ide : dataPair.second){
+      auxDetIdes->push_back(ide);
+      art::Ptr<sim::AuxDetIDE> idePtr = makeIdePtr(auxDetIdes->size()-1);
+      Dataassn->addSingle(dataPtr, idePtr);
     }
   }
 
-  // Apply coincidence trigger requirement
-  std::unique_ptr<std::vector<sbnd::crt::CRTData> > triggeredCRTHits(
-      new std::vector<sbnd::crt::CRTData>);
-  art::PtrMaker<sbnd::crt::CRTData> makeDataPtr(e);
-
-  std::unique_ptr<std::vector<sim::AuxDetIDE> > auxDetIdes(
-      new std::vector<sim::AuxDetIDE>);
-  art::PtrMaker<sim::AuxDetIDE> makeIdePtr(e);
-
-  std::unique_ptr< art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE> > Dataassn( new art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>);
-
-  // Logic: For normal taggers, require at least one hit in each perpendicular
-  // plane. For the bottom tagger, any hit triggers read out.
-  for (auto trg : taggers) {
-    bool trigger = false;
-
-    // Loop over pairs of hits
-    for (auto t1 : trg.second.planesHit) {
-      for (auto t2 : trg.second.planesHit) {
-        if (t1 == t2) {
-          continue;
-        }
-
-        // Two hits on different planes with proximal t0 times
-        if (t1.first != t2.first && util::absDiff(t1.second, t2.second) < fTaggerPlaneCoincidenceWindow) {
-          trigger = true;
-          break;
-        }
-      }
-    }
-
-
-    if (trigger || trg.first.find("TaggerBot") != std::string::npos) {
-      // Write out all hits on a tagger when there is any coincidence FIXME this reads out everything!
-      //for (auto d : trg.second.data) {
-      for (size_t d_i = 0; d_i < trg.second.data.size(); d_i++) {
-        triggeredCRTHits->push_back(trg.second.data[d_i]);
-        art::Ptr<sbnd::crt::CRTData> dataPtr = makeDataPtr(triggeredCRTHits->size()-1);
-        if(trg.second.data.size() == trg.second.ides.size()){
-          for (size_t i_i = 0; i_i < trg.second.ides[d_i].size(); i_i++){
-            auxDetIdes->push_back(trg.second.ides[d_i][i_i]);
-            art::Ptr<sim::AuxDetIDE> idePtr = makeIdePtr(auxDetIdes->size()-1);
-            Dataassn->addSingle(dataPtr, idePtr);
-          }
-        }
-      }
-    }
-  }
 
   mf::LogInfo("CRT") << "CRT TRIGGERED HITS: " << triggeredCRTHits->size() << "\n";
 

--- a/sbndcode/CRT/CRTDetSim_module.cc
+++ b/sbndcode/CRT/CRTDetSim_module.cc
@@ -57,12 +57,6 @@ CRTDetSim::CRTDetSim(fhicl::ParameterSet const & p)
 {
   this->reconfigure(p);
 
-  // auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob();
-  // double g4RefTime = -clockData.G4ToElecTime(0); // us
-  // std::cout << "--- G4ToElecTime(0) " << clockData.G4ToElecTime(0) << std::endl;
-
-  // fDetAlg = CRTDetSimAlg(p.get<fhicl::ParameterSet>("DetSimParams"), fEngine, g4RefTime);
-
   produces<std::vector<sbnd::crt::FEBData> >();
   produces<std::vector<sim::AuxDetIDE> >();
   produces<art::Assns<sbnd::crt::FEBData , sim::AuxDetIDE> >();
@@ -82,15 +76,6 @@ void CRTDetSim::produce(art::Event & e) {
 
   std::unique_ptr<art::Assns<sbnd::crt::FEBData, sim::AuxDetIDE>> Dataassn
     (new art::Assns<sbnd::crt::FEBData, sim::AuxDetIDE>);
-
-  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
-  std::cout << "TriggerOffsetTPC " << clockData.TriggerOffsetTPC() << std::endl;
-  std::cout << "TriggerTime " << clockData.TriggerTime() << std::endl;
-  std::cout << "TPCTime " << clockData.TPCTime() << std::endl;
-  std::cout << "G4ToElecTime(0) " << clockData.G4ToElecTime(0) << std::endl;
-
-  // double g4RefTime = -clockData.G4ToElecTime(0);
-
 
   // Handle for (truth) AuxDetSimChannels
   art::Handle<std::vector<sim::AuxDetSimChannel> > channels;

--- a/sbndcode/CRT/CRTSimHitProducer_module.cc
+++ b/sbndcode/CRT/CRTSimHitProducer_module.cc
@@ -96,6 +96,8 @@ namespace sbnd {
 
     // Params from fcl file.......
     art::InputTag fCrtModuleLabel;      ///< name of crt producer
+
+    double fG4RefTime;
    
     CRTHitRecoAlg hitAlg;
 
@@ -103,7 +105,9 @@ namespace sbnd {
 
 
   CRTSimHitProducer::CRTSimHitProducer(fhicl::ParameterSet const & p)
-  : EDProducer(p), hitAlg(p.get<fhicl::ParameterSet>("HitAlg"))
+  : EDProducer(p)
+  , fG4RefTime(art::ServiceHandle<detinfo::DetectorClocksService const>()->DataForJob().G4ToElecTime(0)) // us
+  , hitAlg(p.get<fhicl::ParameterSet>("HitAlg"), fG4RefTime)
   // Initialize member data here, if know don't want to reconfigure on the fly
   {
 

--- a/sbndcode/CRT/CRTSimulation/CMakeLists.txt
+++ b/sbndcode/CRT/CRTSimulation/CMakeLists.txt
@@ -23,6 +23,7 @@ art_make(   LIB_LIBRARIES  larcorealg_Geometry
                            ROOT::XMLIO
                            ROOT::Gdml
                            ${ROOT_BASIC_LIB_LIST}
+                           ${ROOT_MATHMORE}
 
                            sbndcode_CRT
                            sbnobj_Common_CRT

--- a/sbndcode/CRT/CRTSimulation/CMakeLists.txt
+++ b/sbndcode/CRT/CRTSimulation/CMakeLists.txt
@@ -1,35 +1,18 @@
 art_make(   LIB_LIBRARIES  larcorealg_Geometry
                            larcore_Geometry_Geometry_service
-                           # larsim_Simulation
                            lardataobj_Simulation
                            lardataobj_RawData
                            lardataobj_RecoBase
                            lardata_RecoObjects
                            lardataalg_DetectorInfo
-                           # nusimdata::SimulationBase
                            cetlib::cetlib cetlib_except
-                           # art::Framework_Core
-                           # art::Framework_Principal
-                           # art::Framework_Services_Registry
-                           # art_root_io::tfile_support ROOT::Core
-                           # art_root_io::TFileService_service
-                           # art::Persistency_Common canvas
-                           # art::Persistency_Provenance canvas
-                           # art::Utilities canvas
                            messagefacility::MF_MessageLogger
-
                            fhiclcpp::fhiclcpp
-                           # ROOT::Geom
-                           # ROOT::XMLIO
-                           # ROOT::Gdml
+
                            ${ROOT_BASIC_LIB_LIST}
                            ${ROOT_MATHMORE}
 
-                           # sbndcode_CRT
-                           # sbnobj_Common_CRT
                            sbnobj_SBND_CRT
-                           # sbndcode_GeoWrappers
-                           # sbndcode_RecoUtils
         )
 
 install_headers()

--- a/sbndcode/CRT/CRTSimulation/CMakeLists.txt
+++ b/sbndcode/CRT/CRTSimulation/CMakeLists.txt
@@ -1,35 +1,35 @@
 art_make(   LIB_LIBRARIES  larcorealg_Geometry
                            larcore_Geometry_Geometry_service
-                           larsim_Simulation
+                           # larsim_Simulation
                            lardataobj_Simulation
                            lardataobj_RawData
                            lardataobj_RecoBase
                            lardata_RecoObjects
                            lardataalg_DetectorInfo
-                           nusimdata::SimulationBase
+                           # nusimdata::SimulationBase
                            cetlib::cetlib cetlib_except
-                           art::Framework_Core
-                           art::Framework_Principal
-                           art::Framework_Services_Registry
-                           art_root_io::tfile_support ROOT::Core
-                           art_root_io::TFileService_service
-                           art::Persistency_Common canvas
-                           art::Persistency_Provenance canvas
-                           art::Utilities canvas
+                           # art::Framework_Core
+                           # art::Framework_Principal
+                           # art::Framework_Services_Registry
+                           # art_root_io::tfile_support ROOT::Core
+                           # art_root_io::TFileService_service
+                           # art::Persistency_Common canvas
+                           # art::Persistency_Provenance canvas
+                           # art::Utilities canvas
                            messagefacility::MF_MessageLogger
 
                            fhiclcpp::fhiclcpp
-                           ROOT::Geom
-                           ROOT::XMLIO
-                           ROOT::Gdml
+                           # ROOT::Geom
+                           # ROOT::XMLIO
+                           # ROOT::Gdml
                            ${ROOT_BASIC_LIB_LIST}
                            ${ROOT_MATHMORE}
 
-                           sbndcode_CRT
-                           sbnobj_Common_CRT
+                           # sbndcode_CRT
+                           # sbnobj_Common_CRT
                            sbnobj_SBND_CRT
-                           sbndcode_GeoWrappers
-                           sbndcode_RecoUtils
+                           # sbndcode_GeoWrappers
+                           # sbndcode_RecoUtils
         )
 
 install_headers()

--- a/sbndcode/CRT/CRTSimulation/CMakeLists.txt
+++ b/sbndcode/CRT/CRTSimulation/CMakeLists.txt
@@ -1,0 +1,36 @@
+art_make(   LIB_LIBRARIES  larcorealg_Geometry
+                           larcore_Geometry_Geometry_service
+                           larsim_Simulation
+                           lardataobj_Simulation
+                           lardataobj_RawData
+                           lardataobj_RecoBase
+                           lardata_RecoObjects
+                           lardataalg_DetectorInfo
+                           nusimdata::SimulationBase
+                           cetlib::cetlib cetlib_except
+                           art::Framework_Core
+                           art::Framework_Principal
+                           art::Framework_Services_Registry
+                           art_root_io::tfile_support ROOT::Core
+                           art_root_io::TFileService_service
+                           art::Persistency_Common canvas
+                           art::Persistency_Provenance canvas
+                           art::Utilities canvas
+                           messagefacility::MF_MessageLogger
+
+                           fhiclcpp::fhiclcpp
+                           ROOT::Geom
+                           ROOT::XMLIO
+                           ROOT::Gdml
+                           ${ROOT_BASIC_LIB_LIST}
+
+                           sbndcode_CRT
+                           sbnobj_Common_CRT
+                           sbnobj_SBND_CRT
+                           sbndcode_GeoWrappers
+                           sbndcode_RecoUtils
+        )
+
+install_headers()
+install_fhicl()
+install_source()

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -312,7 +312,7 @@ namespace crt {
 
         } // loop over taggers
 
-        mf::LogInfo("CRTDetSimAlg") "We have " << fData.size() << " FEBData objects." << std::endl;
+        mf::LogInfo("CRTDetSimAlg") << "There are " << fData.size() << " FEBData objects." << std::endl;
 
     }
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -1,0 +1,331 @@
+#ifndef SBND_CRTDETSIMALG_CC
+#define SBND_CRTDETSIMALG_CC
+
+#include "sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h"
+
+namespace sbnd {
+namespace crt {
+
+    CRTDetSimAlg::CRTDetSimAlg(fhicl::ParameterSet const & p, CLHEP::HepRandomEngine& engine) :
+        fEngine(engine)
+    {
+
+        this->reconfigure(p);
+        fTaggers.clear();
+    }
+
+    void CRTDetSimAlg::reconfigure(fhicl::ParameterSet const & p) {
+
+        fGlobalT0Offset = p.get<double>("GlobalT0Offset");
+        fTDelayNorm = p.get<double>("TDelayNorm");
+        fTDelayShift = p.get<double>("TDelayShift");
+        fTDelaySigma = p.get<double>("TDelaySigma");
+        fTDelayOffset = p.get<double>("TDelayOffset");
+        fTDelayRMSGausNorm = p.get<double>("TDelayRMSGausNorm");
+        fTDelayRMSGausShift = p.get<double>("TDelayRMSGausShift");
+        fTDelayRMSGausSigma = p.get<double>("TDelayRMSGausSigma");
+        fTDelayRMSExpNorm = p.get<double>("TDelayRMSExpNorm");
+        fTDelayRMSExpShift = p.get<double>("TDelayRMSExpShift");
+        fTDelayRMSExpScale = p.get<double>("TDelayRMSExpScale");
+        fClockSpeedCRT = p.get<double>("ClockSpeedCRT");
+        fPropDelay = p.get<double>("PropDelay");
+        fPropDelayError = p.get<double>("fPropDelayError");
+        fTResInterpolator = p.get<double>("TResInterpolator");
+        fNpeScaleNorm = p.get<double>("NpeScaleNorm");
+        fNpeScaleShift = p.get<double>("NpeScaleShift");
+        fUseEdep = p.get<bool>("UseEdep");
+        fQ0 = p.get<double>("Q0");
+        fQPed = p.get<double>("QPed");
+        fQSlope = p.get<double>("QSlope");
+        fQRMS = p.get<double>("QRMS");
+        fQThreshold = p.get<double>("QThreshold");
+        fStripCoincidenceWindow = p.get<double>("StripCoincidenceWindow");
+        fTaggerPlaneCoincidenceWindow = p.get<double>("TaggerPlaneCoincidenceWindow");
+        fAbsLenEff = p.get<double>("AbsLenEff");
+        fSipmTimeResponse = p.get<double>("SipmTimeResponse");
+        fAdcSaturation = p.get<uint32_t>("AdcSaturation");
+
+    }
+
+
+    std::vector<std::pair<sbnd::crt::CRTData, std::vector<AuxDetIDE>>>  CRTDetSimAlg::CreateData()
+    {
+
+        std::vector<std::pair<sbnd::crt::CRTData, std::vector<AuxDetIDE>>> dataCol;
+
+        // Logic: For normal taggers, require at least one hit in each perpendicular
+        // plane. For the bottom tagger, any hit triggers read out.
+        for (auto trg : fTaggers) {
+            bool trigger = false;
+
+            // Loop over pairs of hits
+            for (auto t1 : trg.second.planesHit) {
+                for (auto t2 : trg.second.planesHit) {
+                    if (t1 == t2) {
+                        continue;
+                    }
+
+                    // Two hits on different planes with proximal t0 times
+                    if (t1.first != t2.first && util::absDiff(t1.second, t2.second) < fTaggerPlaneCoincidenceWindow) {
+                        trigger = true;
+                        break;
+                    }
+                }
+            }
+
+
+            if (trigger || trg.first.find("TaggerBot") != std::string::npos) {
+                // Write out all hits on a tagger when there is any coincidence FIXME this reads out everything!
+                for (size_t d_i = 0; d_i < trg.second.data.size(); d_i++) {
+
+                    dataCol.push_back(std::make_pair(trg.second.data[d_i], trg.second.ides[d_i]));
+
+                }
+            }
+        }
+
+        return dataCol;
+
+    }
+
+
+    void CRTDetSimAlg::FillTaggers(const uint32_t adid, const uint32_t adsid,
+                                   vector<sim::AuxDetIDE> ides) {
+
+        art::ServiceHandle<geo::Geometry> geoService;
+
+        const geo::AuxDetGeo& adGeo = geoService->AuxDet(adid);
+        const geo::AuxDetSensitiveGeo& adsGeo = adGeo.SensitiveVolume(adsid);
+
+        // Return the vector of IDEs
+        std::sort(ides.begin(), ides.end(),
+                  [](const sim::AuxDetIDE & a, const sim::AuxDetIDE & b) -> bool{
+                    return ((a.entryT + a.exitT)/2) < ((b.entryT + b.exitT)/2);
+                  });
+
+        // std::set<std::string> volNames = { adsGeo.TotalVolume()->GetName() };
+        std::set<std::string> volNames = { adGeo.TotalVolume()->GetName() };
+        std::vector<std::vector<TGeoNode const*> > paths =
+          geoService->FindAllVolumePaths(volNames);
+
+        std::string path = "";
+        for (size_t inode=0; inode<paths.at(0).size(); inode++) {
+          path += paths.at(0).at(inode)->GetName();
+          if (inode < paths.at(0).size() - 1) {
+            path += "/";
+          }
+        }
+
+        TGeoManager* manager = geoService->ROOTGeoManager();
+        manager->cd(path.c_str());
+
+        // We get the array of strips first, which is the AuxDet,
+        // then from the AuxDet, we get the strip by picking the
+        // daughter with the ID of the AuxDetSensitive, and finally
+        // from the AuxDet, we go up and pick the module and tagger
+        TGeoNode* nodeArray = manager->GetCurrentNode();
+        TGeoNode* nodeStrip = nodeArray->GetDaughter(adsid);
+        TGeoNode* nodeModule = manager->GetMother(1);
+        TGeoNode* nodeTagger = manager->GetMother(2);
+
+        // Module position in parent (tagger) frame
+        double origin[3] = {0, 0, 0};
+        double modulePosMother[3];
+        nodeModule->LocalToMaster(origin, modulePosMother);
+
+        // Determine plane ID (1 for z > 0, 0 for z < 0 in local coordinates)
+        unsigned planeID = (modulePosMother[2] > 0);
+
+        // Determine module orientation: which way is the top (readout end)?
+        bool top = (planeID == 1) ? (modulePosMother[1] > 0) : (modulePosMother[0] < 0);
+
+        // Simulate the CRT response for each hit
+        for (size_t ide_i = 0; ide_i < ides.size(); ide_i++) {
+
+          sim::AuxDetIDE ide = ides[ide_i];
+
+          // Finally, what is the distance from the hit (centroid of the entry
+          // and exit points) to the readout end?
+          double x = (ide.entryX + ide.exitX) / 2;
+          double y = (ide.entryY + ide.exitY) / 2;
+          double z = (ide.entryZ + ide.exitZ) / 2;
+          int nides = 1;
+
+          double tTrue = (ide.entryT + ide.exitT) / 2 + fGlobalT0Offset;
+          double tTrueLast = (ide.entryT + ide.exitT) / 2 + fGlobalT0Offset;
+          double eDep = ide.energyDeposited;
+
+          std::vector<sim::AuxDetIDE> trueIdes;
+          trueIdes.push_back(ide);
+
+          //ADD UP HITS AT THE SAME TIME - FIXME 2NS DIFF IS A GUESS -VERY APPROXIMATE
+          if(ide_i < ides.size() - 1){
+            while(ide_i < ides.size() - 1 && std::abs(tTrueLast-((ides[ide_i+1].entryT + ides[ide_i+1].exitT) / 2 + fGlobalT0Offset)) < fSipmTimeResponse){
+              ide_i++;
+              x += (ides[ide_i].entryX + ides[ide_i].exitX) / 2;
+              y += (ides[ide_i].entryY + ides[ide_i].exitY) / 2;
+              z += (ides[ide_i].entryZ + ides[ide_i].exitZ) / 2;
+              eDep += ides[ide_i].energyDeposited;
+              tTrue += (ides[ide_i].entryT + ides[ide_i].exitT) / 2;
+              tTrueLast = (ides[ide_i].entryT + ides[ide_i].exitT) / 2;
+
+              nides++;
+
+              trueIdes.push_back(ides[ide_i]);
+            }
+          }
+
+          x = x/nides;
+          y = y/nides;
+          z = z/nides;
+          tTrue = tTrue/nides;
+
+          double world[3] = {x, y, z};
+          double svHitPosLocal[3];
+          adsGeo.WorldToLocal(world, svHitPosLocal);
+
+          double distToReadout;
+          if (top) {
+            distToReadout = abs( adsGeo.HalfWidth1() - svHitPosLocal[0]);
+          }
+          else {
+            distToReadout = abs(-adsGeo.HalfWidth1() - svHitPosLocal[0]);
+          }
+
+          // The expected number of PE, using a quadratic model for the distance
+          // dependence, and scaling linearly with deposited energy.
+          double qr = fUseEdep ? 1.0 * eDep / fQ0 : 1.0;
+
+          double npeExpected =
+            fNpeScaleNorm / pow(distToReadout - fNpeScaleShift, 2) * qr;
+
+          // Put PE on channels weighted by transverse distance across the strip,
+          // using an exponential model
+          double d0 = abs(-adsGeo.HalfHeight() - svHitPosLocal[1]);  // L
+          double d1 = abs( adsGeo.HalfHeight() - svHitPosLocal[1]);  // R
+          double abs0 = exp(-d0 / fAbsLenEff);
+          double abs1 = exp(-d1 / fAbsLenEff);
+          double npeExp0 = npeExpected * abs0 / (abs0 + abs1);
+          double npeExp1 = npeExpected * abs1 / (abs0 + abs1);
+
+          // Observed PE (Poisson-fluctuated)
+          long npe0 = CLHEP::RandPoisson::shoot(&fEngine, npeExp0);
+          long npe1 = CLHEP::RandPoisson::shoot(&fEngine, npeExp1);
+
+          // Time relative to trigger, accounting for propagation delay and 'walk'
+          // for the fixed-threshold discriminator
+          uint32_t t0 =
+            getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
+          uint32_t t1 =
+            getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
+
+          // Time relative to PPS: Random for now! (FIXME)
+          uint32_t ppsTicks =
+            CLHEP::RandFlat::shootInt(&fEngine, /*trigClock.Frequency()*/ fClockSpeedCRT * 1e6);
+
+          // SiPM and ADC response: Npe to ADC counts
+          uint32_t q0 =
+            CLHEP::RandGauss::shoot(&fEngine, fQPed + fQSlope * npe0, fQRMS * sqrt(npe0));
+          if(q0 > fAdcSaturation) q0 = fAdcSaturation;
+          uint32_t q1 =
+            CLHEP::RandGauss::shoot(&fEngine, fQPed + fQSlope * npe1, fQRMS * sqrt(npe1));
+          if(q1 > fAdcSaturation) q1 = fAdcSaturation;
+
+          // Adjacent channels on a strip are numbered sequentially.
+          //
+          // In the AuxDetChannelMapAlg methods, channels are identified by an
+          // AuxDet name (retrievable given the hit AuxDet ID) which specifies a
+          // module, and a channel number from 0 to 32.
+          uint32_t moduleID = adid;
+          uint32_t stripID = adsid;
+          uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
+          uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
+
+          if (moduleID >= 127) {continue;}        //Ignoring MINOS modules for now.
+
+          // Apply ADC threshold and strip-level coincidence (both fibers fire)
+          if (q0 > fQThreshold &&
+              q1 > fQThreshold &&
+              util::absDiff(t0, t1) < fStripCoincidenceWindow) {
+            Tagger& tagger = fTaggers[nodeTagger->GetName()];
+            tagger.planesHit.push_back({planeID, t0});
+            tagger.data.push_back(sbnd::crt::CRTData(channel0ID, t0, ppsTicks, q0));
+            tagger.ides.push_back(trueIdes);
+            tagger.data.push_back(sbnd::crt::CRTData(channel1ID, t1, ppsTicks, q1));
+            tagger.ides.push_back(trueIdes);
+          }
+
+          double poss[3];
+          adsGeo.LocalToWorld(origin, poss);
+          mf::LogInfo("CRTDetSimAlg")
+            << "CRT HIT in " << adid << "/" << adsid << "\n"
+            << "CRT HIT POS " << x << " " << y << " " << z << "\n"
+            << "CRT STRIP POS " << poss[0] << " " << poss[1] << " " << poss[2] << "\n"
+            << "CRT MODULE POS " << modulePosMother[0] << " "
+                                 << modulePosMother[1] << " "
+                                 << modulePosMother[2] << " "
+                                 << "\n"
+            << "CRT PATH: " << path << "\n"
+            << "CRT level 0 (strip): " << nodeStrip->GetName() << "\n"
+            << "CRT level 1 (array): " << nodeArray->GetName() << "\n"
+            << "CRT level 2 (module): " << nodeModule->GetName() << "\n"
+            << "CRT level 3 (tagger): " << nodeTagger->GetName() << "\n"
+            << "CRT PLANE ID: " << planeID << "\n"
+            << "CRT distToReadout: " << distToReadout << " " << (top ? "top" : "bot") << "\n"
+            << "CRT q0: " << q0 << ", q1: " << q1 << ", t0: " << t0 << ", t1: " << t1 << ", dt: " << util::absDiff(t0,t1) << "\n";
+        }
+
+
+    } //end FillTaggers
+
+
+
+    uint32_t CRTDetSimAlg::getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
+                                             /*detinfo::ElecClock& clock,*/
+                                             float t0, float npeMean, float r) {
+      // Hit timing, with smearing and NPE dependence
+      double tDelayMean =
+        fTDelayNorm *
+          exp(-0.5 * pow((npeMean - fTDelayShift) / fTDelaySigma, 2)) +
+        fTDelayOffset;
+
+      double tDelayRMS =
+        fTDelayRMSGausNorm *
+          exp(-pow(npeMean - fTDelayRMSGausShift, 2) / fTDelayRMSGausSigma) +
+        fTDelayRMSExpNorm *
+          exp(-(npeMean - fTDelayRMSExpShift) / fTDelayRMSExpScale);
+
+      double tDelay = CLHEP::RandGauss::shoot(engine, tDelayMean, tDelayRMS);
+
+      // Time resolution of the interpolator
+      tDelay += CLHEP::RandGauss::shoot(engine, 0, fTResInterpolator);
+
+      // Propagation time
+      double tProp = CLHEP::RandGauss::shoot(fPropDelay, fPropDelayError) * r;
+
+      double t = t0 + tProp + tDelay;
+
+      // Get clock ticks
+      // FIXME no clock available for CRTs, have to do it by hand
+      //clock.SetTime(t / 1e3);  // SetTime takes microseconds
+      int time = (t / 1e3) * fClockSpeedCRT;
+
+      mf::LogInfo("CRT")
+        << "CRT TIMING: t0=" << t0
+        << ", tDelayMean=" << tDelayMean << ", tDelayRMS=" << tDelayRMS
+        << ", tDelay=" << tDelay << ", tDelay(interp)="
+        << tDelay << ", tProp=" << tProp << ", t=" << t << /*", ticks=" << clock.Ticks() <<*/ "\n";
+
+      return time;//clock.Ticks();
+    }
+
+
+    void CRTDetSimAlg::ClearTaggers() {
+
+        fTaggers.clear();
+    }
+
+ }//namespace crt
+}//namespace sbnd
+
+#endif

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -106,7 +106,9 @@ namespace crt {
         feb_data.SetADC(sipmID, new_adc);
 
         std::cout << "Updating ADC value for FEB " << feb_data.Mac5()
-                                     << "sipmID " << sipmID << ": was " << original_adc
+                                     << ", sipmID " << sipmID
+                                     << " with adc " << adc
+                                     << ": was " << original_adc
                                      << ", now is " << feb_data.ADC(sipmID) << std::endl;
 
     }
@@ -179,8 +181,8 @@ namespace crt {
             auto &feb_data = mac_to_febdata[strip.mac5];
             uint32_t trigger_time = feb_data.Ts1();
 
-            std::cout << "sipm 0 time " << strip.sipm0.t1 << ", time diff " << strip.sipm0.t1 - trigger_time << std::endl;
-            std::cout << "sipm 1 time " << strip.sipm1.t1 << ", time diff " << strip.sipm1.t1 - trigger_time << std::endl;
+            std::cout << "sipm 0 channel " << strip.sipm0.channel << ", time " << strip.sipm0.t1 << ", time diff " << strip.sipm0.t1 - trigger_time << std::endl;
+            std::cout << "sipm 1 channel " << strip.sipm1.channel << ", time " << strip.sipm1.t1 << ", time diff " << strip.sipm1.t1 - trigger_time << std::endl;
 
             uint16_t adc_sipm0 = WaveformEmulation(strip.sipm0.t1 - trigger_time, strip.sipm0.adc);
             uint16_t adc_sipm1 = WaveformEmulation(strip.sipm1.t1 - trigger_time, strip.sipm1.adc);
@@ -192,7 +194,7 @@ namespace crt {
             ides.push_back(strip.ide);
 
             std::cout << "adc of sipm " << strip.sipm0.sipmID << " is now " << feb_data.ADC(strip.sipm0.sipmID) << std::endl;
-            std::cout << "adc of sipm " << strip.sipm1.sipmID << " is now " << feb_data.ADC(strip.sipm0.sipmID) << std::endl;
+            std::cout << "adc of sipm " << strip.sipm1.sipmID << " is now " << feb_data.ADC(strip.sipm1.sipmID) << std::endl;
 
         }
 
@@ -277,6 +279,7 @@ namespace crt {
                 {
                     // mf::LogDebug("CRTDetSimAlg") << "Strip happened during dead time." << std::endl;
                     std::cout << "[CreateData]   -> Strip happened during dead time or didn't have SiPMs coincidence. " << std::endl;
+                    if (!strip_data.sipm_coinc) std::cout << "[CreateData]   -> (didn't have SiPMs coincidence.) " << strip_data.sipm0.adc << " " << strip_data.sipm1.adc << std::endl;
                 }
 
             }
@@ -413,12 +416,12 @@ namespace crt {
           mf::LogInfo("CRTDetSimAlg") << "True IDE with time " << tTrue
                                       << ", energy " << eDep << std::endl;
 
-          if (tTrue < 0) {
-            throw art::Exception(art::errors::LogicError)
-                << "Time cannot be negative. Check the time offset used for the CRT simulation.\n"
-                << "True time: " << (ide.entryT + ide.exitT) / 2 << "\n"
-                << "TimeOffset: " << fTimeOffset << std::endl;
-          }
+          // if (tTrue < 0) {
+          //   throw art::Exception(art::errors::LogicError)
+          //       << "Time cannot be negative. Check the time offset used for the CRT simulation.\n"
+          //       << "True time: " << (ide.entryT + ide.exitT) / 2 << "\n"
+          //       << "TimeOffset: " << fTimeOffset << std::endl;
+          // }
 
           double world[3] = {x, y, z};
           double svHitPosLocal[3];

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -66,10 +66,6 @@ namespace crt {
             return static_cast<uint16_t>(adc);
         }
 
-        std::cout << "[WaveformEmulation] time_delay " << time_delay
-                  << ", waveform " << fInterpolator->Eval(time_delay) << std::endl;
-
-
         if (time_delay < 0) {
             throw art::Exception(art::errors::LogicError)
                 << "time_delay cannot be negative." << std::endl;
@@ -88,7 +84,6 @@ namespace crt {
         std::cout << "[WaveformEmulation] time_delay " << time_delay
                   << ", adc " << adc
                   << ", waveform " << wf << std::endl;
-
 
         return static_cast<uint16_t>(wf);
     }
@@ -451,6 +446,11 @@ namespace crt {
             getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
           uint32_t ts1_ch1 =
             getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
+
+          if (fParams.EqualizeSiPMTimes()) {
+            mf::LogWarning("CRTDetSimAlg") << "EqualizeSiPMTimes is on." << std::endl;
+            ts1_ch1 = ts1_ch0;
+          }
 
           // Time relative to PPS: Random for now! (FIXME)
           uint32_t ppsTicks =

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -407,9 +407,9 @@ namespace crt {
             // Time relative to trigger, accounting for propagation delay and 'walk'
             // for the fixed-threshold discriminator
             uint32_t ts1_ch0 =
-              getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
+              getChannelTriggerTicks(/*trigClock,*/ tTrue, npe0, distToReadout);
             uint32_t ts1_ch1 =
-              getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
+              getChannelTriggerTicks(/*trigClock,*/ tTrue, npe1, distToReadout);
 
             if (fParams.EqualizeSiPMTimes()) {
                 mf::LogWarning("CRTDetSimAlg") << "EqualizeSiPMTimes is on." << std::endl;
@@ -513,8 +513,7 @@ namespace crt {
 
 
 
-    uint32_t CRTDetSimAlg::getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
-                                             /*detinfo::ElecClock& clock,*/
+    uint32_t CRTDetSimAlg::getChannelTriggerTicks(/*detinfo::ElecClock& clock,*/
                                              float t0, float npeMean, float r) {
         // Hit timing, with smearing and NPE dependence
         double tDelayMean =
@@ -528,10 +527,10 @@ namespace crt {
           fParams.TDelayRMSExpNorm() *
             exp(-(npeMean - fParams.TDelayRMSExpShift()) / fParams.TDelayRMSExpScale());
 
-        double tDelay = CLHEP::RandGauss::shoot(engine, tDelayMean, tDelayRMS);
+        double tDelay = CLHEP::RandGauss::shoot(&fEngine, tDelayMean, tDelayRMS);
 
         // Time resolution of the interpolator
-        tDelay += CLHEP::RandGauss::shoot(engine, 0, fParams.TResInterpolator());
+        tDelay += CLHEP::RandGauss::shoot(&fEngine, 0, fParams.TResInterpolator());
 
         // Propagation time
         double tProp = CLHEP::RandGauss::shoot(fParams.PropDelay(), fParams.PropDelayError()) * r;

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -61,6 +61,11 @@ namespace crt {
 
     uint16_t CRTDetSimAlg::WaveformEmulation(const uint32_t & time_delay, const double & adc)
     {
+
+        if (!fParams.DoWaveformEmulation()) {
+            return static_cast<uint16_t>(adc);
+        }
+
         std::cout << "[WaveformEmulation] time_delay " << time_delay
                   << ", waveform " << fInterpolator->Eval(time_delay) << std::endl;
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -87,9 +87,9 @@ namespace crt {
         double wf = fInterpolator->Eval(time_delay);
         wf *= adc;
 
-        std::cout << "[WaveformEmulation] time_delay " << time_delay
-                  << ", adc " << adc
-                  << ", waveform " << wf << std::endl;
+        mf::LogDebug("CRTDetSimAlg") << "WaveformEmulation, time_delay " << time_delay
+                                     << ", adc " << adc
+                                     << ", waveform " << wf << std::endl;
 
         return static_cast<uint16_t>(wf);
     }
@@ -106,13 +106,9 @@ namespace crt {
             new_adc = fParams.AdcSaturation();
         }
 
-        mf::LogDebug("CRTDetSimAlg") << "Updating ADC value for FEB " << feb_data.Mac5()
-                                     << "sipmID " << sipmID << ": was " << original_adc
-                                     << ", now is " << new_adc << std::endl;
-
         feb_data.SetADC(sipmID, new_adc);
 
-        std::cout << "Updating ADC value for FEB " << feb_data.Mac5()
+        mf::LogDebug("CRTDetSimAlg") << "Updating ADC value for FEB " << feb_data.Mac5()
                                      << ", sipmID " << sipmID
                                      << " with adc " << adc
                                      << ": was " << original_adc
@@ -166,9 +162,6 @@ namespace crt {
             auto &feb_data = mac_to_febdata[strip.mac5];
             uint32_t trigger_time = feb_data.Ts1();
 
-            std::cout << "sipm 0 channel " << strip.sipm0.channel << ", time " << strip.sipm0.t1 << ", time diff " << strip.sipm0.t1 - trigger_time << std::endl;
-            std::cout << "sipm 1 channel " << strip.sipm1.channel << ", time " << strip.sipm1.t1 << ", time diff " << strip.sipm1.t1 - trigger_time << std::endl;
-
             uint16_t adc_sipm0 = WaveformEmulation(strip.sipm0.t1 - trigger_time, strip.sipm0.adc);
             uint16_t adc_sipm1 = WaveformEmulation(strip.sipm1.t1 - trigger_time, strip.sipm1.adc);
 
@@ -177,9 +170,6 @@ namespace crt {
 
             auto &ides = mac_to_ides[strip.mac5];
             ides.push_back(strip.ide);
-
-            std::cout << "adc of sipm " << strip.sipm0.sipmID << " is now " << feb_data.ADC(strip.sipm0.sipmID) << std::endl;
-            std::cout << "adc of sipm " << strip.sipm1.sipmID << " is now " << feb_data.ADC(strip.sipm1.sipmID) << std::endl;
         }
 
         for (auto const& [mac, feb_data] : mac_to_febdata)
@@ -187,8 +177,8 @@ namespace crt {
             fData.push_back(std::make_pair(feb_data, mac_to_ides[mac]));
         }
 
-        std::cout << "Constructed " << mac_to_febdata.size()
-                  << " FEBData object(s)." << std::endl << std::endl;
+        mf::LogDebug("CRTDetSimAlg") << "Constructed " << mac_to_febdata.size()
+                                     << " FEBData object(s)." << std::endl << std::endl;
     }
 
 
@@ -383,7 +373,7 @@ namespace crt {
         bool top = (planeID == 1) ? (modulePosMother[1] > 0) : (modulePosMother[0] < 0);
 
         // Simulate the CRT response for each hit
-        std::cout << "We have " << ides.size() << " IDE for this SimChannel." << std::endl;
+        mf::LogInfo("CRTDetSimAlg") << "We have " << ides.size() << " IDE for this SimChannel." << std::endl;
         for (size_t ide_i = 0; ide_i < ides.size(); ide_i++) {
 
             sim::AuxDetIDE ide = ides[ide_i];

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -18,6 +18,7 @@ namespace crt {
         fData.clear();
     }
 
+
     void CRTDetSimAlg::ConfigureWaveform() {
 
         std::vector<double> wvf_x = fParams.WaveformX();
@@ -64,16 +65,19 @@ namespace crt {
     uint16_t CRTDetSimAlg::WaveformEmulation(const uint32_t & time_delay, const double & adc)
     {
 
-        if (!fParams.DoWaveformEmulation()) {
+        if (!fParams.DoWaveformEmulation())
+        {
             return static_cast<uint16_t>(adc);
         }
 
-        if (time_delay < 0) {
+        if (time_delay < 0)
+        {
             throw art::Exception(art::errors::LogicError)
                 << "Time delay cannot be negative for waveform emulation to happen." << std::endl;
         }
 
-        if (time_delay > fParams.WaveformX().back()) {
+        if (time_delay > fParams.WaveformX().back())
+        {
             // If the time delay is more than the waveform rise time, we
             // will never be able to see this signal. So return a 0 ADC value.
             return 0;
@@ -97,7 +101,8 @@ namespace crt {
         uint16_t original_adc = feb_data.ADC(sipmID);
         uint16_t new_adc = original_adc + adc;
 
-        if (new_adc > fParams.AdcSaturation()) {
+        if (new_adc > fParams.AdcSaturation())
+        {
             new_adc = fParams.AdcSaturation();
         }
 
@@ -126,7 +131,8 @@ namespace crt {
         // TODO Add pedestal fluctuations
         std::array<uint16_t, 32> adc_pedestal = {static_cast<uint16_t>(fParams.QPed())};
 
-        for (auto & strip : strips) {
+        for (auto & strip : strips)
+        {
 
             // First time we encounter this FEB...
             if (!mac_to_febdata.count(strip.mac5))
@@ -144,7 +150,8 @@ namespace crt {
             else
             {
                 // We want to save the earliest t1 and t0 for each FEB.
-                if (strip.sipm0.t1 < mac_to_febdata[strip.mac5].Ts1()) {
+                if (strip.sipm0.t1 < mac_to_febdata[strip.mac5].Ts1())
+                {
                     mac_to_febdata[strip.mac5].SetTs1(strip.sipm0.t1);
                     mac_to_febdata[strip.mac5].SetTs0(strip.sipm0.t0);
                     mac_to_febdata[strip.mac5].SetCoinc(strip.sipm0.sipmID);
@@ -173,10 +180,10 @@ namespace crt {
 
             std::cout << "adc of sipm " << strip.sipm0.sipmID << " is now " << feb_data.ADC(strip.sipm0.sipmID) << std::endl;
             std::cout << "adc of sipm " << strip.sipm1.sipmID << " is now " << feb_data.ADC(strip.sipm1.sipmID) << std::endl;
-
         }
 
-        for (auto const& [mac, feb_data] : mac_to_febdata) {
+        for (auto const& [mac, feb_data] : mac_to_febdata)
+        {
             fData.push_back(std::make_pair(feb_data, mac_to_ides[mac]));
         }
 
@@ -269,7 +276,7 @@ namespace crt {
                     if (!strip_data.sipm_coinc) std::cout << "[CreateData]   -> (didn't have SiPMs coincidence.) " << strip_data.sipm0.adc << " " << strip_data.sipm1.adc << std::endl;
                 }
 
-            }
+            } // loop over strips
 
             if (trigger.tagger_triggered()) {
                 ProcessStrips(strips);
@@ -344,164 +351,164 @@ namespace crt {
         std::cout << "We have " << ides.size() << " IDE for this SimChannel." << std::endl;
         for (size_t ide_i = 0; ide_i < ides.size(); ide_i++) {
 
-          sim::AuxDetIDE ide = ides[ide_i];
+            sim::AuxDetIDE ide = ides[ide_i];
 
-          // Finally, what is the distance from the hit (centroid of the entry
-          // and exit points) to the readout end?
-          double x = (ide.entryX + ide.exitX) / 2;
-          double y = (ide.entryY + ide.exitY) / 2;
-          double z = (ide.entryZ + ide.exitZ) / 2;
+            // Finally, what is the distance from the hit (centroid of the entry
+            // and exit points) to the readout end?
+            double x = (ide.entryX + ide.exitX) / 2;
+            double y = (ide.entryY + ide.exitY) / 2;
+            double z = (ide.entryZ + ide.exitZ) / 2;
 
-          double tTrue = (ide.entryT + ide.exitT) / 2 + fTimeOffset; // ns
-          double eDep = ide.energyDeposited;
+            double tTrue = (ide.entryT + ide.exitT) / 2 + fTimeOffset; // ns
+            double eDep = ide.energyDeposited;
 
-          mf::LogInfo("CRTDetSimAlg") << "True IDE with time " << tTrue
+            mf::LogInfo("CRTDetSimAlg") << "True IDE with time " << tTrue
                                       << ", energy " << eDep << std::endl;
 
-          if (tTrue < 0) {
-            throw art::Exception(art::errors::LogicError)
-                << "Time cannot be negative. Check the time offset used for the CRT simulation.\n"
-                << "True time: " << (ide.entryT + ide.exitT) / 2 << "\n"
-                << "TimeOffset: " << fTimeOffset << std::endl;
-          }
+            if (tTrue < 0) {
+                throw art::Exception(art::errors::LogicError)
+                    << "Time cannot be negative. Check the time offset used for the CRT simulation.\n"
+                    << "True time: " << (ide.entryT + ide.exitT) / 2 << "\n"
+                    << "TimeOffset: " << fTimeOffset << std::endl;
+            }
 
-          double world[3] = {x, y, z};
-          double svHitPosLocal[3];
-          adsGeo.WorldToLocal(world, svHitPosLocal);
+            double world[3] = {x, y, z};
+            double svHitPosLocal[3];
+            adsGeo.WorldToLocal(world, svHitPosLocal);
 
-          double distToReadout;
-          if (top) {
-            distToReadout = abs( adsGeo.HalfWidth1() - svHitPosLocal[0]);
-          }
-          else {
-            distToReadout = abs(-adsGeo.HalfWidth1() - svHitPosLocal[0]);
-          }
+            double distToReadout;
+            if (top) {
+                distToReadout = abs( adsGeo.HalfWidth1() - svHitPosLocal[0]);
+            }
+            else {
+                distToReadout = abs(-adsGeo.HalfWidth1() - svHitPosLocal[0]);
+            }
 
-          // The expected number of PE, using a quadratic model for the distance
-          // dependence, and scaling linearly with deposited energy.
-          double qr = fParams.UseEdep() ? 1.0 * eDep / fParams.Q0() : 1.0;
+            // The expected number of PE, using a quadratic model for the distance
+            // dependence, and scaling linearly with deposited energy.
+            double qr = fParams.UseEdep() ? 1.0 * eDep / fParams.Q0() : 1.0;
 
-          double npeExpected =
-            fParams.NpeScaleNorm() / pow(distToReadout - fParams.NpeScaleShift(), 2) * qr;
+            double npeExpected =
+              fParams.NpeScaleNorm() / pow(distToReadout - fParams.NpeScaleShift(), 2) * qr;
 
-          // Put PE on channels weighted by transverse distance across the strip,
-          // using an exponential model
-          double d0 = abs(-adsGeo.HalfHeight() - svHitPosLocal[1]);  // L
-          double d1 = abs( adsGeo.HalfHeight() - svHitPosLocal[1]);  // R
-          double abs0 = exp(-d0 / fParams.AbsLenEff());
-          double abs1 = exp(-d1 / fParams.AbsLenEff());
-          double npeExp0 = npeExpected * abs0 / (abs0 + abs1);
-          double npeExp1 = npeExpected * abs1 / (abs0 + abs1);
+            // Put PE on channels weighted by transverse distance across the strip,
+            // using an exponential model
+            double d0 = abs(-adsGeo.HalfHeight() - svHitPosLocal[1]);  // L
+            double d1 = abs( adsGeo.HalfHeight() - svHitPosLocal[1]);  // R
+            double abs0 = exp(-d0 / fParams.AbsLenEff());
+            double abs1 = exp(-d1 / fParams.AbsLenEff());
+            double npeExp0 = npeExpected * abs0 / (abs0 + abs1);
+            double npeExp1 = npeExpected * abs1 / (abs0 + abs1);
 
-          // Observed PE (Poisson-fluctuated)
-          long npe0 = CLHEP::RandPoisson::shoot(&fEngine, npeExp0);
-          long npe1 = CLHEP::RandPoisson::shoot(&fEngine, npeExp1);
+            // Observed PE (Poisson-fluctuated)
+            long npe0 = CLHEP::RandPoisson::shoot(&fEngine, npeExp0);
+            long npe1 = CLHEP::RandPoisson::shoot(&fEngine, npeExp1);
 
-          // Time relative to trigger, accounting for propagation delay and 'walk'
-          // for the fixed-threshold discriminator
-          uint32_t ts1_ch0 =
-            getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
-          uint32_t ts1_ch1 =
-            getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
+            // Time relative to trigger, accounting for propagation delay and 'walk'
+            // for the fixed-threshold discriminator
+            uint32_t ts1_ch0 =
+              getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe0, distToReadout);
+            uint32_t ts1_ch1 =
+              getChannelTriggerTicks(&fEngine, /*trigClock,*/ tTrue, npe1, distToReadout);
 
-          if (fParams.EqualizeSiPMTimes()) {
-            mf::LogWarning("CRTDetSimAlg") << "EqualizeSiPMTimes is on." << std::endl;
-            ts1_ch1 = ts1_ch0;
-          }
+            if (fParams.EqualizeSiPMTimes()) {
+                mf::LogWarning("CRTDetSimAlg") << "EqualizeSiPMTimes is on." << std::endl;
+                ts1_ch1 = ts1_ch0;
+            }
 
-          // Time relative to PPS: Random for now! (FIXME)
-          uint32_t ppsTicks =
-            CLHEP::RandFlat::shootInt(&fEngine, /*trigClock.Frequency()*/ fParams.ClockSpeedCRT() * 1e6);
+            // Time relative to PPS: Random for now! (FIXME)
+            uint32_t ppsTicks =
+              CLHEP::RandFlat::shootInt(&fEngine, /*trigClock.Frequency()*/ fParams.ClockSpeedCRT() * 1e6);
 
-          // SiPM and ADC response: Npe to ADC counts, pedestal is added later
-          double q0 =
-            CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe0, fParams.QRMS() * sqrt(npe0));
-          double q1 =
-            CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe1, fParams.QRMS() * sqrt(npe1));
+            // SiPM and ADC response: Npe to ADC counts, pedestal is added later
+            double q0 =
+              CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe0, fParams.QRMS() * sqrt(npe0));
+            double q1 =
+              CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe1, fParams.QRMS() * sqrt(npe1));
 
-          // Apply saturation
-          double saturation = static_cast<double>(fParams.AdcSaturation());
-          if (q0 > saturation) q0 = saturation;
-          if (q1 > saturation) q1 = saturation;
+            // Apply saturation
+            double saturation = static_cast<double>(fParams.AdcSaturation());
+            if (q0 > saturation) q0 = saturation;
+            if (q1 > saturation) q1 = saturation;
 
-          // Adjacent channels on a strip are numbered sequentially.
-          //
-          // In the AuxDetChannelMapAlg methods, channels are identified by an
-          // AuxDet name (retrievable given the hit AuxDet ID) which specifies a
-          // module, and a channel number from 0 to 32.
-          uint32_t moduleID = adid;
-          uint32_t stripID = adsid;
-          uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
-          uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
-          uint32_t sipm0ID = stripID * 2 + 0;
-          uint32_t sipm1ID = stripID * 2 + 1;
+            // Adjacent channels on a strip are numbered sequentially.
+            //
+            // In the AuxDetChannelMapAlg methods, channels are identified by an
+            // AuxDet name (retrievable given the hit AuxDet ID) which specifies a
+            // module, and a channel number from 0 to 32.
+            uint32_t moduleID = adid;
+            uint32_t stripID = adsid;
+            uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
+            uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
+            uint32_t sipm0ID = stripID * 2 + 0;
+            uint32_t sipm1ID = stripID * 2 + 1;
 
-          if (moduleID >= 127) {continue;}        //Ignoring MINOS modules for now.
+            if (moduleID >= 127) {continue;}        //Ignoring MINOS modules for now.
 
-          // Apply ADC threshold and strip-level coincidence (both fibers fire)
-          double threshold = static_cast<double>(fParams.QThreshold());
-          bool sipm_coinc = false;
+            // Apply ADC threshold and strip-level coincidence (both fibers fire)
+            double threshold = static_cast<double>(fParams.QThreshold());
+            bool sipm_coinc = false;
 
-          if (q0 > threshold &&
-              q1 > threshold &&
-              util::absDiff(ts1_ch0, ts1_ch1) < fParams.StripCoincidenceWindow()) {
-            sipm_coinc = true;
-          }
+            if (q0 > threshold &&
+                q1 > threshold &&
+                util::absDiff(ts1_ch0, ts1_ch1) < fParams.StripCoincidenceWindow())
+            {
+                sipm_coinc = true;
+            }
 
-          // Time ordered
-          if (ts1_ch0 > ts1_ch1) {
-              std::swap(ts1_ch0, ts1_ch1);
-              std::swap(channel0ID, channel1ID);
-              std::swap(q0, q1);
-              std::swap(sipm0ID, sipm1ID);
-          }
+            // Time ordered
+            if (ts1_ch0 > ts1_ch1)
+            {
+                std::swap(ts1_ch0, ts1_ch1);
+                std::swap(channel0ID, channel1ID);
+                std::swap(q0, q1);
+                std::swap(sipm0ID, sipm1ID);
+            }
 
-          SiPMData sipm0 = SiPMData(sipm0ID,
-                                    channel0ID,
-                                    ppsTicks,
-                                    ts1_ch0,
-                                    q0);
-          SiPMData sipm1 = SiPMData(sipm1ID,
-                                    channel1ID,
-                                    ppsTicks,
-                                    ts1_ch1,
-                                    q1);
+            SiPMData sipm0 = SiPMData(sipm0ID,
+                                      channel0ID,
+                                      ppsTicks,
+                                      ts1_ch0,
+                                      q0);
+            SiPMData sipm1 = SiPMData(sipm1ID,
+                                      channel1ID,
+                                      ppsTicks,
+                                      ts1_ch1,
+                                      q1);
 
-          StripData strip_data = StripData(mac5,
-                                           planeID,
-                                           sipm0,
-                                           sipm1,
-                                           sipm_coinc,
-                                           ide);
+            StripData strip_data = StripData(mac5,
+                                             planeID,
+                                             sipm0,
+                                             sipm1,
+                                             sipm_coinc,
+                                             ide);
 
-        std::cout << "Constructed StripData for mac " << mac5 << " with true time " << tTrue << " ns. and for trackID " << ide.trackID << std::endl;
-        std::cout << std::endl;
+            std::cout << "Constructed StripData for mac " << mac5 << " with true time " << tTrue << " ns. and for trackID " << ide.trackID << std::endl;
+            std::cout << std::endl;
 
-        // Retrive the Tagger object
-        Tagger& tagger = fTaggers[nodeTagger->GetName()];
-        tagger.data.push_back(strip_data);
+            // Retrive the Tagger object
+            Tagger& tagger = fTaggers[nodeTagger->GetName()];
+            tagger.data.push_back(strip_data);
 
-          double poss[3];
-          adsGeo.LocalToWorld(origin, poss);
-          mf::LogInfo("CRTDetSimAlg")
-            << "CRT HIT in " << adid << "/" << adsid << "\n"
-            << "CRT HIT POS " << x << " " << y << " " << z << "\n"
-            << "CRT STRIP POS " << poss[0] << " " << poss[1] << " " << poss[2] << "\n"
-            << "CRT MODULE POS " << modulePosMother[0] << " "
-                                 << modulePosMother[1] << " "
-                                 << modulePosMother[2] << " "
-                                 << "\n"
-            << "CRT PATH: " << path << "\n"
-            << "CRT level 0 (strip): " << nodeStrip->GetName() << "\n"
-            << "CRT level 1 (array): " << nodeArray->GetName() << "\n"
-            << "CRT level 2 (module): " << nodeModule->GetName() << "\n"
-            << "CRT level 3 (tagger): " << nodeTagger->GetName() << "\n"
-            << "CRT PLANE ID: " << planeID << "\n"
-            << "CRT distToReadout: " << distToReadout << " " << (top ? "top" : "bot") << "\n"
-            << "CRT q0: " << q0 << ", q1: " << q1 << ", ts1_ch0: " << ts1_ch0 << ", ts1_ch1: " << ts1_ch1 << ", dt: " << util::absDiff(ts1_ch0,ts1_ch1) << "\n";
+            double poss[3];
+            adsGeo.LocalToWorld(origin, poss);
+            mf::LogInfo("CRTDetSimAlg")
+                << "CRT HIT in " << adid << "/" << adsid << "\n"
+                << "CRT HIT POS " << x << " " << y << " " << z << "\n"
+                << "CRT STRIP POS " << poss[0] << " " << poss[1] << " " << poss[2] << "\n"
+                << "CRT MODULE POS " << modulePosMother[0] << " "
+                                     << modulePosMother[1] << " "
+                                     << modulePosMother[2] << " "
+                                    << "\n"
+                << "CRT PATH: " << path << "\n"
+                << "CRT level 0 (strip): " << nodeStrip->GetName() << "\n"
+                << "CRT level 1 (array): " << nodeArray->GetName() << "\n"
+                << "CRT level 2 (module): " << nodeModule->GetName() << "\n"
+                << "CRT level 3 (tagger): " << nodeTagger->GetName() << "\n"
+                << "CRT PLANE ID: " << planeID << "\n"
+                << "CRT distToReadout: " << distToReadout << " " << (top ? "top" : "bot") << "\n"
+                << "CRT q0: " << q0 << ", q1: " << q1 << ", ts1_ch0: " << ts1_ch0 << ", ts1_ch1: " << ts1_ch1 << ", dt: " << util::absDiff(ts1_ch0,ts1_ch1) << "\n";
         }
-
-
     } //end FillTaggers
 
 
@@ -509,50 +516,50 @@ namespace crt {
     uint32_t CRTDetSimAlg::getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
                                              /*detinfo::ElecClock& clock,*/
                                              float t0, float npeMean, float r) {
-      // Hit timing, with smearing and NPE dependence
-      double tDelayMean =
-        fParams.TDelayNorm() *
-          exp(-0.5 * pow((npeMean - fParams.TDelayShift()) / fParams.TDelaySigma(), 2)) +
-        fParams.TDelayOffset();
+        // Hit timing, with smearing and NPE dependence
+        double tDelayMean =
+          fParams.TDelayNorm() *
+            exp(-0.5 * pow((npeMean - fParams.TDelayShift()) / fParams.TDelaySigma(), 2)) +
+          fParams.TDelayOffset();
 
-      double tDelayRMS =
-        fParams.TDelayRMSGausNorm() *
-          exp(-pow(npeMean - fParams.TDelayRMSGausShift(), 2) / fParams.TDelayRMSGausSigma()) +
-        fParams.TDelayRMSExpNorm() *
-          exp(-(npeMean - fParams.TDelayRMSExpShift()) / fParams.TDelayRMSExpScale());
+        double tDelayRMS =
+          fParams.TDelayRMSGausNorm() *
+            exp(-pow(npeMean - fParams.TDelayRMSGausShift(), 2) / fParams.TDelayRMSGausSigma()) +
+          fParams.TDelayRMSExpNorm() *
+            exp(-(npeMean - fParams.TDelayRMSExpShift()) / fParams.TDelayRMSExpScale());
 
-      double tDelay = CLHEP::RandGauss::shoot(engine, tDelayMean, tDelayRMS);
+        double tDelay = CLHEP::RandGauss::shoot(engine, tDelayMean, tDelayRMS);
 
-      // Time resolution of the interpolator
-      tDelay += CLHEP::RandGauss::shoot(engine, 0, fParams.TResInterpolator());
+        // Time resolution of the interpolator
+        tDelay += CLHEP::RandGauss::shoot(engine, 0, fParams.TResInterpolator());
 
-      // Propagation time
-      double tProp = CLHEP::RandGauss::shoot(fParams.PropDelay(), fParams.PropDelayError()) * r;
+        // Propagation time
+        double tProp = CLHEP::RandGauss::shoot(fParams.PropDelay(), fParams.PropDelayError()) * r;
 
-      double t = t0 + tProp + tDelay;
+        double t = t0 + tProp + tDelay;
 
-      // Get clock ticks
-      // FIXME no clock available for CRTs, have to do it by hand
-      //clock.SetTime(t / 1e3);  // SetTime takes microseconds
-      float time = (t / 1e3) * fParams.ClockSpeedCRT();
+        // Get clock ticks
+        // FIXME no clock available for CRTs, have to do it by hand
+        //clock.SetTime(t / 1e3);  // SetTime takes microseconds
+        float time = (t / 1e3) * fParams.ClockSpeedCRT();
 
-      if (time < 0) {
-        mf::LogWarning("CRTSetSimAlg") << "Time is negative. Check the time offset used." << std::endl;
-      }
+        if (time < 0) {
+          mf::LogWarning("CRTSetSimAlg") << "Time is negative. Check the time offset used." << std::endl;
+        }
 
-      uint32_t time_int = static_cast<uint32_t>(time);
+        uint32_t time_int = static_cast<uint32_t>(time);
 
-      mf::LogInfo("CRTSetSimAlg")
-        << "CRT TIMING: t0=" << t0
-        << ", tDelayMean=" << tDelayMean
-        << ", tDelayRMS=" << tDelayRMS
-        << ", tDelay=" << tDelay
-        << ", tProp=" << tProp
-        << ", t=" << t
-        << ", time=" << time
-        << ", time_int=" << time_int << std::endl;
+        mf::LogInfo("CRTSetSimAlg")
+            << "CRT TIMING: t0=" << t0
+            << ", tDelayMean=" << tDelayMean
+            << ", tDelayRMS=" << tDelayRMS
+            << ", tDelay=" << tDelay
+            << ", tProp=" << tProp
+            << ", t=" << t
+            << ", time=" << time
+            << ", time_int=" << time_int << std::endl;
 
-      return time_int; // clock.Ticks();
+        return time_int; // clock.Ticks();
     }
 
 
@@ -562,7 +569,7 @@ namespace crt {
         fData.clear();
     }
 
- }//namespace crt
-}//namespace sbnd
+} // namespace crt
+} // namespace sbnd
 
 #endif

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -16,6 +16,7 @@ namespace crt {
 
         fTaggers.clear();
         fData.clear();
+        fAuxData.clear();
     }
 
 
@@ -671,6 +672,7 @@ namespace crt {
 
         fTaggers.clear();
         fData.clear();
+        fAuxData.clear();
     }
 
 } // namespace crt

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -575,15 +575,12 @@ namespace crt {
     void CRTDetSimAlg::ChargeResponse(double eDep, double d0, double d1, double distToReadout, // input
                                       long & npe0, long & npe1, double & q0, double &q1) // output
     {
-        std::cout << "[ChargeResponse] eDep = " << eDep << std::endl;
         // The expected number of PE, using a quadratic model for the distance
         // dependence, and scaling linearly with deposited energy.
         double qr = fParams.UseEdep() ? 1.0 * eDep / fParams.Q0() : 1.0;
-        std::cout << "[ChargeResponse] qr = " << qr << std::endl;
 
         double npeExpected =
             fParams.NpeScaleNorm() / pow(distToReadout - fParams.NpeScaleShift(), 2) * qr;
-        std::cout << "[ChargeResponse] npeExpected = " << npeExpected << std::endl;
 
         // Put PE on channels weighted by transverse distance across the strip,
         // using an exponential model
@@ -602,8 +599,6 @@ namespace crt {
                                      fParams.QRMS() * sqrt(npe0));
         q1 = CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe1,
                                      fParams.QRMS() * sqrt(npe1));
-        std::cout << "[ChargeResponse] npe0 = " << npe0 << " -> q0 = " << q0 << std::endl;
-        std::cout << "[ChargeResponse] npe1 = " << npe1 << " -> q1 = " << q1 << std::endl;
 
         // Apply saturation
         double saturation = static_cast<double>(fParams.AdcSaturation());

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -115,7 +115,7 @@ namespace crt {
 
 
     void CRTDetSimAlg::ProcessStrips(/*const uint32_t & trigger_ts1,
-                                     const uint32_t & trigger_ts0*/,
+                                     const uint32_t & trigger_ts0,*/
                                      const uint32_t & coinc,
                                      const std::vector<StripData> & strips,
                                      const std::string & tagger_name)
@@ -176,13 +176,14 @@ namespace crt {
         for (auto & strip : strips)
         {
 
-            std::cout << "sipm 0 time " << strip.sipm0.t1 << ", time diff " << strip.sipm0.t1 - trigger_ts1 << std::endl;
-            std::cout << "sipm 1 time " << strip.sipm1.t1 << ", time diff " << strip.sipm1.t1 - trigger_ts1 << std::endl;
-
-            uint16_t adc_sipm0 = WaveformEmulation(strip.sipm0.t1 - trigger_ts1, strip.sipm0.adc);
-            uint16_t adc_sipm1 = WaveformEmulation(strip.sipm1.t1 - trigger_ts1, strip.sipm1.adc);
-
             auto &feb_data = mac_to_febdata[strip.mac5];
+            uint32_t trigger_time = feb_data.Ts1();
+
+            std::cout << "sipm 0 time " << strip.sipm0.t1 << ", time diff " << strip.sipm0.t1 - trigger_time << std::endl;
+            std::cout << "sipm 1 time " << strip.sipm1.t1 << ", time diff " << strip.sipm1.t1 - trigger_time << std::endl;
+
+            uint16_t adc_sipm0 = WaveformEmulation(strip.sipm0.t1 - trigger_time, strip.sipm0.adc);
+            uint16_t adc_sipm1 = WaveformEmulation(strip.sipm1.t1 - trigger_time, strip.sipm1.adc);
 
             AddADC(feb_data, strip.sipm0.sipmID, adc_sipm0);
             AddADC(feb_data, strip.sipm1.sipmID, adc_sipm1);
@@ -201,7 +202,7 @@ namespace crt {
         }
 
         std::cout << "Constructed " << mac_to_febdata.size()
-                  << " FEBData object(s) for trigger time " << trigger_ts1 << std::endl << std::endl;
+                  << " FEBData object(s)." << std::endl << std::endl;
     }
 
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -376,6 +376,7 @@ namespace crt {
             double svHitPosLocal[3];
             adsGeo.WorldToLocal(world, svHitPosLocal);
 
+            // Calculate distance to the readout
             double distToReadout;
             if (top) {
                 distToReadout = abs( adsGeo.HalfWidth1() - svHitPosLocal[0]);
@@ -384,33 +385,17 @@ namespace crt {
                 distToReadout = abs(-adsGeo.HalfWidth1() - svHitPosLocal[0]);
             }
 
-            // Distance to fibers
+            // Calculate distance to fibers
             double d0 = abs(-adsGeo.HalfHeight() - svHitPosLocal[1]);  // L
             double d1 = abs( adsGeo.HalfHeight() - svHitPosLocal[1]);  // R
 
+            // Simulate time response
+            // Waveform emulation is added later, because
+            // it depends on trigger time
             long npe0, npe1;
             double q0, q1;
             ChargeResponse(eDep, d0, d1, distToReadout,
                            npe0, npe1, q0, q1);
-
-            // // The expected number of PE, using a quadratic model for the distance
-            // // dependence, and scaling linearly with deposited energy.
-            // double qr = fParams.UseEdep() ? 1.0 * eDep / fParams.Q0() : 1.0;
-
-            // double npeExpected =
-            //   fParams.NpeScaleNorm() / pow(distToReadout - fParams.NpeScaleShift(), 2) * qr;
-
-            // // Put PE on channels weighted by transverse distance across the strip,
-            // // using an exponential model
-
-            // double abs0 = exp(-d0 / fParams.AbsLenEff());
-            // double abs1 = exp(-d1 / fParams.AbsLenEff());
-            // double npeExp0 = npeExpected * abs0 / (abs0 + abs1);
-            // double npeExp1 = npeExpected * abs1 / (abs0 + abs1);
-
-            // // Observed PE (Poisson-fluctuated)
-            // long npe0 = CLHEP::RandPoisson::shoot(&fEngine, npeExp0);
-            // long npe1 = CLHEP::RandPoisson::shoot(&fEngine, npeExp1);
 
             // Time relative to trigger, accounting for propagation delay and 'walk'
             // for the fixed-threshold discriminator
@@ -427,17 +412,6 @@ namespace crt {
             // Time relative to PPS: Random for now! (FIXME)
             uint32_t ppsTicks =
               CLHEP::RandFlat::shootInt(&fEngine, /*trigClock.Frequency()*/ fParams.ClockSpeedCRT() * 1e6);
-
-            // // SiPM and ADC response: Npe to ADC counts, pedestal is added later
-            // double q0 =
-            //   CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe0, fParams.QRMS() * sqrt(npe0));
-            // double q1 =
-            //   CLHEP::RandGauss::shoot(&fEngine, /*fQPed + */fParams.QSlope() * npe1, fParams.QRMS() * sqrt(npe1));
-
-            // // Apply saturation
-            // double saturation = static_cast<double>(fParams.AdcSaturation());
-            // if (q0 > saturation) q0 = saturation;
-            // if (q1 > saturation) q1 = saturation;
 
             // Adjacent channels on a strip are numbered sequentially.
             //

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -355,10 +355,13 @@ namespace crt {
         TGeoNode* nodeModule = manager->GetMother(1);
         TGeoNode* nodeTagger = manager->GetMother(2);
 
+        std::string volumeName = nodeStrip->GetVolume()->GetName();
+
         std::cout << "Strip name: " << nodeStrip->GetName() << ", number = " << nodeStrip->GetNumber() << std::endl;
         std::cout << "Array name: " << nodeArray->GetName() << ", number = " << nodeArray->GetNumber() << std::endl;
         std::cout << "Module name: " << nodeModule->GetName() << ", number = " << nodeModule->GetNumber() << std::endl;
         std::cout << "Tagger name: " << nodeTagger->GetName() << ", number = " << nodeTagger->GetNumber() << std::endl;
+        std::cout << "Strip volume name: " << volumeName << std::endl;
 
         // Retrive the ID of this CRT module
         uint16_t mac5 = static_cast<uint16_t>(nodeModule->GetNumber());
@@ -445,14 +448,15 @@ namespace crt {
             // In the AuxDetChannelMapAlg methods, channels are identified by an
             // AuxDet name (retrievable given the hit AuxDet ID) which specifies a
             // module, and a channel number from 0 to 32.
-            uint32_t moduleID = adid;
+            // uint32_t moduleID = adid;
+            uint32_t moduleID = mac5;
             uint32_t stripID = adsid;
             uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
             uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
             uint32_t sipm0ID = stripID * 2 + 0;
             uint32_t sipm1ID = stripID * 2 + 1;
 
-            if (moduleID >= 127) {continue;}        //Ignoring MINOS modules for now.
+            if (volumeName.find("MINOS") != std::string::npos) {continue;} // Ignoring MINOS modules for now.
 
             // Apply ADC threshold and strip-level coincidence (both fibers fire)
             double threshold = static_cast<double>(fParams.QThreshold());

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -196,6 +196,33 @@ namespace crt {
     void CRTDetSimAlg::CreateData()
     {
 
+        /** A struct to temporarily store information on a CRT Tagger trigger.
+         */
+        struct Trigger {
+            bool is_bottom;
+            bool planeX;
+            bool planeY;
+
+            Trigger(bool _is_bottom) {
+                planeX = planeY = false;
+                is_bottom = _is_bottom;
+            }
+
+            /** \brief Resets this trigger object */
+            void reset() {
+                planeX = planeY = false;
+            }
+
+            /** \brief Tells is a tagger is triggering or not */
+            bool tagger_triggered() {
+                if (is_bottom) {
+                    return planeX or planeY;
+                }
+                return planeX and planeY;
+            }
+        };
+
+
         // Loop over all the CRT Taggers and simulate triggering, dead time, ...
         for (auto iter : fTaggers)
         {

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -116,25 +116,15 @@ namespace crt {
 
 
 
-    void CRTDetSimAlg::ProcessStrips(/*const uint32_t & trigger_ts1,
-                                     const uint32_t & trigger_ts0,*/
-                                     const uint32_t & coinc,
+    void CRTDetSimAlg::ProcessStrips(const uint32_t & coinc,
                                      const std::vector<StripData> & strips,
                                      const std::string & tagger_name)
     {
         std::map<uint16_t, sbnd::crt::FEBData> mac_to_febdata;
         std::map<uint16_t, std::vector<AuxDetIDE>> mac_to_ides;
 
-        // bool plane0_hit, plane1_hit = false;
-
         // TODO Add pedestal fluctuations
         std::array<uint16_t, 32> adc_pedestal = {static_cast<uint16_t>(fParams.QPed())};
-
-        // The system is triggered when the fast-shaped waveform goes above threshold
-        // Here, we don't simulate this waveform, but we should take into account
-        // the delay that this introduces.
-        // uint32_t time_ts0 = trigger_ts0 + fParams.TriggerDelay();
-        // uint32_t time_ts1 = trigger_ts1 + fParams.TriggerDelay();
 
         for (auto & strip : strips) {
             // if (strip.planeID == 0 and strip.sipm_coinc) plane0_hit = true;
@@ -162,17 +152,6 @@ namespace crt {
                 }
             }
         }
-
-        // bool is_bottom = tagger_name.find("Bottom") != std::string::npos;
-        // if (is_bottom) std::cout << "Is bottom tagger." << std::endl;
-
-        // // Emulate the tagger-level trigger for all the taggers but not for the bottom one
-        // if (!is_bottom and !(plane0_hit and plane1_hit)) {
-        //     return;
-        // }
-        // if (is_bottom and !(plane0_hit or plane1_hit)) {
-        //     return;
-        // }
 
 
         for (auto & strip : strips)
@@ -251,7 +230,6 @@ namespace crt {
                 {
                     first_trigger = false;
                     trigger_ts1 = current_time;
-                    // trigger_ts0 = strip_data.sipm0.t0;
                     coinc = strip_data.sipm0.sipmID;
                     trigger_index ++;
                     std::cout << "[CreateData]   TRIGGER TIME IS " << trigger_ts1 << std::endl;
@@ -268,11 +246,10 @@ namespace crt {
                 {
                     std::cout << "[CreateData]   -> Created new trigger. " << std::endl;
                     if (trigger.tagger_triggered()) {
-                        ProcessStrips(/*trigger_ts1, trigger_ts0, */coinc, strips, name);
+                        ProcessStrips(coinc, strips, name);
                     }
 
                     trigger_ts1 = current_time;
-                    // trigger_ts0 = strip_data.sipm0.t0;
                     coinc = strip_data.sipm0.sipmID;
                     trigger_index ++;
 
@@ -300,59 +277,12 @@ namespace crt {
             }
 
             if (trigger.tagger_triggered()) {
-                ProcessStrips(/*trigger_ts1, trigger_ts0, */coinc, strips, name);
+                ProcessStrips(coinc, strips, name);
             }
 
         } // loop over taggers
 
         std::cout << "We have " << fData.size() << " FEBData objects." << std::endl;
-
-        // for (auto & feb_data : fFEBDatas) {
-        //     std::cout << "FEBData mac5: " << feb_data.Mac5() << std::endl;
-        // }
-
-
-        // Logic: For normal taggers, require at least one hit in each perpendicular
-        // plane. For the bottom tagger, any hit triggers read out.
-        // for (auto trg : fTaggers) {
-        //     bool trigger = false;
-
-        //     auto name = trg.first;
-        //     auto tagger = trg.second;
-
-        //     // Loop over pairs of hits
-        //     for (size_t i = 0; i < tagger.size(); i++) {
-        //       auto planeID1 =  tagger.planeID[i];
-        //       auto time1 = tagger.time[i];
-
-        //       for (size_t j = 0; j < tagger.size(); j++) {
-        //         auto planeID2 =  tagger.planeID[j];
-        //         auto time2 = tagger.time[j];
-
-        //         if (planeID1 == planeID2 && time1 == time2) {
-        //           continue;
-        //         }
-
-        //         // Two hits on different planes with proximal t0 times
-        //         if (planeID1 != planeID2 && util::absDiff(time1, time2) < fTaggerPlaneCoincidenceWindow) {
-        //           trigger = true;
-        //           break;
-        //         }
-        //       }
-        //     }
-
-        //     if (trigger || name.find("TaggerBot") != std::string::npos) {
-        //         // Write out all hits on a tagger when there is any coincidence FIXME this reads out everything!
-        //         for (size_t d_i = 0; d_i < tagger.data.size(); d_i++) {
-
-        //             dataCol.push_back(std::make_pair(tagger.data[d_i], tagger.ides[d_i]));
-
-        //         }
-        //     }
-        // }
-
-        // std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> dataCol;
-        // return dataCol;
 
     }
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -2,9 +2,7 @@
 #define SBND_CRTDETSIMALG_H
 
 // art includes
-#include "art/Framework/Principal/Handle.h"
 #include "fhiclcpp/ParameterSet.h"
-#include "nurandom/RandomUtils/NuRandomService.h"
 
 // larsoft includes
 #include "lardataobj/Simulation/AuxDetSimChannel.h"

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -37,6 +37,7 @@
 // CRT includes
 #include "sbnobj/SBND/CRT/FEBData.hh"
 #include "sbnobj/SBND/CRT/CRTData.hh"
+#include "CRTDetSimParams.h"
 
 using std::vector;
 using std::pair;
@@ -48,23 +49,16 @@ using sim::AuxDetIDE;
 namespace sbnd {
     namespace crt {
         class CRTDetSimAlg;
+        struct SiPMData;
+        struct StripData;
+        struct Tagger;
     }
 }
 
-// struct Tagger {
-//   std::vector<std::pair<unsigned, uint32_t> > planesHit;
-//   std::vector<sbnd::crt::CRTData> data;
-//   std::vector<std::vector<sim::AuxDetIDE>> ides;
-// };
-
-struct SiPMData {
-    // uint16_t mac5;
-    // unsigned planeID;
-    int sipmID;
-    int channel;
-    uint64_t t0;
-    uint64_t t1;
-    double adc;
+/** An enum type. 
+ *  The documentation block cannot be put after the enum! 
+ */
+struct sbnd::crt::SiPMData {
     SiPMData(int _sipmID, int _channel, uint64_t _t0, uint64_t _t1, double _adc) :
         sipmID(_sipmID)
       , channel(_channel)
@@ -72,21 +66,15 @@ struct SiPMData {
       , t1(_t1)
       , adc(_adc)
     {};
-    // sim::AuxDetIDE ide;
+
+    int sipmID; ///< The SiPM ID in the strip (0-31)
+    int channel; ///< The SiPM global channel number, calculated as 32 x (module) + 2 x (strip) + j
+    uint64_t t0; ///< The SiPM Ts0
+    uint64_t t1; ///< The SiPM Ts1
+    double adc; ///< The SiPM simulated ADC value in double format
 };
 
-struct StripData {
-    uint16_t mac5;
-    unsigned planeID;
-    SiPMData sipm0;
-    SiPMData sipm1;
-    bool sipm_coinc;
-    // int channel;
-    // uint64_t t0;
-    // uint64_t t1;
-    // uint16_t adc;
-    sim::AuxDetIDE ide;
-
+struct sbnd::crt::StripData {
     StripData(uint16_t _mac5, unsigned _planeID, SiPMData _sipm0, SiPMData _sipm1,
               bool _sipm_coinc, sim::AuxDetIDE _ide) :
         mac5(_mac5)
@@ -96,20 +84,18 @@ struct StripData {
       , sipm_coinc(_sipm_coinc)
       , ide(_ide)
     {};
+
+    uint16_t mac5; ///< The FEB number this strip is in
+    unsigned planeID; ///< The plane ID (0 or 1 for horizontal or vertical)
+    SiPMData sipm0; ///< One SiPM (the one that sees signal first) 
+    SiPMData sipm1; ///< One SiPM
+    bool sipm_coinc; ///< Stores the ID of the SiPM that sees signal first (0-31)
+    sim::AuxDetIDE ide; ///< The AuxDetIDE associated with this strip
 };
 
-// struct ModuleData {
-//     uint16_t mac5;
-//     std::vector<uint16_t> adcs;
-//     std::vector<uint64_t> times;
-// };
-
-struct Tagger {
-  // std::vector<uint32_t> mac5;
-  // std::vector<unsigned> planeID;
-  // std::vector<uint32_t> time;
-  std::vector<StripData> data;
-  // std::vector<sim::AuxDetIDE> ide;
+struct sbnd::crt::Tagger {
+  std::vector<StripData> data; ///< A vector of strips that have energy deposits
+  /** \brief Returns the number of strips with energy deposits for this tagger */
   int size() {return data.size();}
 };
 
@@ -119,14 +105,8 @@ class sbnd::crt::CRTDetSimAlg {
 
 public:
 
-<<<<<<< Updated upstream
-    CRTDetSimAlg(fhicl::ParameterSet const & p, CLHEP::HepRandomEngine& fRandEngine);
-    void reconfigure(fhicl::ParameterSet const & p);
-
-=======
     using Parameters = fhicl::Table<CRTDetSimParams>;
     CRTDetSimAlg(const Parameters & p, CLHEP::HepRandomEngine& fRandEngine, double g4RefTime);
->>>>>>> Stashed changes
 
     /**
      * Function to clear member data at beginning of each art::event
@@ -173,46 +153,6 @@ public:
 
 private:
 
-<<<<<<< Updated upstream
-    double fGlobalT0Offset;  //!< Time delay fit: Gaussian normalization
-    double fTDelayNorm;  //!< Time delay fit: Gaussian normalization
-    double fTDelayShift;  //!< Time delay fit: Gaussian x shift
-    double fTDelaySigma;  //!< Time delay fit: Gaussian width
-    double fTDelayOffset;  //!< Time delay fit: Gaussian baseline offset
-    double fTDelayRMSGausNorm;  //!< Time delay RMS fit: Gaussian normalization
-    double fTDelayRMSGausShift;  //!< Time delay RMS fit: Gaussian x shift
-    double fTDelayRMSGausSigma;  //!< Time delay RMS fit: Gaussian width
-    double fTDelayRMSExpNorm;  //!< Time delay RMS fit: Exponential normalization
-    double fTDelayRMSExpShift;  //!< Time delay RMS fit: Exponential x shift
-    double fTDelayRMSExpScale;  //!< Time delay RMS fit: Exponential scale
-    double fClockSpeedCRT; //!< Clock speed for the CRT system [MHz]
-    double fNpeScaleNorm;  //!< Npe vs. distance: 1/r^2 scale
-    double fNpeScaleShift;  //!< Npe vs. distance: 1/r^2 x shift
-    double fQ0;  //!< Average energy deposited for mips, for charge scaling [GeV]
-    double fQPed;  //!< ADC offset for the single-peak peak mean [ADC]
-    double fQSlope;  //!< Slope in mean ADC / Npe [ADC]
-    double fQRMS;  //!< ADC single-pe spectrum width [ADC]
-    double fQThreshold;  //!< ADC charge threshold [ADC]
-    double fTResInterpolator;  //!< Interpolator time resolution [ns]
-    double fPropDelay;  //!< Delay in pulse arrival time [ns/m]
-    double fPropDelayError;  //!< Delay in pulse arrival time, uncertainty [ns/m]
-    double fStripCoincidenceWindow;  //!< Time window for two-fiber coincidence [ns]
-    double fTaggerPlaneCoincidenceWindow;  //!< Time window for two-plane coincidence [ticks]
-    double fAbsLenEff;  //!< Effective abs. length for transverse Npe scaling [cm]
-    bool fUseEdep;  //!< Use the true G4 energy deposited, assume mip if false.
-    double fSipmTimeResponse; //!< Minimum time to resolve separate energy deposits [ns]
-    uint32_t fAdcSaturation; //!< Saturation limit per SiPM in ADC counts
-    double fDeadTime; //!< Saturation limit per SiPM in ADC counts
-    std::vector<double> fWaveformX; //!< SiPM waveform sampled, X
-    std::vector<double> fWaveformY; //!< SiPM waveform sampled, Y
-
-    CLHEP::HepRandomEngine& fEngine;
-
-    std::unique_ptr<ROOT::Math::Interpolator> fInterpolator;
-
-    // A list of hit taggers, before any coincidence requirement (mac5 -> tagger)
-    std::map<std::string, Tagger> fTaggers;
-=======
     CRTDetSimParams fParams; //!< The table of CRT simulation parameters
 
     CLHEP::HepRandomEngine& fEngine; //!< The random-number engine
@@ -224,7 +164,6 @@ private:
     std::unique_ptr<ROOT::Math::Interpolator> fInterpolator; //!< The interpolator used to estimate the CRT waveform
 
     std::map<std::string, Tagger> fTaggers; // A list of hit taggers, before any coincidence requirement (name -> tagger)
->>>>>>> Stashed changes
 
     // std::vector<sbnd::crt::FEBData> fFEBDatas;
     std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> fData;

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -1,0 +1,152 @@
+#ifndef SBND_CRTDETSIMALG_H
+#define SBND_CRTDETSIMALG_H
+
+// art includes
+#include "art/Framework/Principal/Handle.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "nurandom/RandomUtils/NuRandomService.h"
+
+// larsoft includes
+#include "lardataobj/Simulation/AuxDetSimChannel.h"
+#include "larcore/Geometry/Geometry.h"
+#include "larcorealg/Geometry/AuxDetGeo.h"
+#include "larcore/Geometry/AuxDetGeometry.h"
+#include "larcorealg/CoreUtils/NumericUtils.h"
+
+// CLHEP includes
+#include "CLHEP/Random/RandomEngine.h"
+#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandGauss.h"
+#include "CLHEP/Random/RandPoisson.h"
+
+//C++ includes
+#include <cmath>
+#include <map>
+#include <set>
+#include <vector>
+#include <string>
+#include <utility>
+
+// ROOT includes
+#include "TGeoManager.h"
+#include "TGeoNode.h"
+
+// CRT includes
+#include "sbnobj/SBND/CRT/CRTData.hh"
+
+using std::vector;
+using std::pair;
+using std::map;
+using std::set;
+using std::string;
+using sim::AuxDetIDE;
+
+namespace sbnd {
+    namespace crt {
+        class CRTDetSimAlg;
+    }
+}
+
+struct Tagger {
+  std::vector<std::pair<unsigned, uint32_t> > planesHit;
+  std::vector<sbnd::crt::CRTData> data;
+  std::vector<std::vector<sim::AuxDetIDE>> ides;
+};
+
+
+
+class sbnd::crt::CRTDetSimAlg {
+
+public:
+
+    CRTDetSimAlg(fhicl::ParameterSet const & p, CLHEP::HepRandomEngine& fRandEngine);
+    void reconfigure(fhicl::ParameterSet const & p);
+
+
+    /**
+       * Function to clear member data at beginning of each art::event
+       */
+    void ClearTaggers();
+
+
+    /**
+       * Filles CRT taggers from AuxDetSimChannels.
+       *
+       * Intented to be called within loop over AuxDetChannels and provided the
+       * AuxDetChannelID, AuxDetSensitiveChannelID, vector of AuxDetIDEs and
+       * the number of ides from the end of the vector to include in the detector sim.
+       * It handles deposited energy ti light output at SiPM (including attenuation)
+       * and to PEs from the SiPM with associated time stamps.
+       *
+       * @param adid The AuxDetChannelID
+       * @param adsid The AuxDetSensitiveChannelID
+       * @param ides The vector of AuxDetIDE
+       */
+    void FillTaggers(const uint32_t adid, const uint32_t adsid, vector<AuxDetIDE> ides);
+
+    /**
+       * Returns CRTData objects.
+       *
+       * This function is called after loop over AuxDetSimChannels where FillTaggers
+       * was used to perform first detsim step. This function applies trigger logic,
+       * deadtime, and close-in-time signal biasing effects. it produces the
+       * "triggered data" products which make it into the event.
+       *
+       * @return Vector of pairs (CRTData, vector of AuxDetIDE)
+       */
+    std::vector<std::pair<sbnd::crt::CRTData, std::vector<AuxDetIDE>>> CreateData();
+
+
+private:
+
+    double fGlobalT0Offset;  //!< Time delay fit: Gaussian normalization
+    double fTDelayNorm;  //!< Time delay fit: Gaussian normalization
+    double fTDelayShift;  //!< Time delay fit: Gaussian x shift
+    double fTDelaySigma;  //!< Time delay fit: Gaussian width
+    double fTDelayOffset;  //!< Time delay fit: Gaussian baseline offset
+    double fTDelayRMSGausNorm;  //!< Time delay RMS fit: Gaussian normalization
+    double fTDelayRMSGausShift;  //!< Time delay RMS fit: Gaussian x shift
+    double fTDelayRMSGausSigma;  //!< Time delay RMS fit: Gaussian width
+    double fTDelayRMSExpNorm;  //!< Time delay RMS fit: Exponential normalization
+    double fTDelayRMSExpShift;  //!< Time delay RMS fit: Exponential x shift
+    double fTDelayRMSExpScale;  //!< Time delay RMS fit: Exponential scale
+    double fClockSpeedCRT; //!< Clock speed for the CRT system [MHz]
+    double fNpeScaleNorm;  //!< Npe vs. distance: 1/r^2 scale
+    double fNpeScaleShift;  //!< Npe vs. distance: 1/r^2 x shift
+    double fQ0;  //!< Average energy deposited for mips, for charge scaling [GeV]
+    double fQPed;  //!< ADC offset for the single-peak peak mean [ADC]
+    double fQSlope;  //!< Slope in mean ADC / Npe [ADC]
+    double fQRMS;  //!< ADC single-pe spectrum width [ADC]
+    double fQThreshold;  //!< ADC charge threshold [ADC]
+    double fTResInterpolator;  //!< Interpolator time resolution [ns]
+    double fPropDelay;  //!< Delay in pulse arrival time [ns/m]
+    double fPropDelayError;  //!< Delay in pulse arrival time, uncertainty [ns/m]
+    double fStripCoincidenceWindow;  //!< Time window for two-fiber coincidence [ns]
+    double fTaggerPlaneCoincidenceWindow;  //!< Time window for two-plane coincidence [ticks]
+    double fAbsLenEff;  //!< Effective abs. length for transverse Npe scaling [cm]
+    bool fUseEdep;  //!< Use the true G4 energy deposited, assume mip if false.
+    double fSipmTimeResponse; //!< Minimum time to resolve separate energy deposits [ns]
+    uint32_t fAdcSaturation; //!< Saturation limit per SiPM in ADC counts
+
+    CLHEP::HepRandomEngine& fEngine;
+
+    // A list of hit taggers, before any coincidence requirement (mac5 -> tagger)
+    std::map<std::string, Tagger> fTaggers;
+
+    /**
+       * Get the channel trigger time relative to the start of the MC event.
+       *
+       * @param engine The random number generator engine
+       * @param clock The clock to count ticks on
+       * @param t0 The starting time (which delay is added to)
+       * @param npe Number of observed photoelectrons
+       * @param r Distance between the energy deposit and strip readout end [mm]
+       * @return Trigger clock ticks at this true hit time
+       */
+    uint32_t getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
+                                    /*detinfo::ElecClock& clock,*/
+                                    float t0, float npeMean, float r);
+
+};
+
+#endif

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -32,6 +32,7 @@
 // ROOT includes
 #include "TGeoManager.h"
 #include "TGeoNode.h"
+#include "Math/Interpolator.h"
 
 // CRT includes
 #include "sbnobj/SBND/CRT/FEBData.hh"
@@ -193,8 +194,12 @@ private:
     double fSipmTimeResponse; //!< Minimum time to resolve separate energy deposits [ns]
     uint32_t fAdcSaturation; //!< Saturation limit per SiPM in ADC counts
     double fDeadTime; //!< Saturation limit per SiPM in ADC counts
+    std::vector<double> fWaveformX; //!< SiPM waveform sampled, X
+    std::vector<double> fWaveformY; //!< SiPM waveform sampled, Y
 
     CLHEP::HepRandomEngine& fEngine;
+
+    std::unique_ptr<ROOT::Math::Interpolator> fInterpolator;
 
     // A list of hit taggers, before any coincidence requirement (mac5 -> tagger)
     std::map<std::string, Tagger> fTaggers;

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -190,6 +190,22 @@ public:
                                     float t0, float npeMean, float r);
 
 
+    /**
+     * Simulated the CRT charge response. Does not include waveform emulation.
+     *
+     * @param eDep The simulated energy deposited on the strip from G4
+     * @param d0 The distance to the optical fiber connected to SiPM 0
+     * @param d1 The distance to the optical fiber connected to SiPM 1
+     * @param distToReadout The distance to the readout
+     * @param npe0 The output number of PEs for SiPM 0
+     * @param npe1 The output number of PEs for SiPM 1
+     * @param q0 The output ADC simulated value (double) for SiPM 0
+     * @param q1 The output ADC simulated value (double) for SiPM 1
+     */
+    void ChargeResponse(double eDep, double d0, double d1, double distToReadout,
+                        long & npe0, long & npe1, double & q0, double & q1);
+
+
 
 private:
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -12,6 +12,7 @@
 #include "larcorealg/Geometry/AuxDetGeo.h"
 #include "larcore/Geometry/AuxDetGeometry.h"
 #include "larcorealg/CoreUtils/NumericUtils.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
 
 // CLHEP includes
 #include "CLHEP/Random/RandomEngine.h"
@@ -119,37 +120,46 @@ public:
 
 
     /**
-       * Function to clear member data at beginning of each art::event
-       */
+     * Function to clear member data at beginning of each art::event
+     */
     void ClearTaggers();
 
 
     /**
-       * Filles CRT taggers from AuxDetSimChannels.
-       *
-       * Intented to be called within loop over AuxDetChannels and provided the
-       * AuxDetChannelID, AuxDetSensitiveChannelID, vector of AuxDetIDEs and
-       * the number of ides from the end of the vector to include in the detector sim.
-       * It handles deposited energy ti light output at SiPM (including attenuation)
-       * and to PEs from the SiPM with associated time stamps.
-       *
-       * @param adid The AuxDetChannelID
-       * @param adsid The AuxDetSensitiveChannelID
-       * @param ides The vector of AuxDetIDE
-       */
+     * Filles CRT taggers from AuxDetSimChannels.
+     *
+     * Intented to be called within loop over AuxDetChannels and provided the
+     * AuxDetChannelID, AuxDetSensitiveChannelID, vector of AuxDetIDEs and
+     * the number of ides from the end of the vector to include in the detector sim.
+     * It handles deposited energy ti light output at SiPM (including attenuation)
+     * and to PEs from the SiPM with associated time stamps.
+     *
+     * @param adid The AuxDetChannelID
+     * @param adsid The AuxDetSensitiveChannelID
+     * @param ides The vector of AuxDetIDE
+     */
     void FillTaggers(const uint32_t adid, const uint32_t adsid, vector<AuxDetIDE> ides);
 
     /**
-       * Returns FEBData objects.
-       *
-       * This function is called after loop over AuxDetSimChannels where FillTaggers
-       * was used to perform first detsim step. This function applies trigger logic,
-       * deadtime, and close-in-time signal biasing effects. it produces the
-       * "triggered data" products which make it into the event.
-       *
-       * @return Vector of pairs (FEBData, vector of AuxDetIDE)
-       */
-    std::vector<std::pair<sbnd::crt::CRTData, std::vector<AuxDetIDE>>> CreateData();
+     * Returns FEBData objects.
+     *
+     * This function is called after loop over AuxDetSimChannels where FillTaggers
+     * was used to perform first detsim step. This function applies trigger logic,
+     * deadtime, and close-in-time signal biasing effects. it produces the
+     * "triggered data" products which make it into the event. Use "GetData"
+     * to retrieve the result.
+     *
+     * @return Vector of pairs (FEBData, vector of AuxDetIDE)
+     */
+    void CreateData();
+
+    /**
+     * Returns the simulated FEBData and AuxDetIDEs
+     *
+     * @return Vector of pairs (FEBData, vector of AuxDetIDE)
+     */
+    std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> GetData();
+
 
 
 private:
@@ -190,6 +200,7 @@ private:
     std::map<std::string, Tagger> fTaggers;
 
     std::vector<sbnd::crt::FEBData> fFEBDatas;
+    std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> fData;
 
     /**
        * Get the channel trigger time relative to the start of the MC event.

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -207,9 +207,7 @@ private:
                                     /*detinfo::ElecClock& clock,*/
                                     float t0, float npeMean, float r);
 
-    void ProcessStrips(/*const uint32_t & trigger_ts1,
-                       const uint32_t & trigger_ts0,*/
-                       const uint32_t & coinc,
+    void ProcessStrips(const uint32_t & coinc,
                        const std::vector<StripData> & strips,
                        const std::string & tagger_name);
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -206,6 +206,27 @@ public:
                         long & npe0, long & npe1, double & q0, double & q1);
 
 
+    /**
+     * Emulated the CRT slow-shaped waveform. This is not a full waveform simulation,
+     * but it tries to encapsulate the main effect of the waveform, which is that the ADC
+     * counts are reduced if the signal arrives with a time delay w.r.t. the primary event
+     * trigger.
+     *
+     * @param time_delay The time delay of this SiPM signal w.r.t. the primary event trigger.
+     * @param adc The simulated ADC counts (double) of this SiPM.
+     * @return The simulated ADC counts after waveform emulation (in uint16_t format).
+     */
+    uint16_t WaveformEmulation(const uint32_t & time_delay, const double & adc);
+
+
+    /**
+     * Returns the CRT simulation parmeters
+     *
+     * @return The CRT simulation parameters
+     */
+    const CRTDetSimParams & Params() {return fParams;}
+
+
 
 private:
 
@@ -242,18 +263,6 @@ private:
      * @param strips The set of strips that belong to the same trigger
      */
     void ProcessStrips(const std::vector<StripData> & strips);
-
-    /**
-     * Emulated the CRT slow-shaped waveform. This is not a full waveform simulation,
-     * but it tries to encapsulate the main effect of the waveform, which is that the ADC
-     * counts are reduced if the signal arrives with a time delay w.r.t. the primary event
-     * trigger.
-     *
-     * @param time_delay The time delay of this SiPM signal w.r.t. the primary event trigger.
-     * @param adc The simulated ADC counts (double) of this SiPM.
-     * @return The simulated ADC counts after waveform emulation (in uint16_t format).
-     */
-    uint16_t WaveformEmulation(const uint32_t & time_delay, const double & adc);
 
     /**
      * Adds ADCs to a certain SiPM in a FEBData object

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -179,40 +179,71 @@ private:
 
     CLHEP::HepRandomEngine& fEngine; //!< The random-number engine
 
-    double fG4RefTime;
-
-    double fTimeOffset;
+    double fG4RefTime; //!< The G4 reference time that can be used as a time offset
+    double fTimeOffset; //!< The time that will be used in the simulation
 
     std::unique_ptr<ROOT::Math::Interpolator> fInterpolator; //!< The interpolator used to estimate the CRT waveform
 
-    std::map<std::string, Tagger> fTaggers; // A list of hit taggers, before any coincidence requirement (name -> tagger)
+    std::map<std::string, Tagger> fTaggers; //!< A list of hit taggers, before any coincidence requirement (name -> tagger)
 
-    // std::vector<sbnd::crt::FEBData> fFEBDatas;
-    std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> fData;
+    std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> fData; //!< This member stores the final FEBData for the CRT simulation
 
+    /**
+     * Configures the waveform by reading waveform points from configuration and
+     * setting up the interpolator.
+     */
     void ConfigureWaveform();
+
+    /**
+     * Configures the time offset to use, either a custom number,
+     * of the G4RefTime, depending on user configuration.
+     */
     void ConfigureTimeOffset();
 
     /**
-       * Get the channel trigger time relative to the start of the MC event.
-       *
-       * @param engine The random number generator engine
-       * @param clock The clock to count ticks on
-       * @param t0 The starting time (which delay is added to)
-       * @param npe Number of observed photoelectrons
-       * @param r Distance between the energy deposit and strip readout end [mm]
-       * @return Trigger clock ticks at this true hit time
-       */
+     * Get the channel trigger time relative to the start of the MC event.
+     *
+     * @param engine The random number generator engine
+     * @param clock The clock to count ticks on
+     * @param t0 The starting time (which delay is added to)
+     * @param npe Number of observed photoelectrons
+     * @param r Distance between the energy deposit and strip readout end [mm]
+     * @return Trigger clock ticks at this true hit time
+     */
     uint32_t getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
                                     /*detinfo::ElecClock& clock,*/
                                     float t0, float npeMean, float r);
 
-    void ProcessStrips(const uint32_t & coinc,
-                       const std::vector<StripData> & strips,
-                       const std::string & tagger_name);
+    /**
+     * Proccesses a set of CRT strips that belong to the same trigger. This method
+     * takes as input all the strips that belong to a single CRT tagger-level trigger
+     * and constructs FEBData objects from them.
+     *
+     * @param strips The set of strips that belong to the same trigger
+     */
+    void ProcessStrips(const std::vector<StripData> & strips,
+                       const std::string & tagger_name,
+                       const uint32_t & coinc);
 
+    /**
+     * Emulated the CRT slow-shaped waveform. This is not a full waveform simulation,
+     * but it tries to encapsulate the main effect of the waveform, which is that the ADC
+     * counts are reduced if the signal arrives with a time delay w.r.t. the primary event
+     * trigger.
+     *
+     * @param time_delay The time delay of this SiPM signal w.r.t. the primary event trigger.
+     * @param adc The simulated ADC counts (double) of this SiPM.
+     * @return The simulated ADC counts after waveform emulation (in uint16_t format).
+     */
     uint16_t WaveformEmulation(const uint32_t & time_delay, const double & adc);
 
+    /**
+     * Adds ADCs to a certain SiPM in a FEBData object
+     *
+     * @param feb_data The FEBData object.
+     * @param sipmID The SiPM index (0-31).
+     * @param adc ADC value to be added.
+     */
     void AddADC(sbnd::crt::FEBData & feb_data, const int & sipmID, const uint16_t & adc);
 
 };

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -56,8 +56,7 @@ namespace sbnd {
     }
 }
 
-/** An enum type. 
- *  The documentation block cannot be put after the enum! 
+/** A struct to temporarily store information on a single SiPM.
  */
 struct sbnd::crt::SiPMData {
     SiPMData(int _sipmID, int _channel, uint64_t _t0, uint64_t _t1, double _adc) :
@@ -75,6 +74,8 @@ struct sbnd::crt::SiPMData {
     double adc; ///< The SiPM simulated ADC value in double format
 };
 
+/** A struct to temporarily store information on a single CRT Strip.
+ */
 struct sbnd::crt::StripData {
     StripData(uint16_t _mac5, unsigned _planeID, SiPMData _sipm0, SiPMData _sipm1,
               bool _sipm_coinc, sim::AuxDetIDE _ide) :
@@ -88,19 +89,23 @@ struct sbnd::crt::StripData {
 
     uint16_t mac5; ///< The FEB number this strip is in
     unsigned planeID; ///< The plane ID (0 or 1 for horizontal or vertical)
-    SiPMData sipm0; ///< One SiPM (the one that sees signal first) 
+    SiPMData sipm0; ///< One SiPM (the one that sees signal first)
     SiPMData sipm1; ///< One SiPM
     bool sipm_coinc; ///< Stores the ID of the SiPM that sees signal first (0-31)
     sim::AuxDetIDE ide; ///< The AuxDetIDE associated with this strip
 };
 
+/** A struct to temporarily store information on a CRT Tagger.
+ */
 struct sbnd::crt::Tagger {
-  std::vector<StripData> data; ///< A vector of strips that have energy deposits
-  /** \brief Returns the number of strips with energy deposits for this tagger */
-  int size() {return data.size();}
+    std::vector<StripData> data; ///< A vector of strips that have energy deposits
+
+    /** \brief Returns the number of strips with energy deposits for this tagger */
+    int size() {return data.size();}
 };
 
-
+/** A struct to temporarily store information on a CRT Tagger trigger.
+ */
 struct sbnd::crt::Trigger {
     bool is_bottom;
     bool planeX;
@@ -111,10 +116,12 @@ struct sbnd::crt::Trigger {
         is_bottom = _is_bottom;
     }
 
+    /** \brief Resets this trigger object */
     void reset() {
         planeX = planeY = false;
     }
 
+    /** \brief Tells is a tagger is triggering or not */
     bool tagger_triggered() {
         if (is_bottom) {
             return planeX or planeY;

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -52,6 +52,7 @@ namespace sbnd {
         struct SiPMData;
         struct StripData;
         struct Tagger;
+        struct Trigger;
     }
 }
 
@@ -100,6 +101,27 @@ struct sbnd::crt::Tagger {
 };
 
 
+struct sbnd::crt::Trigger {
+    bool is_bottom;
+    bool planeX;
+    bool planeY;
+
+    Trigger(bool _is_bottom) {
+        planeX = planeY = false;
+        is_bottom = _is_bottom;
+    }
+
+    void reset() {
+        planeX = planeY = false;
+    }
+
+    bool tagger_triggered() {
+        if (is_bottom) {
+            return planeX or planeY;
+        }
+        return planeX and planeY;
+    }
+};
 
 class sbnd::crt::CRTDetSimAlg {
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -185,8 +185,8 @@ private:
                                     /*detinfo::ElecClock& clock,*/
                                     float t0, float npeMean, float r);
 
-    void ProcessStrips(const uint32_t & trigger_ts1,
-                       const uint32_t & trigger_ts0,
+    void ProcessStrips(/*const uint32_t & trigger_ts1,
+                       const uint32_t & trigger_ts0*/,
                        const uint32_t & coinc,
                        const std::vector<StripData> & strips,
                        const std::string & tagger_name);

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -228,9 +228,7 @@ private:
      *
      * @param strips The set of strips that belong to the same trigger
      */
-    void ProcessStrips(const std::vector<StripData> & strips,
-                       const std::string & tagger_name,
-                       const uint32_t & coinc);
+    void ProcessStrips(const std::vector<StripData> & strips);
 
     /**
      * Emulated the CRT slow-shaped waveform. This is not a full waveform simulation,

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -186,7 +186,7 @@ private:
                                     float t0, float npeMean, float r);
 
     void ProcessStrips(/*const uint32_t & trigger_ts1,
-                       const uint32_t & trigger_ts0*/,
+                       const uint32_t & trigger_ts0,*/
                        const uint32_t & coinc,
                        const std::vector<StripData> & strips,
                        const std::string & tagger_name);

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -163,6 +163,13 @@ public:
      */
     std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> GetData();
 
+    /**
+     * Returns the indeces of SiPMs associated to the AuxDetIDEs
+     *
+     * @return Vector of vector (1: FEBs, 2: SiPMs indeces per AuxDetIDE)
+     */
+    std::vector<std::vector<int>> GetAuxData();
+
 
     /**
      * Get the channel trigger time relative to the start of the MC event.
@@ -229,6 +236,8 @@ private:
     std::map<std::string, Tagger> fTaggers; //!< A list of hit taggers, before any coincidence requirement (name -> tagger)
 
     std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> fData; //!< This member stores the final FEBData for the CRT simulation
+
+    std::vector<std::vector<int>> fAuxData; //!< This member stores the indeces of SiPM per AuxDetIDE
 
     /**
      * Configures the waveform by reading waveform points from configuration and

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -177,6 +177,19 @@ public:
     std::vector<std::pair<sbnd::crt::FEBData, std::vector<AuxDetIDE>>> GetData();
 
 
+    /**
+     * Get the channel trigger time relative to the start of the MC event.
+     *
+     * @param clock The clock to count ticks on
+     * @param t0 The starting time (which delay is added to)
+     * @param npe Number of observed photoelectrons
+     * @param r Distance between the energy deposit and strip readout end [mm]
+     * @return Trigger clock ticks at this true hit time
+     */
+    uint32_t getChannelTriggerTicks(/*detinfo::ElecClock& clock,*/
+                                    float t0, float npeMean, float r);
+
+
 
 private:
 
@@ -204,20 +217,6 @@ private:
      * of the G4RefTime, depending on user configuration.
      */
     void ConfigureTimeOffset();
-
-    /**
-     * Get the channel trigger time relative to the start of the MC event.
-     *
-     * @param engine The random number generator engine
-     * @param clock The clock to count ticks on
-     * @param t0 The starting time (which delay is added to)
-     * @param npe Number of observed photoelectrons
-     * @param r Distance between the energy deposit and strip readout end [mm]
-     * @return Trigger clock ticks at this true hit time
-     */
-    uint32_t getChannelTriggerTicks(CLHEP::HepRandomEngine* engine,
-                                    /*detinfo::ElecClock& clock,*/
-                                    float t0, float npeMean, float r);
 
     /**
      * Proccesses a set of CRT strips that belong to the same trigger. This method

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -1,3 +1,15 @@
+/**
+ * \brief Class for SBND CRT detector simulation.
+ *
+ * \details This class performs the SBND CRT detector simulation starting from AuxDetSimChannels.
+ * Each AuxDetSimChannel can be passed to this class by calling method FillTaggers for each
+ * AuxDetSimChannel. Then, the CreateData method performs the CRT detector simulation
+ * (time and charge responde, and triggering).
+ *
+ * \author Andy Mastbaum
+ * \author Marco Del Tutto
+ */
+
 #ifndef SBND_CRTDETSIMALG_H
 #define SBND_CRTDETSIMALG_H
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h
@@ -102,31 +102,6 @@ struct sbnd::crt::Tagger {
     int size() {return data.size();}
 };
 
-/** A struct to temporarily store information on a CRT Tagger trigger.
- */
-struct sbnd::crt::Trigger {
-    bool is_bottom;
-    bool planeX;
-    bool planeY;
-
-    Trigger(bool _is_bottom) {
-        planeX = planeY = false;
-        is_bottom = _is_bottom;
-    }
-
-    /** \brief Resets this trigger object */
-    void reset() {
-        planeX = planeY = false;
-    }
-
-    /** \brief Tells is a tagger is triggering or not */
-    bool tagger_triggered() {
-        if (is_bottom) {
-            return planeX or planeY;
-        }
-        return planeX and planeY;
-    }
-};
 
 class sbnd::crt::CRTDetSimAlg {
 

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -1,3 +1,14 @@
+/**
+ * \brief Class for SBND CRT detector simulation parameters
+ *
+ * \details This class contains all the parameters for the CRT detector simulation.
+ * Note that physics parameters do not have default values,
+ * and all parameters need to be initialized via fhicl.
+ *
+ * \author Andy Mastbaum
+ * \author Marco Del Tutto
+ */
+
 #ifndef SBND_CRTDETSIMPARAMS_H
 #define SBND_CRTDETSIMPARAMS_H
 
@@ -15,163 +26,132 @@ namespace crt
 
     fhicl::Atom<double> GlobalT0Offset {
       fhicl::Name("GlobalT0Offset"),
-      fhicl::Comment("Time delay fit: Gaussian normalization"),
-      // true
+      fhicl::Comment("The global time offset to use for the CRT times"),
     };
     fhicl::Atom<bool> UseG4RefTimeOffset {
       fhicl::Name("UseG4RefTimeOffset"),
-      fhicl::Comment("Time delay fit: Gaussian normalization"),
-      // true
+      fhicl::Comment("Wheater or not to use the G4RefTime as GlobalT0Offset"),
     };
     fhicl::Atom<double> TDelayNorm {
       fhicl::Name("TDelayNorm"),
       fhicl::Comment("Time delay fit: Gaussian normalization"),
-      // true
     };
     fhicl::Atom<double> TDelayShift {
       fhicl::Name("TDelayShift"),
       fhicl::Comment("Time delay fit: Gaussian x shift"),
-      // true
     };
     fhicl::Atom<double> TDelaySigma {
       fhicl::Name("TDelaySigma"),
       fhicl::Comment("Time delay fit: Gaussian width"),
-      // true
     };
     fhicl::Atom<double> TDelayOffset {
       fhicl::Name("TDelayOffset"),
       fhicl::Comment("Time delay fit: Gaussian baseline offset"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSGausNorm {
       fhicl::Name("TDelayRMSGausNorm"),
       fhicl::Comment("Time delay RMS fit: Gaussian normalization"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSGausShift {
       fhicl::Name("TDelayRMSGausShift"),
       fhicl::Comment("Time delay RMS fit: Gaussian x shift"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSGausSigma {
       fhicl::Name("TDelayRMSGausSigma"),
       fhicl::Comment("Time delay fit: Gaussian width"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSExpNorm {
       fhicl::Name("TDelayRMSExpNorm"),
       fhicl::Comment("Time delay RMS fit: Exponential normalization"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSExpShift {
       fhicl::Name("TDelayRMSExpShift"),
       fhicl::Comment("Time delay RMS fit: Exponential x shift"),
-      // true
     };
     fhicl::Atom<double> TDelayRMSExpScale {
       fhicl::Name("TDelayRMSExpScale"),
       fhicl::Comment("Time delay RMS fit: Exponential scale"),
-      // true
     };
     fhicl::Atom<uint32_t> TriggerDelay {
       fhicl::Name("TriggerDelay"),
       fhicl::Comment("Time between signal starts and waveform goes above threshold"),
-      // true
     };
     fhicl::Atom<bool> EqualizeSiPMTimes {
       fhicl::Name("EqualizeSiPMTimes"),
-      fhicl::Comment("Makes the time simulation to the two SiPMs on a strip identical."),
+      fhicl::Comment("Makes the time simulation to the two SiPMs on a strip identical"),
       false
     };
     fhicl::Atom<double> ClockSpeedCRT {
       fhicl::Name("ClockSpeedCRT"),
       fhicl::Comment("Clock speed for the CRT system [MHz]"),
-      // true
     };
     fhicl::Atom<double> NpeScaleNorm {
       fhicl::Name("NpeScaleNorm"),
       fhicl::Comment("Npe vs. distance: 1/r^2 scale"),
-      // true
     };
     fhicl::Atom<double> NpeScaleShift {
       fhicl::Name("NpeScaleShift"),
       fhicl::Comment("Npe vs. distance: 1/r^2 x shift"),
-      // true
     };
     fhicl::Atom<double> Q0 {
       fhicl::Name("Q0"),
       fhicl::Comment("Average energy deposited for mips, for charge scaling [GeV]"),
-      // true
     };
     fhicl::Atom<double> QPed {
       fhicl::Name("QPed"),
       fhicl::Comment("ADC offset for the single-peak peak mean [ADC]"),
-      // true
     };
     fhicl::Atom<double> QSlope {
       fhicl::Name("QSlope"),
       fhicl::Comment("Slope in mean ADC / Npe [ADC]"),
-      // true
     };
     fhicl::Atom<double> QRMS {
       fhicl::Name("QRMS"),
       fhicl::Comment("ADC single-pe spectrum width [ADC]"),
-      // true
     };
     fhicl::Atom<double> QThreshold {
       fhicl::Name("QThreshold"),
       fhicl::Comment("ADC charge threshold [ADC]"),
-      // true
     };
     fhicl::Atom<double> TResInterpolator {
       fhicl::Name("TResInterpolator"),
       fhicl::Comment("Interpolator time resolution [ns]"),
-      // true
     };
     fhicl::Atom<double> PropDelay {
       fhicl::Name("PropDelay"),
       fhicl::Comment("Delay in pulse arrival time [ns/m]"),
-      // true
     };
     fhicl::Atom<double> PropDelayError {
       fhicl::Name("PropDelayError"),
       fhicl::Comment("Delay in pulse arrival time, uncertainty [ns/m]"),
-      // true
     };
     fhicl::Atom<double> StripCoincidenceWindow {
       fhicl::Name("StripCoincidenceWindow"),
       fhicl::Comment("Time window for two-fiber coincidence [ns]"),
-      // true
     };
     fhicl::Atom<double> TaggerPlaneCoincidenceWindow {
       fhicl::Name("TaggerPlaneCoincidenceWindow"),
       fhicl::Comment("Time window for two-plane coincidence [ticks]"),
-      // true
     };
     fhicl::Atom<double> AbsLenEff {
       fhicl::Name("AbsLenEff"),
       fhicl::Comment("Effective abs. length for transverse Npe scaling [cm]"),
-      // true
     };
     fhicl::Atom<bool> UseEdep {
       fhicl::Name("UseEdep"),
       fhicl::Comment("Use the true G4 energy deposited, assume mip if false"),
-      // true
     };
     fhicl::Atom<double> SipmTimeResponse {
       fhicl::Name("SipmTimeResponse"),
       fhicl::Comment("Minimum time to resolve separate energy deposits [ns]"),
-      // true
     };
     fhicl::Atom<uint32_t> AdcSaturation {
       fhicl::Name("AdcSaturation"),
       fhicl::Comment("Saturation limit per SiPM in ADC counts"),
-      // true
     };
     fhicl::Atom<double> DeadTime {
       fhicl::Name("DeadTime"),
-      fhicl::Comment("Saturation limit per SiPM in ADC counts"),
-      // true
+      fhicl::Comment("FEB dead time after a trigger [ns]"),
     };
     fhicl::Sequence<double> WaveformX {
       fhicl::Name("WaveformX"),

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -164,7 +164,11 @@ namespace crt
     fhicl::Atom<bool> DoWaveformEmulation {
       fhicl::Name("DoWaveformEmulation"),
       fhicl::Comment("Weather or not to perform waveform simulation"),
-      true
+    };
+    fhicl::Atom<bool> DebugTrigger {
+      fhicl::Name("DebugTrigger"),
+      fhicl::Comment("If true, prints out additional debug messages for trigger debugging"),
+      false
     };
   };
 }

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -1,0 +1,192 @@
+#ifndef SBND_CRTDETSIMPARAMS_H
+#define SBND_CRTDETSIMPARAMS_H
+
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/OptionalTable.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "fhiclcpp/types/OptionalSequence.h"
+#include "canvas/Utilities/InputTag.h"
+// #include "art/Framework/Core/EDProducer.h"
+
+namespace sbnd
+{
+namespace crt
+{
+  struct CRTDetSimParams
+  {
+    template<class T> using Atom = fhicl::Atom<T>;
+    template<class T> using Sequence = fhicl::Sequence<T>;
+    template<class T> using Table = fhicl::Table<T>;
+    using Comment  = fhicl::Comment;
+    using Name     = fhicl::Name;
+    using string   = std::string;
+    using InputTag = art::InputTag;
+
+    Atom<double> GlobalT0Offset {
+      Name("GlobalT0Offset"),
+      Comment("Time delay fit: Gaussian normalization"),
+      // true
+    };
+    Atom<bool> UseG4RefTimeOffset {
+      Name("UseG4RefTimeOffset"),
+      Comment("Time delay fit: Gaussian normalization"),
+      // true
+    };
+    Atom<double> TDelayNorm {
+      Name("TDelayNorm"),
+      Comment("Time delay fit: Gaussian normalization"),
+      // true
+    };
+    Atom<double> TDelayShift {
+      Name("TDelayShift"),
+      Comment("Time delay fit: Gaussian x shift"),
+      // true
+    };
+    Atom<double> TDelaySigma {
+      Name("TDelaySigma"),
+      Comment("Time delay fit: Gaussian width"),
+      // true
+    };
+    Atom<double> TDelayOffset {
+      Name("TDelayOffset"),
+      Comment("Time delay fit: Gaussian baseline offset"),
+      // true
+    };
+    Atom<double> TDelayRMSGausNorm {
+      Name("TDelayRMSGausNorm"),
+      Comment("Time delay RMS fit: Gaussian normalization"),
+      // true
+    };
+    Atom<double> TDelayRMSGausShift {
+      Name("TDelayRMSGausShift"),
+      Comment("Time delay RMS fit: Gaussian x shift"),
+      // true
+    };
+    Atom<double> TDelayRMSGausSigma {
+      Name("TDelayRMSGausSigma"),
+      Comment("Time delay fit: Gaussian width"),
+      // true
+    };
+    Atom<double> TDelayRMSExpNorm {
+      Name("TDelayRMSExpNorm"),
+      Comment("Time delay RMS fit: Exponential normalization"),
+      // true
+    };
+    Atom<double> TDelayRMSExpShift {
+      Name("TDelayRMSExpShift"),
+      Comment("Time delay RMS fit: Exponential x shift"),
+      // true
+    };
+    Atom<double> TDelayRMSExpScale {
+      Name("TDelayRMSExpScale"),
+      Comment("Time delay RMS fit: Exponential scale"),
+      // true
+    };
+    Atom<uint32_t> TriggerDelay {
+      Name("TriggerDelay"),
+      Comment("Time between signal starts and waveform goes above threshold"),
+      // true
+    };
+    Atom<double> ClockSpeedCRT {
+      Name("ClockSpeedCRT"),
+      Comment("Clock speed for the CRT system [MHz]"),
+      // true
+    };
+    Atom<double> NpeScaleNorm {
+      Name("NpeScaleNorm"),
+      Comment("Npe vs. distance: 1/r^2 scale"),
+      // true
+    };
+    Atom<double> NpeScaleShift {
+      Name("NpeScaleShift"),
+      Comment("Npe vs. distance: 1/r^2 x shift"),
+      // true
+    };
+    Atom<double> Q0 {
+      Name("Q0"),
+      Comment("Average energy deposited for mips, for charge scaling [GeV]"),
+      // true
+    };
+    Atom<double> QPed {
+      Name("QPed"),
+      Comment("ADC offset for the single-peak peak mean [ADC]"),
+      // true
+    };
+    Atom<double> QSlope {
+      Name("QSlope"),
+      Comment("Slope in mean ADC / Npe [ADC]"),
+      // true
+    };
+    Atom<double> QRMS {
+      Name("QRMS"),
+      Comment("ADC single-pe spectrum width [ADC]"),
+      // true
+    };
+    Atom<double> QThreshold {
+      Name("QThreshold"),
+      Comment("ADC charge threshold [ADC]"),
+      // true
+    };
+    Atom<double> TResInterpolator {
+      Name("TResInterpolator"),
+      Comment("Interpolator time resolution [ns]"),
+      // true
+    };
+    Atom<double> PropDelay {
+      Name("PropDelay"),
+      Comment("Delay in pulse arrival time [ns/m]"),
+      // true
+    };
+    Atom<double> PropDelayError {
+      Name("PropDelayError"),
+      Comment("Delay in pulse arrival time, uncertainty [ns/m]"),
+      // true
+    };
+    Atom<double> StripCoincidenceWindow {
+      Name("StripCoincidenceWindow"),
+      Comment("Time window for two-fiber coincidence [ns]"),
+      // true
+    };
+    Atom<double> TaggerPlaneCoincidenceWindow {
+      Name("TaggerPlaneCoincidenceWindow"),
+      Comment("Time window for two-plane coincidence [ticks]"),
+      // true
+    };
+    Atom<double> AbsLenEff {
+      Name("AbsLenEff"),
+      Comment("Effective abs. length for transverse Npe scaling [cm]"),
+      // true
+    };
+    Atom<bool> UseEdep {
+      Name("UseEdep"),
+      Comment("Use the true G4 energy deposited, assume mip if false"),
+      // true
+    };
+    Atom<double> SipmTimeResponse {
+      Name("SipmTimeResponse"),
+      Comment("Minimum time to resolve separate energy deposits [ns]"),
+      // true
+    };
+    Atom<uint32_t> AdcSaturation {
+      Name("AdcSaturation"),
+      Comment("Saturation limit per SiPM in ADC counts"),
+      // true
+    };
+    Atom<double> DeadTime {
+      Name("DeadTime"),
+      Comment("Saturation limit per SiPM in ADC counts"),
+      // true
+    };
+    fhicl::Sequence<double> WaveformX {
+      Name("WaveformX"),
+      Comment("SiPM waveform sampled, X")
+    };
+    fhicl::Sequence<double> WaveformY {
+      Name("WaveformY"),
+      Comment("SiPM waveform sampled, Y")
+    };
+  };
+}
+}
+
+#endif

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -87,6 +87,11 @@ namespace crt
       Comment("Time between signal starts and waveform goes above threshold"),
       // true
     };
+    Atom<bool> EqualizeSiPMTimes {
+      Name("EqualizeSiPMTimes"),
+      Comment("Makes the time simulation to the two SiPMs on a strip identical."),
+      false
+    };
     Atom<double> ClockSpeedCRT {
       Name("ClockSpeedCRT"),
       Comment("Clock speed for the CRT system [MHz]"),

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -5,8 +5,6 @@
 #include "fhiclcpp/types/OptionalTable.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/OptionalSequence.h"
-#include "canvas/Utilities/InputTag.h"
-// #include "art/Framework/Core/EDProducer.h"
 
 namespace sbnd
 {
@@ -14,185 +12,178 @@ namespace crt
 {
   struct CRTDetSimParams
   {
-    template<class T> using Atom = fhicl::Atom<T>;
-    template<class T> using Sequence = fhicl::Sequence<T>;
-    template<class T> using Table = fhicl::Table<T>;
-    using Comment  = fhicl::Comment;
-    using Name     = fhicl::Name;
-    using string   = std::string;
-    using InputTag = art::InputTag;
 
-    Atom<double> GlobalT0Offset {
-      Name("GlobalT0Offset"),
-      Comment("Time delay fit: Gaussian normalization"),
+    fhicl::Atom<double> GlobalT0Offset {
+      fhicl::Name("GlobalT0Offset"),
+      fhicl::Comment("Time delay fit: Gaussian normalization"),
       // true
     };
-    Atom<bool> UseG4RefTimeOffset {
-      Name("UseG4RefTimeOffset"),
-      Comment("Time delay fit: Gaussian normalization"),
+    fhicl::Atom<bool> UseG4RefTimeOffset {
+      fhicl::Name("UseG4RefTimeOffset"),
+      fhicl::Comment("Time delay fit: Gaussian normalization"),
       // true
     };
-    Atom<double> TDelayNorm {
-      Name("TDelayNorm"),
-      Comment("Time delay fit: Gaussian normalization"),
+    fhicl::Atom<double> TDelayNorm {
+      fhicl::Name("TDelayNorm"),
+      fhicl::Comment("Time delay fit: Gaussian normalization"),
       // true
     };
-    Atom<double> TDelayShift {
-      Name("TDelayShift"),
-      Comment("Time delay fit: Gaussian x shift"),
+    fhicl::Atom<double> TDelayShift {
+      fhicl::Name("TDelayShift"),
+      fhicl::Comment("Time delay fit: Gaussian x shift"),
       // true
     };
-    Atom<double> TDelaySigma {
-      Name("TDelaySigma"),
-      Comment("Time delay fit: Gaussian width"),
+    fhicl::Atom<double> TDelaySigma {
+      fhicl::Name("TDelaySigma"),
+      fhicl::Comment("Time delay fit: Gaussian width"),
       // true
     };
-    Atom<double> TDelayOffset {
-      Name("TDelayOffset"),
-      Comment("Time delay fit: Gaussian baseline offset"),
+    fhicl::Atom<double> TDelayOffset {
+      fhicl::Name("TDelayOffset"),
+      fhicl::Comment("Time delay fit: Gaussian baseline offset"),
       // true
     };
-    Atom<double> TDelayRMSGausNorm {
-      Name("TDelayRMSGausNorm"),
-      Comment("Time delay RMS fit: Gaussian normalization"),
+    fhicl::Atom<double> TDelayRMSGausNorm {
+      fhicl::Name("TDelayRMSGausNorm"),
+      fhicl::Comment("Time delay RMS fit: Gaussian normalization"),
       // true
     };
-    Atom<double> TDelayRMSGausShift {
-      Name("TDelayRMSGausShift"),
-      Comment("Time delay RMS fit: Gaussian x shift"),
+    fhicl::Atom<double> TDelayRMSGausShift {
+      fhicl::Name("TDelayRMSGausShift"),
+      fhicl::Comment("Time delay RMS fit: Gaussian x shift"),
       // true
     };
-    Atom<double> TDelayRMSGausSigma {
-      Name("TDelayRMSGausSigma"),
-      Comment("Time delay fit: Gaussian width"),
+    fhicl::Atom<double> TDelayRMSGausSigma {
+      fhicl::Name("TDelayRMSGausSigma"),
+      fhicl::Comment("Time delay fit: Gaussian width"),
       // true
     };
-    Atom<double> TDelayRMSExpNorm {
-      Name("TDelayRMSExpNorm"),
-      Comment("Time delay RMS fit: Exponential normalization"),
+    fhicl::Atom<double> TDelayRMSExpNorm {
+      fhicl::Name("TDelayRMSExpNorm"),
+      fhicl::Comment("Time delay RMS fit: Exponential normalization"),
       // true
     };
-    Atom<double> TDelayRMSExpShift {
-      Name("TDelayRMSExpShift"),
-      Comment("Time delay RMS fit: Exponential x shift"),
+    fhicl::Atom<double> TDelayRMSExpShift {
+      fhicl::Name("TDelayRMSExpShift"),
+      fhicl::Comment("Time delay RMS fit: Exponential x shift"),
       // true
     };
-    Atom<double> TDelayRMSExpScale {
-      Name("TDelayRMSExpScale"),
-      Comment("Time delay RMS fit: Exponential scale"),
+    fhicl::Atom<double> TDelayRMSExpScale {
+      fhicl::Name("TDelayRMSExpScale"),
+      fhicl::Comment("Time delay RMS fit: Exponential scale"),
       // true
     };
-    Atom<uint32_t> TriggerDelay {
-      Name("TriggerDelay"),
-      Comment("Time between signal starts and waveform goes above threshold"),
+    fhicl::Atom<uint32_t> TriggerDelay {
+      fhicl::Name("TriggerDelay"),
+      fhicl::Comment("Time between signal starts and waveform goes above threshold"),
       // true
     };
-    Atom<bool> EqualizeSiPMTimes {
-      Name("EqualizeSiPMTimes"),
-      Comment("Makes the time simulation to the two SiPMs on a strip identical."),
+    fhicl::Atom<bool> EqualizeSiPMTimes {
+      fhicl::Name("EqualizeSiPMTimes"),
+      fhicl::Comment("Makes the time simulation to the two SiPMs on a strip identical."),
       false
     };
-    Atom<double> ClockSpeedCRT {
-      Name("ClockSpeedCRT"),
-      Comment("Clock speed for the CRT system [MHz]"),
+    fhicl::Atom<double> ClockSpeedCRT {
+      fhicl::Name("ClockSpeedCRT"),
+      fhicl::Comment("Clock speed for the CRT system [MHz]"),
       // true
     };
-    Atom<double> NpeScaleNorm {
-      Name("NpeScaleNorm"),
-      Comment("Npe vs. distance: 1/r^2 scale"),
+    fhicl::Atom<double> NpeScaleNorm {
+      fhicl::Name("NpeScaleNorm"),
+      fhicl::Comment("Npe vs. distance: 1/r^2 scale"),
       // true
     };
-    Atom<double> NpeScaleShift {
-      Name("NpeScaleShift"),
-      Comment("Npe vs. distance: 1/r^2 x shift"),
+    fhicl::Atom<double> NpeScaleShift {
+      fhicl::Name("NpeScaleShift"),
+      fhicl::Comment("Npe vs. distance: 1/r^2 x shift"),
       // true
     };
-    Atom<double> Q0 {
-      Name("Q0"),
-      Comment("Average energy deposited for mips, for charge scaling [GeV]"),
+    fhicl::Atom<double> Q0 {
+      fhicl::Name("Q0"),
+      fhicl::Comment("Average energy deposited for mips, for charge scaling [GeV]"),
       // true
     };
-    Atom<double> QPed {
-      Name("QPed"),
-      Comment("ADC offset for the single-peak peak mean [ADC]"),
+    fhicl::Atom<double> QPed {
+      fhicl::Name("QPed"),
+      fhicl::Comment("ADC offset for the single-peak peak mean [ADC]"),
       // true
     };
-    Atom<double> QSlope {
-      Name("QSlope"),
-      Comment("Slope in mean ADC / Npe [ADC]"),
+    fhicl::Atom<double> QSlope {
+      fhicl::Name("QSlope"),
+      fhicl::Comment("Slope in mean ADC / Npe [ADC]"),
       // true
     };
-    Atom<double> QRMS {
-      Name("QRMS"),
-      Comment("ADC single-pe spectrum width [ADC]"),
+    fhicl::Atom<double> QRMS {
+      fhicl::Name("QRMS"),
+      fhicl::Comment("ADC single-pe spectrum width [ADC]"),
       // true
     };
-    Atom<double> QThreshold {
-      Name("QThreshold"),
-      Comment("ADC charge threshold [ADC]"),
+    fhicl::Atom<double> QThreshold {
+      fhicl::Name("QThreshold"),
+      fhicl::Comment("ADC charge threshold [ADC]"),
       // true
     };
-    Atom<double> TResInterpolator {
-      Name("TResInterpolator"),
-      Comment("Interpolator time resolution [ns]"),
+    fhicl::Atom<double> TResInterpolator {
+      fhicl::Name("TResInterpolator"),
+      fhicl::Comment("Interpolator time resolution [ns]"),
       // true
     };
-    Atom<double> PropDelay {
-      Name("PropDelay"),
-      Comment("Delay in pulse arrival time [ns/m]"),
+    fhicl::Atom<double> PropDelay {
+      fhicl::Name("PropDelay"),
+      fhicl::Comment("Delay in pulse arrival time [ns/m]"),
       // true
     };
-    Atom<double> PropDelayError {
-      Name("PropDelayError"),
-      Comment("Delay in pulse arrival time, uncertainty [ns/m]"),
+    fhicl::Atom<double> PropDelayError {
+      fhicl::Name("PropDelayError"),
+      fhicl::Comment("Delay in pulse arrival time, uncertainty [ns/m]"),
       // true
     };
-    Atom<double> StripCoincidenceWindow {
-      Name("StripCoincidenceWindow"),
-      Comment("Time window for two-fiber coincidence [ns]"),
+    fhicl::Atom<double> StripCoincidenceWindow {
+      fhicl::Name("StripCoincidenceWindow"),
+      fhicl::Comment("Time window for two-fiber coincidence [ns]"),
       // true
     };
-    Atom<double> TaggerPlaneCoincidenceWindow {
-      Name("TaggerPlaneCoincidenceWindow"),
-      Comment("Time window for two-plane coincidence [ticks]"),
+    fhicl::Atom<double> TaggerPlaneCoincidenceWindow {
+      fhicl::Name("TaggerPlaneCoincidenceWindow"),
+      fhicl::Comment("Time window for two-plane coincidence [ticks]"),
       // true
     };
-    Atom<double> AbsLenEff {
-      Name("AbsLenEff"),
-      Comment("Effective abs. length for transverse Npe scaling [cm]"),
+    fhicl::Atom<double> AbsLenEff {
+      fhicl::Name("AbsLenEff"),
+      fhicl::Comment("Effective abs. length for transverse Npe scaling [cm]"),
       // true
     };
-    Atom<bool> UseEdep {
-      Name("UseEdep"),
-      Comment("Use the true G4 energy deposited, assume mip if false"),
+    fhicl::Atom<bool> UseEdep {
+      fhicl::Name("UseEdep"),
+      fhicl::Comment("Use the true G4 energy deposited, assume mip if false"),
       // true
     };
-    Atom<double> SipmTimeResponse {
-      Name("SipmTimeResponse"),
-      Comment("Minimum time to resolve separate energy deposits [ns]"),
+    fhicl::Atom<double> SipmTimeResponse {
+      fhicl::Name("SipmTimeResponse"),
+      fhicl::Comment("Minimum time to resolve separate energy deposits [ns]"),
       // true
     };
-    Atom<uint32_t> AdcSaturation {
-      Name("AdcSaturation"),
-      Comment("Saturation limit per SiPM in ADC counts"),
+    fhicl::Atom<uint32_t> AdcSaturation {
+      fhicl::Name("AdcSaturation"),
+      fhicl::Comment("Saturation limit per SiPM in ADC counts"),
       // true
     };
-    Atom<double> DeadTime {
-      Name("DeadTime"),
-      Comment("Saturation limit per SiPM in ADC counts"),
+    fhicl::Atom<double> DeadTime {
+      fhicl::Name("DeadTime"),
+      fhicl::Comment("Saturation limit per SiPM in ADC counts"),
       // true
     };
     fhicl::Sequence<double> WaveformX {
-      Name("WaveformX"),
-      Comment("SiPM waveform sampled, X")
+      fhicl::Name("WaveformX"),
+      fhicl::Comment("SiPM waveform sampled, X")
     };
     fhicl::Sequence<double> WaveformY {
-      Name("WaveformY"),
-      Comment("SiPM waveform sampled, Y")
+      fhicl::Name("WaveformY"),
+      fhicl::Comment("SiPM waveform sampled, Y")
     };
-    Atom<bool> DoWaveformEmulation {
-      Name("DoWaveformEmulation"),
-      Comment("Weather or not to perform waveform simulation"),
+    fhicl::Atom<bool> DoWaveformEmulation {
+      fhicl::Name("DoWaveformEmulation"),
+      fhicl::Comment("Weather or not to perform waveform simulation"),
       true
     };
   };

--- a/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimParams.h
@@ -185,6 +185,11 @@ namespace crt
       Name("WaveformY"),
       Comment("SiPM waveform sampled, Y")
     };
+    Atom<bool> DoWaveformEmulation {
+      Name("DoWaveformEmulation"),
+      Comment("Weather or not to perform waveform simulation"),
+      true
+    };
   };
 }
 }

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -107,16 +107,16 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
 
       // std::cout << "[CRTSlimmer] ADC of " << i << " is " << adc << " (th is " << _adc_threshold << ")" << std::endl;
 
-      // Either one of the two sipms above threshold is enough to save
-      // both sipms
-      if (adcs[i] < _adc_threshold and adcs[i+1] < _adc_threshold) {
-        continue;
-      }
-
-      // // Both sipms need to be above threshold to save them
-      // if (not (adcs[i] >= _adc_threshold and adcs[i+1] >= _adc_threshold) {
+      // // Either one of the two sipms above threshold is enough to save
+      // // both sipms
+      // if (adcs[i] < _adc_threshold and adcs[i+1] < _adc_threshold) {
       //   continue;
       // }
+
+      // Both sipms need to be above threshold to save them
+      if (not (adcs[i] >= _adc_threshold and adcs[i+1] >= _adc_threshold)) {
+        continue;
+      }
 
       // 32 * feb_data->Mac5() + 2 * stripID + 0
       // uint32_t moduleID = feb_data->Mac5();

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -113,6 +113,11 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
         continue;
       }
 
+      // // Both sipms need to be above threshold to save them
+      // if (not (adcs[i] >= _adc_threshold and adcs[i+1] >= _adc_threshold) {
+      //   continue;
+      // }
+
       // 32 * feb_data->Mac5() + 2 * stripID + 0
       // uint32_t moduleID = feb_data->Mac5();
       // uint32_t stripID = std::floor(i / 2);

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -110,8 +110,10 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
   for (size_t feb_i = 0; feb_i < feb_data_v.size(); feb_i++) {
 
     auto const feb_data = feb_data_v[feb_i];
+    mf::LogDebug("CRTSlimmer") << "FEB " << feb_i << " with mac " << feb_data->Mac5() << std::endl;
 
     auto ides = febdata_to_ides.at(feb_data.key());
+    mf::LogDebug("CRTSlimmer") << "We have " << ides.size() << " IDEs." << std::endl;
 
     // Construct a map to go from SiPM ID to the index of the IDE
     // FEBTruthInfo stores, for each AuxDetIDE, a vector containing
@@ -121,6 +123,7 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
     for (size_t ide_i = 0; ide_i < febdata_to_ides.data(feb_i).size(); ide_i++) {
       const sbnd::crt::FEBTruthInfo *fti = febdata_to_ides.data(feb_i)[ide_i];
       sipm_to_ideids[fti->GetChannel()].push_back(ide_i);
+      mf::LogDebug("CRTSlimmer") << "ide_i " << ide_i << " ene " << ides[ide_i]->energyDeposited << " fti->GetChannel() " << fti->GetChannel() << std::endl;
     }
 
     auto adcs = feb_data->ADC();

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -102,27 +102,10 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
 
     for (size_t i = 0; i < adcs.size(); i+=2) {
 
-      // uint16_t & adc_0 = adcs[i];
-      // uint16_t & adc_1 = adcs[i+1];
-
-      // std::cout << "[CRTSlimmer] ADC of " << i << " is " << adc << " (th is " << _adc_threshold << ")" << std::endl;
-
-      // // Either one of the two sipms above threshold is enough to save
-      // // both sipms
-      // if (adcs[i] < _adc_threshold and adcs[i+1] < _adc_threshold) {
-      //   continue;
-      // }
-
       // Both sipms need to be above threshold to save them
       if (not (adcs[i] >= _adc_threshold and adcs[i+1] >= _adc_threshold)) {
         continue;
       }
-
-      // 32 * feb_data->Mac5() + 2 * stripID + 0
-      // uint32_t moduleID = feb_data->Mac5();
-      // uint32_t stripID = std::floor(i / 2);
-      // uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
-      // uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
 
       for (size_t sipm = 0; sipm < 2; sipm++) {
         sbnd::crt::CRTData crt_data = sbnd::crt::CRTData(feb_data->Mac5() * 32 + i + sipm,
@@ -130,8 +113,8 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
                                                          feb_data->Ts1(),
                                                          adcs[i+sipm]);
 
-        std::cout << "[CRTSlimmer] Adding SiPM with mac " << feb_data->Mac5()
-                  << " mapped to channel " << crt_data.Channel() << std::endl;
+        mf::LogDebug("CRTSlimmer") << "Adding SiPM with mac " << feb_data->Mac5()
+                                   << " mapped to channel " << crt_data.Channel() << std::endl;
 
         crt_data_v->emplace_back(std::move(crt_data));
 
@@ -152,7 +135,8 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
     }
   }
 
-  std::cout << "[CRTSlimmer] Creating " << crt_data_v->size() << " CRTData products." << std::endl;
+  mf::LogInfo("CRTSlimmer") << "Creating " << crt_data_v->size()
+                            << " CRTData products." << std::endl;
 
   e.put(std::move(crt_data_v));
   e.put(std::move(crtdata_to_febdata_assns));

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -1,3 +1,13 @@
+/**
+ * \brief Makes sbnd::crt::CRTData from sbnd::crt::FEBData
+ *
+ * \details This class loops over sbnd::crt::FEBData objects and only selects
+ * strips which have both SiPM ADC values above a certain (configurable) threshold.
+ * The two SiPMs in the selected strips are then saved in sbnd::crt::CRTData objects.
+ *
+ * \author Marco Del Tutto
+ */
+
 ////////////////////////////////////////////////////////////////////////
 // Class:       CRTSlimmer
 // Plugin Type: producer (Unknown Unknown)

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -38,6 +38,7 @@
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "sbnobj/SBND/CRT/FEBData.hh"
 #include "sbnobj/SBND/CRT/CRTData.hh"
+#include "sbnobj/SBND/CRT/FEBTruthInfo.hh"
 
 namespace sbnd {
   namespace crt {
@@ -79,7 +80,7 @@ sbnd::crt::CRTSlimmer::CRTSlimmer(fhicl::ParameterSet const& p)
   produces<art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>>();
 
   consumes<std::vector<sbnd::crt::FEBData>>(_feb_data_producer);
-  consumes<art::Assns<sbnd::crt::FEBData, sim::AuxDetIDE>>(_feb_data_producer);
+  consumes<art::Assns<sbnd::crt::FEBData, sim::AuxDetIDE, sbnd::crt::FEBTruthInfo>>(_feb_data_producer);
 }
 
 void sbnd::crt::CRTSlimmer::produce(art::Event& e)
@@ -102,11 +103,25 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
   std::vector<art::Ptr<sbnd::crt::FEBData>> feb_data_v;
   art::fill_ptr_vector(feb_data_v, feb_data_h);
 
-  art::FindManyP<sim::AuxDetIDE> febdata_to_ides (feb_data_h, e, _feb_data_producer);
+  art::FindManyP<sim::AuxDetIDE, sbnd::crt::FEBTruthInfo> febdata_to_ides (feb_data_h, e, _feb_data_producer);
 
   art::PtrMaker<sbnd::crt::CRTData> makeDataPtr(e);
 
-  for (auto const feb_data : feb_data_v) {
+  for (size_t feb_i = 0; feb_i < feb_data_v.size(); feb_i++) {
+
+    auto const feb_data = feb_data_v[feb_i];
+
+    auto ides = febdata_to_ides.at(feb_data.key());
+
+    // Construct a map to go from SiPM ID to the index of the IDE
+    // FEBTruthInfo stores, for each AuxDetIDE, a vector containing
+    // the SiPM IDs contributing to that energy deposit
+    std::map<int, std::vector<int>> sipm_to_ideids;
+    for (size_t j = 0; j < 32; j++) sipm_to_ideids[j] = std::vector<int>();
+    for (size_t ide_i = 0; ide_i < febdata_to_ides.data(feb_i).size(); ide_i++) {
+      const sbnd::crt::FEBTruthInfo *fti = febdata_to_ides.data(feb_i)[ide_i];
+      sipm_to_ideids[fti->GetChannel()].push_back(ide_i);
+    }
 
     auto adcs = feb_data->ADC();
 
@@ -123,7 +138,7 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
                                                          feb_data->Ts1(),
                                                          adcs[i+sipm]);
 
-        mf::LogDebug("CRTSlimmer") << "Adding SiPM with mac " << feb_data->Mac5()
+        mf::LogDebug("CRTSlimmer") << "Adding SiPM " << i + sipm << " with mac " << feb_data->Mac5()
                                    << " mapped to channel " << crt_data.Channel() << std::endl;
 
         crt_data_v->emplace_back(std::move(crt_data));
@@ -134,11 +149,10 @@ void sbnd::crt::CRTSlimmer::produce(art::Event& e)
         crtdata_to_febdata_assns->addSingle(crt_data_p, feb_data);
 
         // Create the association between CRTData and AuxDetIDEs
-        // Note: we should further selects AuxDetIDEs that belong
-        // to a particular strip; this would require an additional
-        // product to do the bookkeping.
-        auto ides = febdata_to_ides.at(feb_data.key());
-        for (auto ide : ides) {
+        auto & ide_ids = sipm_to_ideids[i];
+        for (auto ide_id: ide_ids) {
+          auto ide = ides[ide_id];
+          mf::LogDebug("CRTSlimmer") << "Adding IDE with ID " << ide_id << std::endl;
           crtdata_to_ide_assns->addSingle(crt_data_p, ide);
         }
       }

--- a/sbndcode/CRT/CRTSlimmer_module.cc
+++ b/sbndcode/CRT/CRTSlimmer_module.cc
@@ -1,0 +1,155 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       CRTSlimmer
+// Plugin Type: producer (Unknown Unknown)
+// File:        CRTSlimmer_module.cc
+//
+// Generated at Thu Mar 24 11:27:06 2022 by Marco Del Tutto using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDProducer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "canvas/Persistency/Common/Assns.h"
+#include "art/Persistency/Common/PtrMaker.h"
+
+
+#include <memory>
+#include <math.h>
+
+#include "lardataobj/Simulation/AuxDetSimChannel.h"
+#include "sbnobj/SBND/CRT/FEBData.hh"
+#include "sbnobj/SBND/CRT/CRTData.hh"
+
+namespace sbnd {
+  namespace crt {
+    class CRTSlimmer;
+  }
+}
+
+
+class sbnd::crt::CRTSlimmer : public art::EDProducer {
+public:
+  explicit CRTSlimmer(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  CRTSlimmer(CRTSlimmer const&) = delete;
+  CRTSlimmer(CRTSlimmer&&) = delete;
+  CRTSlimmer& operator=(CRTSlimmer const&) = delete;
+  CRTSlimmer& operator=(CRTSlimmer&&) = delete;
+
+  // Required functions.
+  void produce(art::Event& e) override;
+
+private:
+
+  std::string _feb_data_producer;
+  uint16_t _adc_threshold;
+
+};
+
+
+sbnd::crt::CRTSlimmer::CRTSlimmer(fhicl::ParameterSet const& p)
+  : EDProducer{p}
+  , _feb_data_producer(p.get<std::string>("FEBDataProducer"))
+  , _adc_threshold(p.get<uint16_t>("ADCThreshold"))
+{
+  produces<std::vector<sbnd::crt::CRTData>>();
+  produces<art::Assns<sbnd::crt::CRTData, sbnd::crt::FEBData>>();
+  produces<art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>>();
+
+  consumes<std::vector<sbnd::crt::FEBData>>(_feb_data_producer);
+  consumes<art::Assns<sbnd::crt::FEBData, sim::AuxDetIDE>>(_feb_data_producer);
+}
+
+void sbnd::crt::CRTSlimmer::produce(art::Event& e)
+{
+  // Implementation of required member function here.
+  std::unique_ptr<std::vector<sbnd::crt::CRTData>> crt_data_v(new std::vector<sbnd::crt::CRTData>);
+  std::unique_ptr<art::Assns<sbnd::crt::CRTData, sbnd::crt::FEBData>> crtdata_to_febdata_assns
+      (new art::Assns<sbnd::crt::CRTData, sbnd::crt::FEBData>);
+  std::unique_ptr<art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>> crtdata_to_ide_assns
+      (new art::Assns<sbnd::crt::CRTData, sim::AuxDetIDE>);
+
+  art::Handle<std::vector<sbnd::crt::FEBData>> feb_data_h;
+  e.getByLabel(_feb_data_producer, feb_data_h);
+
+  // make sure hits look good
+  if (!feb_data_h.isValid()) {
+    throw art::Exception(art::errors::Configuration) << "could not locate FEBData." << std::endl;;
+  }
+
+  std::vector<art::Ptr<sbnd::crt::FEBData>> feb_data_v;
+  art::fill_ptr_vector(feb_data_v, feb_data_h);
+
+  art::FindManyP<sim::AuxDetIDE> febdata_to_ides (feb_data_h, e, _feb_data_producer);
+
+  art::PtrMaker<sbnd::crt::CRTData> makeDataPtr(e);
+
+  for (auto const feb_data : feb_data_v) {
+
+    auto adcs = feb_data->ADC();
+
+    for (size_t i = 0; i < adcs.size(); i++) {
+
+      uint16_t & adc = adcs[i];
+
+      if (adc < _adc_threshold) {
+        continue;
+      }
+
+      // 32 * feb_data->Mac5() + 2 * stripID + 0
+      // uint32_t moduleID = feb_data->Mac5();
+      // uint32_t stripID = std::floor(i / 2);
+      // uint32_t channel0ID = 32 * moduleID + 2 * stripID + 0;
+      // uint32_t channel1ID = 32 * moduleID + 2 * stripID + 1;
+
+      sbnd::crt::CRTData crt_data = sbnd::crt::CRTData(feb_data->Mac5() * 32 + i,
+                                                       feb_data->Ts0(),
+                                                       feb_data->Ts1(),
+                                                       adc);
+
+      std::cout << "[CRTSlimmer] Adding SiPM with mac " << feb_data->Mac5()
+                << " mapped to channel " << crt_data.Channel() << std::endl;
+
+      crt_data_v->emplace_back(std::move(crt_data));
+
+      art::Ptr<sbnd::crt::CRTData> crt_data_p = makeDataPtr(crt_data_v->size() - 1);
+
+      // Create the association between CRTData and FEBData
+      crtdata_to_febdata_assns->addSingle(crt_data_p, feb_data);
+
+      // Create the association between CRTData and AuxDetIDEs
+      // Note: we should further selects AuxDetIDEs that belong
+      // to a particular strip; this would require an additional
+      // product to do the bookkeping.
+      auto ides = febdata_to_ides.at(feb_data.key());
+      for (auto ide : ides) {
+        crtdata_to_ide_assns->addSingle(crt_data_p, ide);
+      }
+    }
+  }
+
+  std::cout << "[CRTSlimmer] Creating " << crt_data_v->size() << " CRTData products." << std::endl;
+
+  e.put(std::move(crt_data_v));
+  e.put(std::move(crtdata_to_febdata_assns));
+  e.put(std::move(crtdata_to_ide_assns));
+}
+
+
+
+DEFINE_ART_MODULE(sbnd::crt::CRTSlimmer)
+
+
+

--- a/sbndcode/CRT/CRTTrackProducer_module.cc
+++ b/sbndcode/CRT/CRTTrackProducer_module.cc
@@ -351,8 +351,8 @@ void CRTTrackProducer::produce(art::Event & evt)
   }
 
   mf::LogInfo("CRTTrackProducer")
-    <<"Number of tracks            = "<<"\n"
-    <<"Number of complete tracks   = "<<"\n"
+    <<"Number of tracks            = "<<CRTTrackCol->size()<<"\n"
+    <<"Number of complete tracks   = "<<CRTTrackCol->size()-nIncTrack<<"\n"
     <<"Number of incomplete tracks = "<<nIncTrack;
   
 } // CRTTrackProducer::produce()

--- a/sbndcode/CRT/CRTTrackProducer_module.cc
+++ b/sbndcode/CRT/CRTTrackProducer_module.cc
@@ -344,16 +344,16 @@ void CRTTrackProducer::produce(art::Event & evt)
     }// loop over tzeros
   }
   
+  mf::LogInfo("CRTTrackProducer")
+    <<"Number of tracks            = "<<CRTTrackCol->size()<<"\n"
+    <<"Number of complete tracks   = "<<CRTTrackCol->size()-nIncTrack<<"\n"
+    <<"Number of incomplete tracks = "<<nIncTrack;
+
   //store track collection into event
   if(fStoreTrack == 1){
     evt.put(std::move(CRTTrackCol));
     evt.put(std::move(Trackassn));
   }
-
-  mf::LogInfo("CRTTrackProducer")
-    <<"Number of tracks            = "<<CRTTrackCol->size()<<"\n"
-    <<"Number of complete tracks   = "<<CRTTrackCol->size()-nIncTrack<<"\n"
-    <<"Number of incomplete tracks = "<<nIncTrack;
   
 } // CRTTrackProducer::produce()
 

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -50,6 +50,7 @@ std::map<std::pair<std::string, unsigned>, std::vector<CRTStrip>> CRTHitRecoAlg:
       if(!(t1 >= -driftTimeMuS && t1 <= readoutWindowMuS)) continue;
     }
 
+    std::cout << "[CRTHitRecoAlg] Creating CRTStrip for channels " << crtList[i]->Channel() << ", " << crtList[i+1]->Channel()  << std::endl;
     CRTStrip strip = CreateCRTStrip(crtList[i], crtList[i+1], i);
 
     taggerStrips[strip.tagger].push_back(strip);
@@ -88,6 +89,7 @@ CRTStrip CRTHitRecoAlg::CreateCRTStrip(art::Ptr<sbnd::crt::CRTData> sipm1, art::
   double time = (t1 + t2)/2.;
 
   CRTStrip stripHit = {time, channel, sipmDist.first, sipmDist.second, npe1+npe2, tagger, ind};
+  std::cout << "[CRTHitRecoAlg] Created CRTStrip for channel " << channel << ", tagger " << tagger.first << std::endl;
   return stripHit;
 
 }

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -43,9 +43,9 @@ std::map<std::pair<std::string, unsigned>, std::vector<CRTStrip>> CRTHitRecoAlg:
   for (size_t i = 0; i < crtList.size(); i+=2){
 
     // Get the time
-    //fTrigClock.SetTime(crtList[i]->T0());
+    //fTrigClock.SetTime(crtList[i]->T1());
     //double t1 = fTrigClock.Time(); // [us]
-    double t1 = (double)(int)crtList[i]->T0()/fClockSpeedCRT; // [tick -> us]
+    double t1 = (double)(int)crtList[i]->T1()/fClockSpeedCRT; // [tick -> us]
     if(fUseReadoutWindow){
       if(!(t1 >= -driftTimeMuS && t1 <= readoutWindowMuS)) continue;
     }
@@ -65,9 +65,9 @@ std::map<std::pair<std::string, unsigned>, std::vector<CRTStrip>> CRTHitRecoAlg:
 CRTStrip CRTHitRecoAlg::CreateCRTStrip(art::Ptr<sbnd::crt::CRTData> sipm1, art::Ptr<sbnd::crt::CRTData> sipm2, size_t ind){
 
   // Get the time, channel, center and width
-  //fTrigClock.SetTime(sipm1->T0());
+  //fTrigClock.SetTime(sipm1->T1());
   //double t1 = fTrigClock.Time(); // [us]
-  double t1 = (double)(int)sipm1->T0()/fClockSpeedCRT; // [tick -> us]
+  double t1 = (double)(int)sipm1->T1()/fClockSpeedCRT; // [tick -> us]
 
   // Get strip info from the geometry service
   uint32_t channel = sipm1->Channel();
@@ -75,9 +75,9 @@ CRTStrip CRTHitRecoAlg::CreateCRTStrip(art::Ptr<sbnd::crt::CRTData> sipm1, art::
   std::pair<std::string,unsigned> tagger = ChannelToTagger(channel);
 
   // Get the time of hit on the second SiPM
-  //fTrigClock.SetTime(sipm2->T0());
+  //fTrigClock.SetTime(sipm2->T1());
   //double t2 = fTrigClock.Time(); // [us]
-  double t2 = (double)(int)sipm2->T0()/fClockSpeedCRT; // [tick -> us]
+  double t2 = (double)(int)sipm2->T1()/fClockSpeedCRT; // [tick -> us]
 
   // Calculate the number of photoelectrons at each SiPM
   double npe1 = ((double)sipm1->ADC() - fQPed)/fQSlope;

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -50,7 +50,6 @@ std::map<std::pair<std::string, unsigned>, std::vector<CRTStrip>> CRTHitRecoAlg:
       if(!(t1 >= -driftTimeMuS && t1 <= readoutWindowMuS)) continue;
     }
 
-    std::cout << "[CRTHitRecoAlg] Creating CRTStrip for channels " << crtList[i]->Channel() << ", " << crtList[i+1]->Channel()  << std::endl;
     CRTStrip strip = CreateCRTStrip(crtList[i], crtList[i+1], i);
 
     taggerStrips[strip.tagger].push_back(strip);
@@ -89,7 +88,6 @@ CRTStrip CRTHitRecoAlg::CreateCRTStrip(art::Ptr<sbnd::crt::CRTData> sipm1, art::
   double time = (t1 + t2)/2.;
 
   CRTStrip stripHit = {time, channel, sipmDist.first, sipmDist.second, npe1+npe2, tagger, ind};
-  std::cout << "[CRTHitRecoAlg] Created CRTStrip for channel " << channel << ", tagger " << tagger.first << std::endl;
   return stripHit;
 
 }

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -107,12 +107,21 @@ namespace sbnd{
         Comment("Clock speed of the CRT system [MHz]")
       };
 
+      fhicl::Atom<double> TimeOffset {
+        Name("TimeOffset"),
+        Comment("The global time offset to use for the CRT times")
+      };
+      fhicl::Atom<bool> UseG4RefTimeOffset {
+        Name("UseG4RefTimeOffset"),
+        Comment("Wheater or not to use the G4RefTime as GlobalT0Offset"),
+      };
+
     };
 
-    CRTHitRecoAlg(const Config& config);
+    CRTHitRecoAlg(const Config& config, double g4RefTime);
 
-    CRTHitRecoAlg(const fhicl::ParameterSet& pset) :
-      CRTHitRecoAlg(fhicl::Table<Config>(pset, {})()) {}
+    CRTHitRecoAlg(const fhicl::ParameterSet& pset,  double g4RefTime) :
+      CRTHitRecoAlg(fhicl::Table<Config>(pset, {})(), g4RefTime) {}
 
     CRTHitRecoAlg();
 
@@ -161,6 +170,8 @@ namespace sbnd{
     double fNpeScaleShift;
     double fTimeCoincidenceLimit;
     double fClockSpeedCRT;
+    double fTimeOffset;
+    bool fUseG4RefTimeOffset;
 
   };
 

--- a/sbndcode/CRT/CRTUtils/CRTTrackRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTTrackRecoAlg.cc
@@ -80,15 +80,15 @@ sbn::crt::CRTTrack CRTTrackRecoAlg::FillCrtTrack(sbn::crt::CRTHit hit1, sbn::crt
   sbn::crt::CRTTrack newtr;
 
   newtr.ts0_s         = (hit1.ts0_s + hit2.ts0_s)/2.;
-  newtr.ts0_s_err     = (uint32_t)((hit1.ts0_s - hit2.ts0_s)/2.);
+  newtr.ts0_s_err     = (hit1.ts0_s - hit2.ts0_s)/2.;
   newtr.ts0_ns_h1     = hit1.ts0_ns;
   newtr.ts0_ns_err_h1 = hit1.ts0_ns_corr;
   newtr.ts0_ns_h2     = hit2.ts0_ns;
   newtr.ts0_ns_err_h2 = hit2.ts0_ns_corr;
-  newtr.ts0_ns        = (uint32_t)((hit1.ts0_ns + hit2.ts0_ns)/2.);
-  newtr.ts0_ns_err    = (uint16_t)(sqrt(hit1.ts0_ns_corr*hit1.ts0_ns_corr + hit2.ts0_ns_corr*hit2.ts0_ns_corr)/2.);
-  newtr.ts1_ns        = (int32_t)(((double)(int)hit1.ts1_ns + (double)(int)hit2.ts1_ns)/2.);
-  newtr.ts1_ns_err    = (uint16_t)(sqrt(hit1.ts0_ns_corr*hit1.ts0_ns_corr + hit2.ts0_ns_corr*hit2.ts0_ns_corr)/2.);
+  newtr.ts0_ns        = (hit1.ts0_ns + hit2.ts0_ns)/2.;
+  newtr.ts0_ns_err    = sqrt(hit1.ts0_ns_corr*hit1.ts0_ns_corr + hit2.ts0_ns_corr*hit2.ts0_ns_corr)/2.;
+  newtr.ts1_ns        = (hit1.ts1_ns + hit2.ts1_ns)/2.;
+  newtr.ts1_ns_err    = sqrt(hit1.ts0_ns_corr*hit1.ts0_ns_corr + hit2.ts0_ns_corr*hit2.ts0_ns_corr)/2.;
   newtr.peshit        = hit1.peshit+hit2.peshit;
   newtr.x1_pos        = hit1.x_pos;
   newtr.x1_err        = hit1.x_err;

--- a/sbndcode/CRT/CRTUtils/crteventdisplay_sbnd.fcl
+++ b/sbndcode/CRT/CRTUtils/crteventdisplay_sbnd.fcl
@@ -10,7 +10,7 @@ standard_crteventdisplay:
     CRTHitLabel:      "crthit"
     CRTTrackLabel:    "crttrack"
     TPCTrackLabel:    "pandoraTrack"
-    ClockSpeedCRT:    @local::sbnd_crtsim.ClockSpeedCRT
+    ClockSpeedCRT:    @local::sbnd_crtsim.DetSimParams.ClockSpeedCRT
 
     DrawTaggers:          false   
     DrawModules:          false

--- a/sbndcode/CRT/crtsim_sbnd.fcl
+++ b/sbndcode/CRT/crtsim_sbnd.fcl
@@ -13,6 +13,7 @@
 
 #include "detsimmodules_sbnd.fcl"
 #include "crtsimmodules_sbnd.fcl"
+#include "crtslimmer_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 
 
@@ -44,17 +45,18 @@ physics:
   producers:
   {
     rns:       { module_type: "RandomNumberSaver" }
-    crt:       @local::sbnd_crtsim
+    crtsim:    @local::sbnd_crtsim
+    crt:       @local::sbnd_crtslimmer
   }
 
-  #define the producer and filter modules for this path, order matters, 
-  simulate:  [ rns, crt ]
+  #define the producer and filter modules for this path, order matters,
+  simulate:  [ rns, crtsim, crt ]
 
-  #define the output stream, there could be more than one if using filters 
+  #define the output stream, there could be more than one if using filters
   stream1:   [ out1 ]
 
   #ie analyzers and output streams.  these all run simultaneously
-  end_paths: [stream1]  
+  end_paths: [stream1]
 }
 
 # block to define where the output goes.  if you defined a filter in the physics

--- a/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
+++ b/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
@@ -10,6 +10,8 @@ standard_crtsimhitalg:
     UseReadoutWindow:     false  # Only reconstruct hits within central readout window
     TimeCoincidenceLimit: 0.08  # Minimum time between two overlapping hit crt strips [us]
     ClockSpeedCRT:        @local::sbnd_crtsim.DetSimParams.ClockSpeedCRT
+    TimeOffset:           @local::sbnd_crtsim.DetSimParams.GlobalT0Offset
+    UseG4RefTimeOffset:   @local::sbnd_crtsim.DetSimParams.UseG4RefTimeOffset
 }
 
 

--- a/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
+++ b/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
@@ -9,7 +9,7 @@ standard_crtsimhitalg:
     NpeScaleShift:        -1085.0  # Model parameter for correcting distance down strip
     UseReadoutWindow:     false  # Only reconstruct hits within central readout window
     TimeCoincidenceLimit: 0.08  # Minimum time between two overlapping hit crt strips [us]
-    ClockSpeedCRT:        @local::sbnd_crtsim.ClockSpeedCRT
+    ClockSpeedCRT:        @local::sbnd_crtsim.DetSimParams.ClockSpeedCRT
 }
 
 

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -65,6 +65,9 @@ standard_sbnd_crtsimparams: {
 
   WaveformX: [0., 11.83, 18.59, 28.72,  41.40,  51.53,  62.51, 75.]
   WaveformY: [0., 3.412, 12.08, 34.138, 65.646, 84.554, 101.1, 108.3]
+  DoWaveformEmulation: true
+
+  DebugTrigger: true
 }
 
 sbnd_crtsim: {

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -1,20 +1,17 @@
 BEGIN_PROLOG
 
-sbnd_crtsim: {
-  module_type: "sbndcode/CRT/CRTDetSim"
-  G4ModuleLabel: "genericcrt"
-
-  // Global timing offset [ns]
-  // For Corsika cosmics, use 2.76e6 (see corsika_sbnd.fcl)
+standard_sbnd_crtsimparams: {
+  # Global timing offset [ns]
+  # For Corsika cosmics, use 2.76e6 (see corsika_sbnd.fcl)
   GlobalT0Offset: 0.0
 
-  // Shape parameters for mean time delay vs. Npe
+  # Shape parameters for mean time delay vs. Npe
   TDelayNorm: 4125.74
   TDelayShift: -300.31
   TDelaySigma: 90.392
   TDelayOffset: -1.525
 
-  // Shape parameters for time delay RMS vs. Npe  
+  # Shape parameters for time delay RMS vs. Npe
   TDelayRMSGausNorm: 2.09138
   TDelayRMSGausShift: 7.23993
   TDelayRMSGausSigma: 170.027
@@ -22,44 +19,50 @@ sbnd_crtsim: {
   TDelayRMSExpShift: 75.6183
   TDelayRMSExpScale: 79.3543
 
-  // Clock speed of the CRT system [MHz] (1 ns = 1 tick @ 1000 MHz)
-  // (was 16 MHz for files before v08_25_00)
+  # Clock speed of the CRT system [MHz] (1 ns = 1 tick @ 1000 MHz)
+  # (was 16 MHz for files before v08_25_00)
   ClockSpeedCRT: 1000.
 
-  // Propagation delay [ns/cm]
+  # Propagation delay [ns/cm]
   PropDelay: 0.0061
   fPropDelayError: 0.007
 
-  // Interpolator time resolution [ns]
+  # Interpolator time resolution [ns]
   TResInterpolator: 1.268
 
-  // Model parameters for Npe vs. distance along strip
+  # Model parameters for Npe vs. distance along strip
   NpeScaleNorm: 8.023e7 #5.261e7
   NpeScaleShift: -1085.0
 
-  // Mean deposited charge for mips [GeV]
+  # Mean deposited charge for mips [GeV]
   UseEdep: true
   Q0: 1.75e-3
 
-  // ADC model: Pedestal offset [ADC], slope [ADC/photon], RMS [ADC]
+  # ADC model: Pedestal offset [ADC], slope [ADC/photon], RMS [ADC]
   QPed: 0.0 #63.6
   QSlope: 40.0 #131.9
   QRMS: 80.0 #15.0
   QThreshold: 60.0 #100
 
-  // Coincidence window for two fibers on a strip [ticks = ns]
+  # Coincidence window for two fibers on a strip [ticks = ns]
   StripCoincidenceWindow: 100.0 #30.0
 
-  // Coincidence for hits in a tagger [ticks = ns]
+  # Coincidence for hits in a tagger [ticks = ns]
   TaggerPlaneCoincidenceWindow: 150.0 #5
 
-  // Effective absorption length (for transverse response) [cm]
+  # Effective absorption length (for transverse response) [cm]
   AbsLenEff: 8.5
 
-  // Minimum time between energy deposits that SiPMs can resolve [ns]
+  # Minimum time between energy deposits that SiPMs can resolve [ns]
   SipmTimeResponse: 2.0
 
   AdcSaturation: 4095
+}
+
+sbnd_crtsim: {
+  module_type: "sbndcode/CRT/CRTDetSim"
+  G4ModuleLabel: "genericcrt"
+  DetSimParams: @local::standard_sbnd_crtsimparams
 }
 
 END_PROLOG

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -28,7 +28,7 @@ standard_sbnd_crtsimparams: {
 
   # Propagation delay [ns/cm]
   PropDelay: 0.0061
-  fPropDelayError: 0.007
+  PropDelayError: 0.007
 
   # Interpolator time resolution [ns]
   TResInterpolator: 1.268

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -57,6 +57,8 @@ standard_sbnd_crtsimparams: {
   SipmTimeResponse: 2.0
 
   AdcSaturation: 4095
+
+  DeadTime: 22000
 }
 
 sbnd_crtsim: {

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -4,6 +4,7 @@ standard_sbnd_crtsimparams: {
   # Global timing offset [ns]
   # For Corsika cosmics, use 2.76e6 (see corsika_sbnd.fcl)
   GlobalT0Offset: 0.0
+  UseG4RefTimeOffset: true
 
   # Shape parameters for mean time delay vs. Npe
   TDelayNorm: 4125.74
@@ -18,6 +19,8 @@ standard_sbnd_crtsimparams: {
   TDelayRMSExpNorm: 1.6544
   TDelayRMSExpShift: 75.6183
   TDelayRMSExpScale: 79.3543
+
+  TriggerDelay: 10 # ns
 
   # Clock speed of the CRT system [MHz] (1 ns = 1 tick @ 1000 MHz)
   # (was 16 MHz for files before v08_25_00)

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -67,7 +67,7 @@ standard_sbnd_crtsimparams: {
   WaveformY: [0., 3.412, 12.08, 34.138, 65.646, 84.554, 101.1, 108.3]
   DoWaveformEmulation: true
 
-  DebugTrigger: true
+  DebugTrigger: false
 }
 
 sbnd_crtsim: {

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -59,6 +59,9 @@ standard_sbnd_crtsimparams: {
   AdcSaturation: 4095
 
   DeadTime: 22000
+
+  WaveformX: [0., 11.83, 18.59, 28.72,  41.40,  51.53,  62.51, 75.]
+  WaveformY: [0., 3.412, 12.08, 34.138, 65.646, 84.554, 101.1, 108.3]
 }
 
 sbnd_crtsim: {

--- a/sbndcode/CRT/crtslimmer_sbnd.fcl
+++ b/sbndcode/CRT/crtslimmer_sbnd.fcl
@@ -1,0 +1,10 @@
+BEGIN_PROLOG
+
+sbnd_crtslimmer: {
+  module_type: "CRTSlimmer"
+
+  FEBDataProducer: "crtsim"
+  ADCThreshold: 60
+}
+
+END_PROLOG

--- a/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00.gdml
@@ -14270,92 +14270,92 @@
                 <volume name="volTaggerTopHigh">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopHigh"/>
-                                <physvol>
+                                <physvol copynumber="0">
                                         <volumeref ref="volCRTModule0"/>
                                         <position name="posCRT_module0" unit="cm" x="225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="1">
                                         <volumeref ref="volCRTModule1"/>
                                         <position name="posCRT_module1" unit="cm" x="225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="2">
                                         <volumeref ref="volCRTModule2"/>
                                         <position name="posCRT_module2" unit="cm" x="225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="3">
                                         <volumeref ref="volCRTModule3"/>
                                         <position name="posCRT_module3" unit="cm" x="225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="4">
                                         <volumeref ref="volCRTModule4"/>
                                         <position name="posCRT_module4" unit="cm" x="225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="5">
                                         <volumeref ref="volCRTModule5"/>
                                         <position name="posCRT_module5" unit="cm" x="-225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="6">
                                         <volumeref ref="volCRTModule6"/>
                                         <position name="posCRT_module6" unit="cm" x="-225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="7">
                                         <volumeref ref="volCRTModule7"/>
                                         <position name="posCRT_module7" unit="cm" x="-225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="8">
                                         <volumeref ref="volCRTModule8"/>
                                         <position name="posCRT_module8" unit="cm" x="-225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="9">
                                         <volumeref ref="volCRTModule9"/>
                                         <position name="posCRT_module9" unit="cm" x="-225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="10">
                                         <volumeref ref="volCRTModule10"/>
                                         <position name="posCRT_module10" unit="cm" x="-360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="11">
                                         <volumeref ref="volCRTModule11"/>
                                         <position name="posCRT_module11" unit="cm" x="-180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="12">
                                         <volumeref ref="volCRTModule12"/>
                                         <position name="posCRT_module12" unit="cm" x="0" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="13">
                                         <volumeref ref="volCRTModule13"/>
                                         <position name="posCRT_module13" unit="cm" x="180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="14">
                                         <volumeref ref="volCRTModule14"/>
                                         <position name="posCRT_module14" unit="cm" x="360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="15">
                                         <volumeref ref="volCRTModule15"/>
                                         <position name="posCRT_module15" unit="cm" x="-360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="16">
                                         <volumeref ref="volCRTModule16"/>
                                         <position name="posCRT_module16" unit="cm" x="-180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="17">
                                         <volumeref ref="volCRTModule17"/>
                                         <position name="posCRT_module17" unit="cm" x="0" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="18">
                                         <volumeref ref="volCRTModule18"/>
                                         <position name="posCRT_module18" unit="cm" x="180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="19">
                                         <volumeref ref="volCRTModule19"/>
                                         <position name="posCRT_module19" unit="cm" x="360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14364,92 +14364,92 @@
                 <volume name="volTaggerTopLow">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopLow"/>
-                                <physvol>
+                                <physvol copynumber="20">
                                         <volumeref ref="volCRTModule20"/>
                                         <position name="posCRT_module20" unit="cm" x="225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="21">
                                         <volumeref ref="volCRTModule21"/>
                                         <position name="posCRT_module21" unit="cm" x="225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="22">
                                         <volumeref ref="volCRTModule22"/>
                                         <position name="posCRT_module22" unit="cm" x="225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="23">
                                         <volumeref ref="volCRTModule23"/>
                                         <position name="posCRT_module23" unit="cm" x="225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="24">
                                         <volumeref ref="volCRTModule24"/>
                                         <position name="posCRT_module24" unit="cm" x="225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="25">
                                         <volumeref ref="volCRTModule25"/>
                                         <position name="posCRT_module25" unit="cm" x="-225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="26">
                                         <volumeref ref="volCRTModule26"/>
                                         <position name="posCRT_module26" unit="cm" x="-225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="27">
                                         <volumeref ref="volCRTModule27"/>
                                         <position name="posCRT_module27" unit="cm" x="-225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="28">
                                         <volumeref ref="volCRTModule28"/>
                                         <position name="posCRT_module28" unit="cm" x="-225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="29">
                                         <volumeref ref="volCRTModule29"/>
                                         <position name="posCRT_module29" unit="cm" x="-225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="30">
                                         <volumeref ref="volCRTModule30"/>
                                         <position name="posCRT_module30" unit="cm" x="-360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="31">
                                         <volumeref ref="volCRTModule31"/>
                                         <position name="posCRT_module31" unit="cm" x="-180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="32">
                                         <volumeref ref="volCRTModule32"/>
                                         <position name="posCRT_module32" unit="cm" x="0" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="33">
                                         <volumeref ref="volCRTModule33"/>
                                         <position name="posCRT_module33" unit="cm" x="180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="34">
                                         <volumeref ref="volCRTModule34"/>
                                         <position name="posCRT_module34" unit="cm" x="360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="35">
                                         <volumeref ref="volCRTModule35"/>
                                         <position name="posCRT_module35" unit="cm" x="-360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="36">
                                         <volumeref ref="volCRTModule36"/>
                                         <position name="posCRT_module36" unit="cm" x="-180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="37">
                                         <volumeref ref="volCRTModule37"/>
                                         <position name="posCRT_module37" unit="cm" x="0" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="38">
                                         <volumeref ref="volCRTModule38"/>
                                         <position name="posCRT_module38" unit="cm" x="180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="39">
                                         <volumeref ref="volCRTModule39"/>
                                         <position name="posCRT_module39" unit="cm" x="360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14458,74 +14458,74 @@
                 <volume name="volTaggerSouth">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerSouth"/>
-                                <physvol>
+                                <physvol copynumber="40">
                                         <volumeref ref="volCRTModule40"/>
                                         <position name="posCRT_module40" unit="cm" x="180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="41">
                                         <volumeref ref="volCRTModule41"/>
                                         <position name="posCRT_module41" unit="cm" x="180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="42">
                                         <volumeref ref="volCRTModule42"/>
                                         <position name="posCRT_module42" unit="cm" x="180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="43">
                                         <volumeref ref="volCRTModule43"/>
                                         <position name="posCRT_module43" unit="cm" x="180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="44">
                                         <volumeref ref="volCRTModule44"/>
                                         <position name="posCRT_module44" unit="cm" x="-180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="45">
                                         <volumeref ref="volCRTModule45"/>
                                         <position name="posCRT_module45" unit="cm" x="-180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="46">
                                         <volumeref ref="volCRTModule46"/>
                                         <position name="posCRT_module46" unit="cm" x="-180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="47">
                                         <volumeref ref="volCRTModule47"/>
                                         <position name="posCRT_module47" unit="cm" x="-180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="48">
                                         <volumeref ref="volCRTModule48"/>
                                         <position name="posCRT_module48" unit="cm" x="-270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="49">
                                         <volumeref ref="volCRTModule49"/>
                                         <position name="posCRT_module49" unit="cm" x="-90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="50">
                                         <volumeref ref="volCRTModule50"/>
                                         <position name="posCRT_module50" unit="cm" x="90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="51">
                                         <volumeref ref="volCRTModule51"/>
                                         <position name="posCRT_module51" unit="cm" x="270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="52">
                                         <volumeref ref="volCRTModule52"/>
                                         <position name="posCRT_module52" unit="cm" x="-270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="53">
                                         <volumeref ref="volCRTModule53"/>
                                         <position name="posCRT_module53" unit="cm" x="-90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="54">
                                         <volumeref ref="volCRTModule54"/>
                                         <position name="posCRT_module54" unit="cm" x="90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="55">
                                         <volumeref ref="volCRTModule55"/>
                                         <position name="posCRT_module55" unit="cm" x="270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14534,74 +14534,74 @@
                 <volume name="volTaggerNorth">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerNorth"/>
-                                <physvol>
+                                <physvol copynumber="56">
                                         <volumeref ref="volCRTModule56"/>
                                         <position name="posCRT_module56" unit="cm" x="180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="57">
                                         <volumeref ref="volCRTModule57"/>
                                         <position name="posCRT_module57" unit="cm" x="180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="58">
                                         <volumeref ref="volCRTModule58"/>
                                         <position name="posCRT_module58" unit="cm" x="180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="59">
                                         <volumeref ref="volCRTModule59"/>
                                         <position name="posCRT_module59" unit="cm" x="180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="60">
                                         <volumeref ref="volCRTModule60"/>
                                         <position name="posCRT_module60" unit="cm" x="-180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="61">
                                         <volumeref ref="volCRTModule61"/>
                                         <position name="posCRT_module61" unit="cm" x="-180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="62">
                                         <volumeref ref="volCRTModule62"/>
                                         <position name="posCRT_module62" unit="cm" x="-180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="63">
                                         <volumeref ref="volCRTModule63"/>
                                         <position name="posCRT_module63" unit="cm" x="-180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="64">
                                         <volumeref ref="volCRTModule64"/>
                                         <position name="posCRT_module64" unit="cm" x="-270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="65">
                                         <volumeref ref="volCRTModule65"/>
                                         <position name="posCRT_module65" unit="cm" x="-90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="66">
                                         <volumeref ref="volCRTModule66"/>
                                         <position name="posCRT_module66" unit="cm" x="90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="67">
                                         <volumeref ref="volCRTModule67"/>
                                         <position name="posCRT_module67" unit="cm" x="270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="68">
                                         <volumeref ref="volCRTModule68"/>
                                         <position name="posCRT_module68" unit="cm" x="-270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="69">
                                         <volumeref ref="volCRTModule69"/>
                                         <position name="posCRT_module69" unit="cm" x="-90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="70">
                                         <volumeref ref="volCRTModule70"/>
                                         <position name="posCRT_module70" unit="cm" x="90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="71">
                                         <volumeref ref="volCRTModule71"/>
                                         <position name="posCRT_module71" unit="cm" x="270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14610,84 +14610,84 @@
 				<volume name="volTaggerEast">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerEast"/>
-                                <physvol>
+                                <physvol copynumber="72">
                                         <volumeref ref="volCRTModule72"/>
                                         <position name="posCRT_module72" unit="cm" x="225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="73">
                                         <volumeref ref="volCRTModule73"/>
                                         <position name="posCRT_module73" unit="cm" x="225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="74">
                                         <volumeref ref="volCRTModule74"/>
                                         <position name="posCRT_module74" unit="cm" x="225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="75">
                                         <volumeref ref="volCRTModule75"/>
                                         <position name="posCRT_module75" unit="cm" x="225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="76">
                                         <volumeref ref="volCRTModule76"/>
                                         <position name="posCRT_module76" unit="cm" x="-225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="77">
                                         <volumeref ref="volCRTModule77"/>
                                         <position name="posCRT_module77" unit="cm" x="-225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="78">
                                         <volumeref ref="volCRTModule78"/>
                                         <position name="posCRT_module78" unit="cm" x="-225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="79">
                                         <volumeref ref="volCRTModule79"/>
                                         <position name="posCRT_module79" unit="cm" x="-225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="80">
                                         <volumeref ref="volCRTModule80"/>
                                         <position name="posCRT_module80" unit="cm" x="-360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="81">
                                         <volumeref ref="volCRTModule81"/>
                                         <position name="posCRT_module81" unit="cm" x="-180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="82">
                                         <volumeref ref="volCRTModule82"/>
                                         <position name="posCRT_module82" unit="cm" x="0" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="83">
                                         <volumeref ref="volCRTModule83"/>
                                         <position name="posCRT_module83" unit="cm" x="180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="84">
                                         <volumeref ref="volCRTModule84"/>
                                         <position name="posCRT_module84" unit="cm" x="360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="85">
                                         <volumeref ref="volCRTModule85"/>
                                         <position name="posCRT_module85" unit="cm" x="-360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="86">
                                         <volumeref ref="volCRTModule86"/>
                                         <position name="posCRT_module86" unit="cm" x="-180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="87">
                                         <volumeref ref="volCRTModule87"/>
                                         <position name="posCRT_module87" unit="cm" x="0" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="88">
                                         <volumeref ref="volCRTModule88"/>
                                         <position name="posCRT_module88" unit="cm" x="180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="89">
                                         <volumeref ref="volCRTModule89"/>
                                         <position name="posCRT_module89" unit="cm" x="360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14696,84 +14696,84 @@
                 <volume name="volTaggerWest">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerWest"/>
-                                <physvol>
+                                <physvol copynumber="90">
                                         <volumeref ref="volCRTModule90"/>
                                         <position name="posCRT_module90" unit="cm" x="225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="91">
                                         <volumeref ref="volCRTModule91"/>
                                         <position name="posCRT_module91" unit="cm" x="225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="92">
                                         <volumeref ref="volCRTModule92"/>
                                         <position name="posCRT_module92" unit="cm" x="225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="93">
                                         <volumeref ref="volCRTModule93"/>
                                         <position name="posCRT_module93" unit="cm" x="225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="94">
                                         <volumeref ref="volCRTModule94"/>
                                         <position name="posCRT_module94" unit="cm" x="-225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="95">
                                         <volumeref ref="volCRTModule95"/>
                                         <position name="posCRT_module95" unit="cm" x="-225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="96">
                                         <volumeref ref="volCRTModule96"/>
                                         <position name="posCRT_module96" unit="cm" x="-225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="97">
                                         <volumeref ref="volCRTModule97"/>
                                         <position name="posCRT_module97" unit="cm" x="-225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="98">
                                         <volumeref ref="volCRTModule98"/>
                                         <position name="posCRT_module98" unit="cm" x="-360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="99">
                                         <volumeref ref="volCRTModule99"/>
                                         <position name="posCRT_module99" unit="cm" x="-180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="100">
                                         <volumeref ref="volCRTModule100"/>
                                         <position name="posCRT_module100" unit="cm" x="0" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="101">
                                         <volumeref ref="volCRTModule101"/>
                                         <position name="posCRT_module101" unit="cm" x="180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="102">
                                         <volumeref ref="volCRTModule102"/>
                                         <position name="posCRT_module102" unit="cm" x="360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="103">
                                         <volumeref ref="volCRTModule103"/>
                                         <position name="posCRT_module103" unit="cm" x="-360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="104">
                                         <volumeref ref="volCRTModule104"/>
                                         <position name="posCRT_module104" unit="cm" x="-180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="105">
                                         <volumeref ref="volCRTModule105"/>
                                         <position name="posCRT_module105" unit="cm" x="0" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="106">
                                         <volumeref ref="volCRTModule106"/>
                                         <position name="posCRT_module106" unit="cm" x="180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="107">
                                         <volumeref ref="volCRTModule107"/>
                                         <position name="posCRT_module107" unit="cm" x="360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14782,115 +14782,115 @@
                 <volume name="volTaggerBot">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerBottom"/>
-                        <physvol>
+                        <physvol copynumber="108">
                                 <volumeref ref="volCRTModule108"/>
                                 <position name="posCRT_module108" unit="cm" x="-268.55000000000001" y="445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="109">
                                 <volumeref ref="volCRTModule109"/>
                                 <position name="posCRT_module109" unit="cm" x="-268.55000000000001" y="238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="110">
                                 <volumeref ref="volCRTModule110"/>
                                 <position name="posCRT_module110" unit="cm" x="-356.89999999999998" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
 						</physvol>
-                        <physvol>
+                        <physvol copynumber="111">
                                 <volumeref ref="volCRTModule111"/>
                                 <position name="posCRT_module111" unit="cm" x="-180.40000000000001" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="112">
                                 <volumeref ref="volCRTModule112"/>
                                 <position name="posCRT_module112" unit="cm" x="-52.899999999999999" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="113">
                                 <volumeref ref="volCRTModule113"/>
                                 <position name="posCRT_module113" unit="cm" x="52.899999999999999" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="114">
                                 <volumeref ref="volCRTModule114"/>
                                 <position name="posCRT_module114" unit="cm" x="180.40000000000001" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="115">
                                 <volumeref ref="volCRTModule115"/>
                                 <position name="posCRT_module115" unit="cm" x="356.89999999999998" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="116">
                                 <volumeref ref="volCRTModule116"/>
                                 <position name="posCRT_module116" unit="cm" x="268.55000000000001" y="238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="117">
                                 <volumeref ref="volCRTModule117"/>
                                 <position name="posCRT_module117" unit="cm" x="-268.55000000000001" y="-238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="118">
                                 <volumeref ref="volCRTModule118"/>
                                 <position name="posCRT_module118" unit="cm" x="-268.55000000000001" y="-445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="119">
                                 <volumeref ref="volCRTModule119"/>
                                 <position name="posCRT_module119" unit="cm" x="-356.89999999999998" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="120">
                                 <volumeref ref="volCRTModule120"/>
                                 <position name="posCRT_module120" unit="cm" x="-180.40000000000001" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="121">
                                 <volumeref ref="volCRTModule121"/>
                                 <position name="posCRT_module121" unit="cm" x="-52.899999999999999" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="122">
                                 <volumeref ref="volCRTModule122"/>
                                 <position name="posCRT_module122" unit="cm" x="52.899999999999999" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="123">
                                 <volumeref ref="volCRTModule123"/>
                                 <position name="posCRT_module123" unit="cm" x="180.40000000000001" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="124">
                                 <volumeref ref="volCRTModule124"/>
                                 <position name="posCRT_module124" unit="cm" x="356.89999999999998" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="125">
                                 <volumeref ref="volCRTModule125"/>
                                 <position name="posCRT_module125" unit="cm" x="268.55000000000001" y="-238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="126">
                                 <volumeref ref="volCRTModule126"/>
                                 <position name="posCRT_module126" unit="cm" x="268.55000000000001" y="-445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="127">
                                 <volumeref ref="volCRTModule127"/>
                                 <position name="posCRT_module127" unit="cm" x="-268.5" y="115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="128">
                                 <volumeref ref="volCRTModule128"/>
                                 <position name="posCRT_module128" unit="cm" x="-268.5" y="0" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="129">
                                 <volumeref ref="volCRTModule129"/>
                                 <position name="posCRT_module129" unit="cm" x="-268.5" y="-115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="130">
                                 <volumeref ref="volCRTModule130"/>
                                 <position name="posCRT_module130" unit="cm" x="268.5" y="115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="131">
                                 <volumeref ref="volCRTModule131"/>
                                 <position name="posCRT_module131" unit="cm" x="268.5" y="0" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="132">
                                 <volumeref ref="volCRTModule132"/>
                                 <position name="posCRT_module132" unit="cm" x="268.5" y="-115.175" z="0.59999999999999998"/>
                         </physvol>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_base.gdml
@@ -4426,26 +4426,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopHigh"/>
                         <loop for="CRT_placing_modules" to="4" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleY_l/2" y="(-2*CRTmoduleY_w)+(CRT_placing_modules-0*5)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="9" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleY_l/2" y="(-2*CRTmoduleY_w)+(CRT_placing_modules-1*5)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="14" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleY_w)+(CRT_placing_modules-2*5)*CRTmoduleY_w" y="CRTmoduleY_l/2" z="-CRTmoduleY_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="19" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleY_w)+(CRT_placing_modules-3*5)*CRTmoduleY_w" y="-CRTmoduleY_l/2" z="-CRTmoduleY_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4457,26 +4457,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopLow"/>
                         <loop for="CRT_placing_modules" to="24" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleY_l/2" y="(-2*CRTmoduleY_w)+(CRT_placing_modules-4*5)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="29" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleY_l/2" y="(-2*CRTmoduleY_w)+(CRT_placing_modules-5*5)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="34" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleY_w)+(CRT_placing_modules-6*5)*CRTmoduleY_w" y="CRTmoduleY_l/2" z="-CRTmoduleY_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="39" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleY_w)+(CRT_placing_modules-7*5)*CRTmoduleY_w" y="-CRTmoduleY_l/2" z="-CRTmoduleY_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4488,26 +4488,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerSouth"/>
                         <loop for="CRT_placing_modules" to="43" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleX_l/2" y="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-40)*CRTmoduleX_w" z="CRTmoduleX_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="47" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleX_l/2" y="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-44)*CRTmoduleX_w" z="CRTmoduleX_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="51" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-48)*CRTmoduleX_w" y="CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="55" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-52)*CRTmoduleX_w" y="-CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4519,26 +4519,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerNorth"/>
                         <loop for="CRT_placing_modules" to="59" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleX_l/2" y="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-56)*CRTmoduleX_w" z="CRTmoduleX_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="63" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleX_l/2" y="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-60)*CRTmoduleX_w" z="CRTmoduleX_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="67" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-64)*CRTmoduleX_w" y="CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="71" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-1.5*CRTmoduleX_w)+(CRT_placing_modules-68)*CRTmoduleX_w" y="-CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4550,26 +4550,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerEast"/>
                         <loop for="CRT_placing_modules" to="75" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleY_l/2" y="(-1.5*CRTmoduleY_w)+(CRT_placing_modules-72)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="79" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleY_l/2" y="(-1.5*CRTmoduleY_w)+(CRT_placing_modules-76)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="84" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleX_w)+(CRT_placing_modules-80)*CRTmoduleX_w" y="CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="89" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleX_w)+(CRT_placing_modules-85)*CRTmoduleX_w" y="-CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4581,26 +4581,26 @@
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerWest"/>
                         <loop for="CRT_placing_modules" to="93" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="CRTmoduleY_l/2" y="(-1.5*CRTmoduleY_w)+(CRT_placing_modules-90)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="97" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="-CRTmoduleY_l/2" y="(-1.5*CRTmoduleY_w)+(CRT_placing_modules-94)*CRTmoduleY_w" z="CRTmoduleY_t/2"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="102" step="1"/>
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleX_w)+(CRT_placing_modules-98)*CRTmoduleX_w" y="CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
                         </loop>
                         <loop for="CRT_placing_modules" to="107" step="1">
-                                <physvol>
+                                <physvol copynumber="CRT_placing_modules">
                                         <volumeref ref="volCRTModuleCRT_placing_modules"/>
                                         <position name="posCRT_moduleCRT_placing_modules" unit="cm" x="(-2*CRTmoduleX_w)+(CRT_placing_modules-103)*CRTmoduleX_w" y="-CRTmoduleX_l/2" z="-CRTmoduleX_t/2"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -4613,118 +4613,118 @@
                         <solidref ref="TaggerBottom"/>
 
                         <!-- BERN -->
-                        <physvol>
+                        <physvol copynumber="108">
                                 <volumeref ref="volCRTModule108"/>
                                 <position name="posCRT_module108" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_l/2)" y="BERNmodule_DY_large+(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="109">
                                 <volumeref ref="volCRTModule109"/>
                                 <position name="posCRT_module109" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_l/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="110">
                                 <volumeref ref="volCRTModule110"/>
                                 <position name="posCRT_module110" unit="cm" x="-BERNmodule_DX_large-(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
 						</physvol>
-                        <physvol>
+                        <physvol copynumber="111">
                                 <volumeref ref="volCRTModule111"/>
                                 <position name="posCRT_module111" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
 
-                        <physvol>
+                        <physvol copynumber="112">
                                 <volumeref ref="volCRTModule112"/>
                                 <position name="posCRT_module112" unit="cm" x="-BERNmodule_DX_small-(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="113">
                                 <volumeref ref="volCRTModule113"/>
                                 <position name="posCRT_module113" unit="cm" x="BERNmodule_DX_small+(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="114">
                                 <volumeref ref="volCRTModule114"/>
                                 <position name="posCRT_module114" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="115">
                                 <volumeref ref="volCRTModule115"/>
                                 <position name="posCRT_module115" unit="cm" x="BERNmodule_DX_large+(CRTmoduleBERN_w/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="116">
                                 <volumeref ref="volCRTModule116"/>
                                 <position name="posCRT_module116" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleBERN_l/2)" y="BERNmodule_DY_small+(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
 
-                        <physvol>
+                        <physvol copynumber="117">
                                 <volumeref ref="volCRTModule117"/>
                                 <position name="posCRT_module117" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_l/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="118">
                                 <volumeref ref="volCRTModule118"/>
                                 <position name="posCRT_module118" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_l/2)" y="-BERNmodule_DY_large-(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="119">
                                 <volumeref ref="volCRTModule119"/>
                                 <position name="posCRT_module119" unit="cm" x="-BERNmodule_DX_large-(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="120">
                                 <volumeref ref="volCRTModule120"/>
                                 <position name="posCRT_module120" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="121">
                                 <volumeref ref="volCRTModule121"/>
                                 <position name="posCRT_module121" unit="cm" x="-BERNmodule_DX_small-(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="122">
                                 <volumeref ref="volCRTModule122"/>
                                 <position name="posCRT_module122" unit="cm" x="BERNmodule_DX_small+(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="123">
                                 <volumeref ref="volCRTModule123"/>
                                 <position name="posCRT_module123" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="124">
                                 <volumeref ref="volCRTModule124"/>
                                 <position name="posCRT_module124" unit="cm" x="BERNmodule_DX_large+(CRTmoduleBERN_w/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_l/2)" z="CRTmoduleBERN_t/2"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="125">
                                 <volumeref ref="volCRTModule125"/>
                                 <position name="posCRT_module125" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleBERN_l/2)" y="-BERNmodule_DY_small-(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="126">
                                 <volumeref ref="volCRTModule126"/>
                                 <position name="posCRT_module126" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleBERN_l/2)" y="-BERNmodule_DY_large-(CRTmoduleBERN_w/2)" z="-CRTmoduleBERN_t/2"/>
                         </physvol>
                         <!-- MINOS -->
-                        <physvol>
+                        <physvol copynumber="127">
                                 <volumeref ref="volCRTModule127"/>
                                 <position name="posCRT_module127" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleMINOS_l/2)" y="BERNmodule_DY_small/2+CRTmoduleMINOS_w/4" z="CRTmoduleMINOS_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="128">
                                 <volumeref ref="volCRTModule128"/>
                                 <position name="posCRT_module128" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleMINOS_l/2)" y="0" z="CRTmoduleMINOS_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="129">
                                 <volumeref ref="volCRTModule129"/>
                                 <position name="posCRT_module129" unit="cm" x="-BERNmodule_DX_middle-(CRTmoduleMINOS_l/2)" y="-BERNmodule_DY_small/2-CRTmoduleMINOS_w/4" z="CRTmoduleMINOS_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="130">
                                 <volumeref ref="volCRTModule130"/>
                                 <position name="posCRT_module130" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleMINOS_l/2)" y="BERNmodule_DY_small/2+CRTmoduleMINOS_w/4" z="CRTmoduleMINOS_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="131">
                                 <volumeref ref="volCRTModule131"/>
                                 <position name="posCRT_module131" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleMINOS_l/2)" y="0" z="CRTmoduleMINOS_t/2"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="132">
                                 <volumeref ref="volCRTModule132"/>
                                 <position name="posCRT_module132" unit="cm" x="BERNmodule_DX_middle+(CRTmoduleMINOS_l/2)" y="-BERNmodule_DY_small/2-CRTmoduleMINOS_w/4" z="CRTmoduleMINOS_t/2"/>
                         </physvol>

--- a/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
+++ b/sbndcode/Geometry/gdml/sbnd_v02_00_nowires.gdml
@@ -14270,92 +14270,92 @@
                 <volume name="volTaggerTopHigh">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopHigh"/>
-                                <physvol>
+                                <physvol copynumber="0">
                                         <volumeref ref="volCRTModule0"/>
                                         <position name="posCRT_module0" unit="cm" x="225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="1">
                                         <volumeref ref="volCRTModule1"/>
                                         <position name="posCRT_module1" unit="cm" x="225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="2">
                                         <volumeref ref="volCRTModule2"/>
                                         <position name="posCRT_module2" unit="cm" x="225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="3">
                                         <volumeref ref="volCRTModule3"/>
                                         <position name="posCRT_module3" unit="cm" x="225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="4">
                                         <volumeref ref="volCRTModule4"/>
                                         <position name="posCRT_module4" unit="cm" x="225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="5">
                                         <volumeref ref="volCRTModule5"/>
                                         <position name="posCRT_module5" unit="cm" x="-225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="6">
                                         <volumeref ref="volCRTModule6"/>
                                         <position name="posCRT_module6" unit="cm" x="-225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="7">
                                         <volumeref ref="volCRTModule7"/>
                                         <position name="posCRT_module7" unit="cm" x="-225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="8">
                                         <volumeref ref="volCRTModule8"/>
                                         <position name="posCRT_module8" unit="cm" x="-225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="9">
                                         <volumeref ref="volCRTModule9"/>
                                         <position name="posCRT_module9" unit="cm" x="-225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="10">
                                         <volumeref ref="volCRTModule10"/>
                                         <position name="posCRT_module10" unit="cm" x="-360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="11">
                                         <volumeref ref="volCRTModule11"/>
                                         <position name="posCRT_module11" unit="cm" x="-180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="12">
                                         <volumeref ref="volCRTModule12"/>
                                         <position name="posCRT_module12" unit="cm" x="0" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="13">
                                         <volumeref ref="volCRTModule13"/>
                                         <position name="posCRT_module13" unit="cm" x="180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="14">
                                         <volumeref ref="volCRTModule14"/>
                                         <position name="posCRT_module14" unit="cm" x="360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="15">
                                         <volumeref ref="volCRTModule15"/>
                                         <position name="posCRT_module15" unit="cm" x="-360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="16">
                                         <volumeref ref="volCRTModule16"/>
                                         <position name="posCRT_module16" unit="cm" x="-180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="17">
                                         <volumeref ref="volCRTModule17"/>
                                         <position name="posCRT_module17" unit="cm" x="0" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="18">
                                         <volumeref ref="volCRTModule18"/>
                                         <position name="posCRT_module18" unit="cm" x="180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="19">
                                         <volumeref ref="volCRTModule19"/>
                                         <position name="posCRT_module19" unit="cm" x="360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14364,92 +14364,92 @@
                 <volume name="volTaggerTopLow">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerTopLow"/>
-                                <physvol>
+                                <physvol copynumber="20">
                                         <volumeref ref="volCRTModule20"/>
                                         <position name="posCRT_module20" unit="cm" x="225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="21">
                                         <volumeref ref="volCRTModule21"/>
                                         <position name="posCRT_module21" unit="cm" x="225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="22">
                                         <volumeref ref="volCRTModule22"/>
                                         <position name="posCRT_module22" unit="cm" x="225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="23">
                                         <volumeref ref="volCRTModule23"/>
                                         <position name="posCRT_module23" unit="cm" x="225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="24">
                                         <volumeref ref="volCRTModule24"/>
                                         <position name="posCRT_module24" unit="cm" x="225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="25">
                                         <volumeref ref="volCRTModule25"/>
                                         <position name="posCRT_module25" unit="cm" x="-225" y="-360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="26">
                                         <volumeref ref="volCRTModule26"/>
                                         <position name="posCRT_module26" unit="cm" x="-225" y="-180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="27">
                                         <volumeref ref="volCRTModule27"/>
                                         <position name="posCRT_module27" unit="cm" x="-225" y="0" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="28">
                                         <volumeref ref="volCRTModule28"/>
                                         <position name="posCRT_module28" unit="cm" x="-225" y="180" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="29">
                                         <volumeref ref="volCRTModule29"/>
                                         <position name="posCRT_module29" unit="cm" x="-225" y="360" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="30">
                                         <volumeref ref="volCRTModule30"/>
                                         <position name="posCRT_module30" unit="cm" x="-360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="31">
                                         <volumeref ref="volCRTModule31"/>
                                         <position name="posCRT_module31" unit="cm" x="-180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="32">
                                         <volumeref ref="volCRTModule32"/>
                                         <position name="posCRT_module32" unit="cm" x="0" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="33">
                                         <volumeref ref="volCRTModule33"/>
                                         <position name="posCRT_module33" unit="cm" x="180" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="34">
                                         <volumeref ref="volCRTModule34"/>
                                         <position name="posCRT_module34" unit="cm" x="360" y="225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="35">
                                         <volumeref ref="volCRTModule35"/>
                                         <position name="posCRT_module35" unit="cm" x="-360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="36">
                                         <volumeref ref="volCRTModule36"/>
                                         <position name="posCRT_module36" unit="cm" x="-180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="37">
                                         <volumeref ref="volCRTModule37"/>
                                         <position name="posCRT_module37" unit="cm" x="0" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="38">
                                         <volumeref ref="volCRTModule38"/>
                                         <position name="posCRT_module38" unit="cm" x="180" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="39">
                                         <volumeref ref="volCRTModule39"/>
                                         <position name="posCRT_module39" unit="cm" x="360" y="-225" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14458,74 +14458,74 @@
                 <volume name="volTaggerSouth">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerSouth"/>
-                                <physvol>
+                                <physvol copynumber="40">
                                         <volumeref ref="volCRTModule40"/>
                                         <position name="posCRT_module40" unit="cm" x="180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="41">
                                         <volumeref ref="volCRTModule41"/>
                                         <position name="posCRT_module41" unit="cm" x="180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="42">
                                         <volumeref ref="volCRTModule42"/>
                                         <position name="posCRT_module42" unit="cm" x="180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="43">
                                         <volumeref ref="volCRTModule43"/>
                                         <position name="posCRT_module43" unit="cm" x="180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="44">
                                         <volumeref ref="volCRTModule44"/>
                                         <position name="posCRT_module44" unit="cm" x="-180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="45">
                                         <volumeref ref="volCRTModule45"/>
                                         <position name="posCRT_module45" unit="cm" x="-180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="46">
                                         <volumeref ref="volCRTModule46"/>
                                         <position name="posCRT_module46" unit="cm" x="-180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="47">
                                         <volumeref ref="volCRTModule47"/>
                                         <position name="posCRT_module47" unit="cm" x="-180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="48">
                                         <volumeref ref="volCRTModule48"/>
                                         <position name="posCRT_module48" unit="cm" x="-270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="49">
                                         <volumeref ref="volCRTModule49"/>
                                         <position name="posCRT_module49" unit="cm" x="-90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="50">
                                         <volumeref ref="volCRTModule50"/>
                                         <position name="posCRT_module50" unit="cm" x="90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="51">
                                         <volumeref ref="volCRTModule51"/>
                                         <position name="posCRT_module51" unit="cm" x="270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="52">
                                         <volumeref ref="volCRTModule52"/>
                                         <position name="posCRT_module52" unit="cm" x="-270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="53">
                                         <volumeref ref="volCRTModule53"/>
                                         <position name="posCRT_module53" unit="cm" x="-90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="54">
                                         <volumeref ref="volCRTModule54"/>
                                         <position name="posCRT_module54" unit="cm" x="90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="55">
                                         <volumeref ref="volCRTModule55"/>
                                         <position name="posCRT_module55" unit="cm" x="270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14534,74 +14534,74 @@
                 <volume name="volTaggerNorth">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerNorth"/>
-                                <physvol>
+                                <physvol copynumber="56">
                                         <volumeref ref="volCRTModule56"/>
                                         <position name="posCRT_module56" unit="cm" x="180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="57">
                                         <volumeref ref="volCRTModule57"/>
                                         <position name="posCRT_module57" unit="cm" x="180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="58">
                                         <volumeref ref="volCRTModule58"/>
                                         <position name="posCRT_module58" unit="cm" x="180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="59">
                                         <volumeref ref="volCRTModule59"/>
                                         <position name="posCRT_module59" unit="cm" x="180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="60">
                                         <volumeref ref="volCRTModule60"/>
                                         <position name="posCRT_module60" unit="cm" x="-180" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="61">
                                         <volumeref ref="volCRTModule61"/>
                                         <position name="posCRT_module61" unit="cm" x="-180" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="62">
                                         <volumeref ref="volCRTModule62"/>
                                         <position name="posCRT_module62" unit="cm" x="-180" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="63">
                                         <volumeref ref="volCRTModule63"/>
                                         <position name="posCRT_module63" unit="cm" x="-180" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="64">
                                         <volumeref ref="volCRTModule64"/>
                                         <position name="posCRT_module64" unit="cm" x="-270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="65">
                                         <volumeref ref="volCRTModule65"/>
                                         <position name="posCRT_module65" unit="cm" x="-90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="66">
                                         <volumeref ref="volCRTModule66"/>
                                         <position name="posCRT_module66" unit="cm" x="90" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="67">
                                         <volumeref ref="volCRTModule67"/>
                                         <position name="posCRT_module67" unit="cm" x="270" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="68">
                                         <volumeref ref="volCRTModule68"/>
                                         <position name="posCRT_module68" unit="cm" x="-270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="69">
                                         <volumeref ref="volCRTModule69"/>
                                         <position name="posCRT_module69" unit="cm" x="-90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="70">
                                         <volumeref ref="volCRTModule70"/>
                                         <position name="posCRT_module70" unit="cm" x="90" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="71">
                                         <volumeref ref="volCRTModule71"/>
                                         <position name="posCRT_module71" unit="cm" x="270" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14610,84 +14610,84 @@
 				<volume name="volTaggerEast">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerEast"/>
-                                <physvol>
+                                <physvol copynumber="72">
                                         <volumeref ref="volCRTModule72"/>
                                         <position name="posCRT_module72" unit="cm" x="225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="73">
                                         <volumeref ref="volCRTModule73"/>
                                         <position name="posCRT_module73" unit="cm" x="225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="74">
                                         <volumeref ref="volCRTModule74"/>
                                         <position name="posCRT_module74" unit="cm" x="225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="75">
                                         <volumeref ref="volCRTModule75"/>
                                         <position name="posCRT_module75" unit="cm" x="225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="76">
                                         <volumeref ref="volCRTModule76"/>
                                         <position name="posCRT_module76" unit="cm" x="-225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="77">
                                         <volumeref ref="volCRTModule77"/>
                                         <position name="posCRT_module77" unit="cm" x="-225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="78">
                                         <volumeref ref="volCRTModule78"/>
                                         <position name="posCRT_module78" unit="cm" x="-225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="79">
                                         <volumeref ref="volCRTModule79"/>
                                         <position name="posCRT_module79" unit="cm" x="-225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="80">
                                         <volumeref ref="volCRTModule80"/>
                                         <position name="posCRT_module80" unit="cm" x="-360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="81">
                                         <volumeref ref="volCRTModule81"/>
                                         <position name="posCRT_module81" unit="cm" x="-180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="82">
                                         <volumeref ref="volCRTModule82"/>
                                         <position name="posCRT_module82" unit="cm" x="0" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="83">
                                         <volumeref ref="volCRTModule83"/>
                                         <position name="posCRT_module83" unit="cm" x="180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="84">
                                         <volumeref ref="volCRTModule84"/>
                                         <position name="posCRT_module84" unit="cm" x="360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="85">
                                         <volumeref ref="volCRTModule85"/>
                                         <position name="posCRT_module85" unit="cm" x="-360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="86">
                                         <volumeref ref="volCRTModule86"/>
                                         <position name="posCRT_module86" unit="cm" x="-180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="87">
                                         <volumeref ref="volCRTModule87"/>
                                         <position name="posCRT_module87" unit="cm" x="0" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="88">
                                         <volumeref ref="volCRTModule88"/>
                                         <position name="posCRT_module88" unit="cm" x="180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="89">
                                         <volumeref ref="volCRTModule89"/>
                                         <position name="posCRT_module89" unit="cm" x="360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14696,84 +14696,84 @@
                 <volume name="volTaggerWest">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerWest"/>
-                                <physvol>
+                                <physvol copynumber="90">
                                         <volumeref ref="volCRTModule90"/>
                                         <position name="posCRT_module90" unit="cm" x="225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="91">
                                         <volumeref ref="volCRTModule91"/>
                                         <position name="posCRT_module91" unit="cm" x="225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="92">
                                         <volumeref ref="volCRTModule92"/>
                                         <position name="posCRT_module92" unit="cm" x="225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="93">
                                         <volumeref ref="volCRTModule93"/>
                                         <position name="posCRT_module93" unit="cm" x="225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="94">
                                         <volumeref ref="volCRTModule94"/>
                                         <position name="posCRT_module94" unit="cm" x="-225" y="-270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="95">
                                         <volumeref ref="volCRTModule95"/>
                                         <position name="posCRT_module95" unit="cm" x="-225" y="-90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="96">
                                         <volumeref ref="volCRTModule96"/>
                                         <position name="posCRT_module96" unit="cm" x="-225" y="90" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="97">
                                         <volumeref ref="volCRTModule97"/>
                                         <position name="posCRT_module97" unit="cm" x="-225" y="270" z="0.90000000000000002"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="98">
                                         <volumeref ref="volCRTModule98"/>
                                         <position name="posCRT_module98" unit="cm" x="-360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="99">
                                         <volumeref ref="volCRTModule99"/>
                                         <position name="posCRT_module99" unit="cm" x="-180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="100">
                                         <volumeref ref="volCRTModule100"/>
                                         <position name="posCRT_module100" unit="cm" x="0" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="101">
                                         <volumeref ref="volCRTModule101"/>
                                         <position name="posCRT_module101" unit="cm" x="180" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="102">
                                         <volumeref ref="volCRTModule102"/>
                                         <position name="posCRT_module102" unit="cm" x="360" y="180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="103">
                                         <volumeref ref="volCRTModule103"/>
                                         <position name="posCRT_module103" unit="cm" x="-360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="104">
                                         <volumeref ref="volCRTModule104"/>
                                         <position name="posCRT_module104" unit="cm" x="-180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="105">
                                         <volumeref ref="volCRTModule105"/>
                                         <position name="posCRT_module105" unit="cm" x="0" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="106">
                                         <volumeref ref="volCRTModule106"/>
                                         <position name="posCRT_module106" unit="cm" x="180" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
                                 </physvol>
-                                <physvol>
+                                <physvol copynumber="107">
                                         <volumeref ref="volCRTModule107"/>
                                         <position name="posCRT_module107" unit="cm" x="360" y="-180" z="-0.90000000000000002"/>
                                         <rotationref ref="rotateP90Z"/>
@@ -14782,115 +14782,115 @@
                 <volume name="volTaggerBot">
                         <materialref ref="matAir"/>
                         <solidref ref="TaggerBottom"/>
-                        <physvol>
+                        <physvol copynumber="108">
                                 <volumeref ref="volCRTModule108"/>
                                 <position name="posCRT_module108" unit="cm" x="-268.55000000000001" y="445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="109">
                                 <volumeref ref="volCRTModule109"/>
                                 <position name="posCRT_module109" unit="cm" x="-268.55000000000001" y="238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="110">
                                 <volumeref ref="volCRTModule110"/>
                                 <position name="posCRT_module110" unit="cm" x="-356.89999999999998" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
 						</physvol>
-                        <physvol>
+                        <physvol copynumber="111">
                                 <volumeref ref="volCRTModule111"/>
                                 <position name="posCRT_module111" unit="cm" x="-180.40000000000001" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="112">
                                 <volumeref ref="volCRTModule112"/>
                                 <position name="posCRT_module112" unit="cm" x="-52.899999999999999" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="113">
                                 <volumeref ref="volCRTModule113"/>
                                 <position name="posCRT_module113" unit="cm" x="52.899999999999999" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="114">
                                 <volumeref ref="volCRTModule114"/>
                                 <position name="posCRT_module114" unit="cm" x="180.40000000000001" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="115">
                                 <volumeref ref="volCRTModule115"/>
                                 <position name="posCRT_module115" unit="cm" x="356.89999999999998" y="326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="116">
                                 <volumeref ref="volCRTModule116"/>
                                 <position name="posCRT_module116" unit="cm" x="268.55000000000001" y="238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="117">
                                 <volumeref ref="volCRTModule117"/>
                                 <position name="posCRT_module117" unit="cm" x="-268.55000000000001" y="-238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="118">
                                 <volumeref ref="volCRTModule118"/>
                                 <position name="posCRT_module118" unit="cm" x="-268.55000000000001" y="-445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="119">
                                 <volumeref ref="volCRTModule119"/>
                                 <position name="posCRT_module119" unit="cm" x="-356.89999999999998" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="120">
                                 <volumeref ref="volCRTModule120"/>
                                 <position name="posCRT_module120" unit="cm" x="-180.40000000000001" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="121">
                                 <volumeref ref="volCRTModule121"/>
                                 <position name="posCRT_module121" unit="cm" x="-52.899999999999999" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="122">
                                 <volumeref ref="volCRTModule122"/>
                                 <position name="posCRT_module122" unit="cm" x="52.899999999999999" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="123">
                                 <volumeref ref="volCRTModule123"/>
                                 <position name="posCRT_module123" unit="cm" x="180.40000000000001" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="124">
                                 <volumeref ref="volCRTModule124"/>
                                 <position name="posCRT_module124" unit="cm" x="356.89999999999998" y="-326.14999999999998" z="0.80000000000000004"/>
 								<rotationref ref="rotateP90Z"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="125">
                                 <volumeref ref="volCRTModule125"/>
                                 <position name="posCRT_module125" unit="cm" x="268.55000000000001" y="-238" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="126">
                                 <volumeref ref="volCRTModule126"/>
                                 <position name="posCRT_module126" unit="cm" x="268.55000000000001" y="-445.89999999999998" z="-0.80000000000000004"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="127">
                                 <volumeref ref="volCRTModule127"/>
                                 <position name="posCRT_module127" unit="cm" x="-268.5" y="115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="128">
                                 <volumeref ref="volCRTModule128"/>
                                 <position name="posCRT_module128" unit="cm" x="-268.5" y="0" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="129">
                                 <volumeref ref="volCRTModule129"/>
                                 <position name="posCRT_module129" unit="cm" x="-268.5" y="-115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="130">
                                 <volumeref ref="volCRTModule130"/>
                                 <position name="posCRT_module130" unit="cm" x="268.5" y="115.175" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="131">
                                 <volumeref ref="volCRTModule131"/>
                                 <position name="posCRT_module131" unit="cm" x="268.5" y="0" z="0.59999999999999998"/>
                         </physvol>
-                        <physvol>
+                        <physvol copynumber="132">
                                 <volumeref ref="volCRTModule132"/>
                                 <position name="posCRT_module132" unit="cm" x="268.5" y="-115.175" z="0.59999999999999998"/>
                         </physvol>

--- a/sbndcode/JobConfigurations/standard/detsim/legacy/legacy_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/legacy/legacy_detsim_sbnd.fcl
@@ -41,6 +41,7 @@
 
 #include "detsimmodules_sbnd.fcl"
 #include "crtsimmodules_sbnd.fcl"
+#include "crtslimmer_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 #include "opdetdigitizer_sbnd.fcl"
 
@@ -74,12 +75,13 @@ physics:
   {
     rns:       { module_type: "RandomNumberSaver" }
     daq:       @local::sbnd_simwire_legacy
-    crt:       @local::sbnd_crtsim
+    crtsim:    @local::sbnd_crtsim
+    crt:       @local::sbnd_crtslimmer
     opdaq:     @local::sbnd_opdetdigitizer_legacy
   }
 
   #define the producer and filter modules for this path, order matters, 
-  simulate:  [ rns, daq, crt, opdaq]
+  simulate:  [ rns, daq, crtsim, crt, opdaq]
 
   #define the output stream, there could be more than one if using filters 
   stream1:   [ out1 ]

--- a/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
@@ -29,6 +29,7 @@
 
 #include "detsimmodules_sbnd.fcl"
 #include "crtsimmodules_sbnd.fcl"
+#include "crtslimmer_sbnd.fcl"
 #include "opdetdigitizer_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 
@@ -61,13 +62,14 @@ physics:
   {
     rns:       { module_type: "RandomNumberSaver" }
     daq:       @local::sbnd_simwire
-    crt:       @local::sbnd_crtsim
+    crtsim:    @local::sbnd_crtsim
+    crt:       @local::sbnd_crtslimmer
     opdaq:     @local::sbnd_opdetdigitizer
   }
 
   #define the producer and filter modules for this path, order matters,
-  simulate:  [ rns,  daq, crt, opdaq]
-  
+  simulate:  [ rns, daq, crtsim, crt, opdaq]
+
 
   #define the output stream, there could be more than one if using filters
   stream1:   [ out1 ]

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -8,6 +8,7 @@ cet_enable_asserts()
 add_subdirectory(Geometry)
 add_subdirectory(LArSoftConfigurations)
 add_subdirectory(JobConfigurations)
+add_subdirectory(CRT)
 
 # integration tests
 add_subdirectory(ci)

--- a/test/CRT/CMakeLists.txt
+++ b/test/CRT/CMakeLists.txt
@@ -1,0 +1,17 @@
+
+cet_test(crt_detsimalg_test
+  SOURCES crt_detsimalg_test.cxx
+  DATAFILES test_crt_detsimalg.fcl
+  TEST_ARGS ./test_crt_detsimalg.fcl
+  LIBRARIES sbndcode_CRT_CRTSimulation
+            sbndcode_Geometry
+            larcorealg_Geometry
+            larcorealg::GeometryTestLib
+            messagefacility::MF_MessageLogger
+            fhiclcpp::fhiclcpp
+            cetlib_except::cetlib_except
+      ROOT::Core
+#  OPTIONAL_GROUPS Broken
+)
+
+install_headers()

--- a/test/CRT/crt_detsimalg_test.cxx
+++ b/test/CRT/crt_detsimalg_test.cxx
@@ -1,4 +1,8 @@
-
+/**
+ * \brief Basic unit tests for the CRT detector simulation
+ *
+ * \author Marco Del Tutto
+ */
 
 #include <iostream> // for output before message facility is set up
 #include <string>

--- a/test/CRT/crt_detsimalg_test.cxx
+++ b/test/CRT/crt_detsimalg_test.cxx
@@ -1,0 +1,66 @@
+
+
+#include <iostream> // for output before message facility is set up
+#include <string>
+#include <memory> // std::unique_ptr<>
+#include <utility> // std::move(), std::forward()
+#include <map>
+#include <type_traits> // std::add_rvalue_reference()
+#include <stdexcept> // std::logic_error
+
+#include "larcorealg/TestUtils/unit_test_base.h"
+#include "CLHEP/Random/JamesRandom.h"
+#include "sbndcode/CRT/CRTSimulation/CRTDetSimAlg.h"
+#include "sbndcode/CRT/CRTSimulation/CRTDetSimParams.h"
+
+
+int main(int argc, char const** argv) {
+
+    int iParam = 0;
+
+    // first argument: configuration file (mandatory)
+    std::cout << "simpleCRT_test SetConfigurationPath" << std::endl;
+    std::string config_path;
+    if (++iParam < argc) config_path = argv[iParam];
+
+
+    char const* fhicl_env = getenv("FHICL_FILE_PATH");
+    std::string search_path = fhicl_env? std::string(fhicl_env) + ":": ".:";
+    testing::details::FirstAbsoluteOrLookupWithDotPolicy policy(search_path);
+
+    // parse a configuration file; obtain intermediate form
+    fhicl::intermediate_table table;
+    table = fhicl::parse_document(argv[iParam], policy);
+
+    // translate into a parameter set
+    fhicl::ParameterSet params;
+    params = fhicl::ParameterSet::make(table);
+
+    std::cout << "simpleCRT_test " << params.to_string() << std::endl;
+
+
+    long seed = 0;
+    CLHEP::HepJamesRandom engine(seed);
+
+    fhicl::ParameterSet p = params.get<fhicl::ParameterSet>("testcrtsim");
+
+    std::cout << "Just before CRTDetSimAlg:" << std::endl;
+    std::cout << "p " << p.to_string() << std::endl;
+    std::cout << "p.get<fhicl::ParameterSet>(DetSimParams) " << p.get<fhicl::ParameterSet>("DetSimParams").to_string() << std::endl;
+
+    using Parameters = fhicl::Table<sbnd::crt::CRTDetSimParams>;
+    Parameters detsim_params(p.template get<fhicl::ParameterSet>("DetSimParams"));
+
+
+
+    sbnd::crt::CRTDetSimAlg detsim_alg(detsim_params,
+                                       engine,
+                                       0.);
+
+
+
+    return 0;
+
+}
+
+

--- a/test/CRT/test_crt_detsimalg.fcl
+++ b/test/CRT/test_crt_detsimalg.fcl
@@ -1,0 +1,12 @@
+#
+# CRT simulation test configuration
+#
+
+#include "crtsimmodules_sbnd.fcl"
+
+process_name: TestCRTSim
+
+testcrtsim: @local::sbnd_crtsim
+
+
+

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -74,3 +74,4 @@ cet_test(dump_channel_map_sbnd_test HANDBUILT
 
 
 install_headers()
+add_subdirectory(CRTGeometry)

--- a/test/Geometry/CRTGeometry/CMakeLists.txt
+++ b/test/Geometry/CRTGeometry/CMakeLists.txt
@@ -1,0 +1,22 @@
+
+simple_plugin( SBNDCRTGeometryTest "module"
+  larcorealg_Geometry
+  art::Framework_Core
+  art::Framework_Principal
+  art::Framework_Services_Registry
+  art::Framework_Services_Optional_RandomNumberGenerator_service
+  art::Persistency_Provenance
+  canvas::canvas
+  messagefacility::MF_MessageLogger
+
+  fhiclcpp::fhiclcpp
+  cetlib::cetlib cetlib_except
+  NO_INSTALL
+)
+
+cet_test(SBNDCRTGeometryTest_1 HANDBUILT
+  TEST_EXEC lar
+  TEST_ARGS --rethrow-all --config SBNDCRTGeometryTest.fcl -n 1
+  DATAFILES
+    SBNDCRTGeometryTest.fcl
+)

--- a/test/Geometry/CRTGeometry/SBNDCRTGeometryTest.fcl
+++ b/test/Geometry/CRTGeometry/SBNDCRTGeometryTest.fcl
@@ -1,0 +1,33 @@
+#include "geometry_sbnd.fcl"
+
+services: {
+  RandomNumberGenerator: {}
+  TimeTracker:           {}
+  MemoryTracker:         {}
+  @table::sbnd_geometry_services
+}
+
+
+source: {
+  module_type: EmptyEvent
+
+  timestampPlugin: {
+    plugin_type: "GeneratedEventTimestamp"
+  }
+}
+
+
+physics: {
+
+  analyzers: {
+    crtgeometrytest: {
+      module_type:  "SBNDCRTGeometryTest"
+      # module_label: "timestampTest"
+    }
+  }
+
+  analysis: [ crtgeometrytest ]
+
+  end_paths: [ analysis ]
+
+}

--- a/test/Geometry/CRTGeometry/SBNDCRTGeometryTest_module.cc
+++ b/test/Geometry/CRTGeometry/SBNDCRTGeometryTest_module.cc
@@ -1,11 +1,8 @@
-////////////////////////////////////////////////////////////////////////
-// Class:       SBNDCRTGeometryTest
-// Plugin Type: analyzer (Unknown Unknown)
-// File:        SBNDCRTGeometryTest_module.cc
-//
-// Generated at Sun Apr 10 18:21:00 2022 by Marco Del Tutto using cetskelgen
-// from  version .
-////////////////////////////////////////////////////////////////////////
+/**
+ * \brief Unit tests for the CRT geometry
+ *
+ * \author Marco Del Tutto
+ */
 
 #include "art/Framework/Core/EDAnalyzer.h"
 #include "art/Framework/Core/ModuleMacros.h"

--- a/test/Geometry/CRTGeometry/SBNDCRTGeometryTest_module.cc
+++ b/test/Geometry/CRTGeometry/SBNDCRTGeometryTest_module.cc
@@ -1,0 +1,142 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SBNDCRTGeometryTest
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        SBNDCRTGeometryTest_module.cc
+//
+// Generated at Sun Apr 10 18:21:00 2022 by Marco Del Tutto using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "larcore/Geometry/Geometry.h"
+
+#include "TGeoManager.h"
+#include "TGeoNode.h"
+
+
+class SBNDCRTGeometryTest;
+
+
+class SBNDCRTGeometryTest : public art::EDAnalyzer {
+public:
+  explicit SBNDCRTGeometryTest(fhicl::ParameterSet const& p);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  // Plugins should not be copied or assigned.
+  SBNDCRTGeometryTest(SBNDCRTGeometryTest const&) = delete;
+  SBNDCRTGeometryTest(SBNDCRTGeometryTest&&) = delete;
+  SBNDCRTGeometryTest& operator=(SBNDCRTGeometryTest const&) = delete;
+  SBNDCRTGeometryTest& operator=(SBNDCRTGeometryTest&&) = delete;
+
+  // Required functions.
+  void analyze(art::Event const& e) override;
+
+private:
+
+};
+
+
+SBNDCRTGeometryTest::SBNDCRTGeometryTest(fhicl::ParameterSet const& p)
+  : EDAnalyzer{p}
+{}
+
+void SBNDCRTGeometryTest::analyze(art::Event const& e)
+{
+  art::ServiceHandle<geo::Geometry const> geoService;
+
+  std::cout << "Number of CRT AuxDets is " << geoService->NAuxDets() << std::endl;
+
+  assert(geoService->NAuxDets() > 0);
+
+
+  std::vector<int> used_copynumbers_auxdet;
+  std::vector<int> used_copynumbers_sensitiveauxdet;
+
+  for (size_t i = 0; i < geoService->NAuxDets(); i++) {
+    const geo::AuxDetGeo& adGeo = geoService->AuxDet(i);
+
+    std::set<std::string> volNames = { adGeo.TotalVolume()->GetName() };
+    std::vector<std::vector<TGeoNode const*> > paths =
+      geoService->FindAllVolumePaths(volNames);
+
+    std::string path = "";
+    for (size_t inode=0; inode<paths.at(0).size(); inode++) {
+      path += paths.at(0).at(inode)->GetName();
+      if (inode < paths.at(0).size() - 1) {
+        path += "/";
+      }
+    }
+
+    TGeoManager* manager = geoService->ROOTGeoManager();
+    manager->cd(path.c_str());
+
+    // We get the array of strips first, which is the AuxDet,
+    // then from the AuxDet, we get the strip by picking the
+    // daughter with the ID of the AuxDetSensitive, and finally
+    // from the AuxDet, we go up and pick the module and tagger
+    TGeoNode* nodeArray = manager->GetCurrentNode();
+    TGeoNode* nodeModule = manager->GetMother(1);
+    TGeoNode* nodeTagger = manager->GetMother(2);
+
+
+    // Ensure auxiliary detector ID and its GDML copynumber are the same
+    assert(i == (size_t)nodeModule->GetNumber());
+
+    // Check every aux det has a different copynumber
+    auto iter = std::find(used_copynumbers_auxdet.begin(), used_copynumbers_auxdet.end(),
+                          nodeModule->GetNumber());
+    assert(iter == used_copynumbers_auxdet.end());
+
+    used_copynumbers_auxdet.push_back(nodeModule->GetNumber());
+
+
+    // Ensure there are CRT strips
+    assert(nodeArray->GetNdaughters() > 0);
+
+
+    // Ensure that the number of AuxDetSensitive in the geometry service
+    // is the same as the number of daughter nodes
+    assert((int)geoService->NAuxDetSensitive(i) == nodeArray->GetNdaughters());
+
+    std::cout << "Auxiliary detector ID " << i
+              << " with copynumber " << nodeModule->GetNumber()
+              << "\n\t strip array name: " << nodeArray->GetName()
+              << "\n\t module name: " << nodeModule->GetName()
+              << "\n\t tagger name: " << nodeTagger->GetName() << std::endl;
+
+    // Loop over the AuxDetSensitive volumes
+    for (int adsid = 0; adsid < nodeArray->GetNdaughters(); adsid++) {
+
+      TGeoNode* nodeStrip = nodeArray->GetDaughter(adsid);
+
+      std::cout << "\t\t has sensitive detector (strip) with ID " << adsid
+                << ", name: " << nodeStrip->GetName()
+                << " (copynumber " << nodeStrip->GetNumber() << ")" << std::endl;
+
+      // Check every sensitive aux det has a different copynumber (this is used by LArG4)
+      auto iter2 = std::find(used_copynumbers_sensitiveauxdet.begin(), used_copynumbers_sensitiveauxdet.end(),
+                             nodeStrip->GetNumber());
+      assert(iter2 == used_copynumbers_sensitiveauxdet.end());
+
+      used_copynumbers_sensitiveauxdet.push_back(nodeStrip->GetNumber());
+    }
+
+  }
+
+
+}
+
+DEFINE_ART_MODULE(SBNDCRTGeometryTest)
+
+
+


### PR DESCRIPTION
This PR contains several updates to the CRT simulation, which are all discussed in detail in docdb [26031](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=26031). The docdb document also shows the validation performed.

Summary of changes:
- introduction of `FEBData` to store all 32 channels for each FEB
- `CRTData` is now constructed from `FEBData` objects with a new `CRTSlimmer` module
- CRT simulation triggering has been improved
- CRT waveform simulation has been implemented
- FEB dead time is now simulated
- CRT unit tests have been added

Depends on SBNSoftware/sbnobj#53.