### PR TITLE
Feature/lg v09 50 00

### DIFF
--- a/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
+++ b/sbndcode/CRT/CRTAna/CRTDetSimAna_module.cc
@@ -18,6 +18,7 @@
 // LArSoft includes
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "larcore/Geometry/AuxDetGeometry.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"

--- a/sbndcode/CRT/CRTUtils/CRTEventDisplay.h
+++ b/sbndcode/CRT/CRTUtils/CRTEventDisplay.h
@@ -22,6 +22,7 @@
 // LArSoft
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 namespace detinfo { class DetectorClocksData; }
 
 // Utility libraries

--- a/sbndcode/CRT/CRTUtils/CRTT0MatchAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTT0MatchAlg.h
@@ -24,6 +24,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataalg/DetectorInfo/DetectorPropertiesData.h"
 #include "larcore/Geometry/Geometry.h"

--- a/sbndcode/CRT/CRTUtils/CRTTrackMatchAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTTrackMatchAlg.h
@@ -24,6 +24,7 @@
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/RecoBase/Track.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardataalg/DetectorInfo/DetectorProperties.h"

--- a/sbndcode/Calibration/HitEfficiencyAna_module.cc
+++ b/sbndcode/Calibration/HitEfficiencyAna_module.cc
@@ -17,6 +17,7 @@
 #define HitEfficiencyAna_module
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 #include "lardataobj/RecoBase/Hit.h"
 #include "lardataobj/Simulation/SimChannel.h"

--- a/sbndcode/Calibration/ROIFinderStandardSBND_tool.cc
+++ b/sbndcode/Calibration/ROIFinderStandardSBND_tool.cc
@@ -12,6 +12,7 @@
 #include "sbndcode/Utilities/SignalShapingServiceSBND.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "TH1D.h"
 #include <fstream>
 #include <algorithm>

--- a/sbndcode/Calibration/tools/TrackHitEfficiencyAnalysis_tool.cc
+++ b/sbndcode/Calibration/tools/TrackHitEfficiencyAnalysis_tool.cc
@@ -10,6 +10,7 @@
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larevt/CalibrationDBI/Interface/ChannelStatusService.h"
 #include "larevt/CalibrationDBI/Interface/ChannelStatusProvider.h"
 

--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -24,6 +24,7 @@
 
 // LArSoft includes
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/WireGeo.h"
 #include "lardataobj/RecoBase/Hit.h"

--- a/sbndcode/Commissioning/MuonTrackProducer_module.cc
+++ b/sbndcode/Commissioning/MuonTrackProducer_module.cc
@@ -12,6 +12,7 @@
 
 // LArSoft includes 
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/PlaneGeo.h"
 #include "larcorealg/Geometry/WireGeo.h"
 #include "lardataobj/RecoBase/Hit.h"

--- a/sbndcode/Filters/GenCRTFilter_module.cc
+++ b/sbndcode/Filters/GenCRTFilter_module.cc
@@ -8,6 +8,7 @@
 #include "art/Framework/Principal/Event.h" 
 #include "art/Framework/Services/Registry/ServiceDefinitionMacros.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"

--- a/sbndcode/Filters/LArG4CRTFilter_module.cc
+++ b/sbndcode/Filters/LArG4CRTFilter_module.cc
@@ -8,6 +8,7 @@
 #include "art/Framework/Core/ModuleMacros.h" 
 #include "art/Framework/Principal/Event.h" 
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"

--- a/sbndcode/Filters/LArG4FakeTriggerFilter_module.cc
+++ b/sbndcode/Filters/LArG4FakeTriggerFilter_module.cc
@@ -5,6 +5,7 @@
 #include "art/Framework/Principal/Event.h" 
 
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 

--- a/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
+++ b/sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h
@@ -21,6 +21,7 @@
 
 // LArSoft
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "lardataobj/Simulation/AuxDetSimChannel.h"
 #include "larcore/Geometry/AuxDetGeometry.h"

--- a/sbndcode/Geometry/GeometryWrappers/TPCGeoAlg.h
+++ b/sbndcode/Geometry/GeometryWrappers/TPCGeoAlg.h
@@ -21,6 +21,7 @@
 
 // LArSoft
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 #include "nusimdata/SimulationBase/MCParticle.h"
 #include "lardataobj/RecoBase/Hit.h"

--- a/sbndcode/MCTruthExtractor/alg/NuAnaAlg.h
+++ b/sbndcode/MCTruthExtractor/alg/NuAnaAlg.h
@@ -3,6 +3,8 @@
 
 
 #include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
 #include "larcore/Geometry/Geometry.h"
 
 #include "nusimdata/SimulationBase/MCParticle.h"

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWiener_tool.cc
@@ -7,6 +7,7 @@
 #include "fhiclcpp/ParameterSet.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
 #include "art_root_io/TFileService.h"
+#include "larcore/CoreUtils/ServiceUtil.h" // lar::providerFrom()
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 #include "lardata/DetectorInfoServices/LArPropertiesService.h"
 #include "art/Utilities/ToolMacros.h"

--- a/sbndcode/OpDetReco/OpFlash/SBNDMCFlash_module.cc
+++ b/sbndcode/OpDetReco/OpFlash/SBNDMCFlash_module.cc
@@ -24,6 +24,7 @@
 #include "lardataobj/Simulation/SimPhotons.h"
 #include "lardataobj/RecoBase/OpFlash.h"
 #include "larcore/Geometry/Geometry.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
 #include "lardata/DetectorInfoServices/DetectorPropertiesService.h"
 #include "lardata/DetectorInfoServices/DetectorClocksService.h"
 // #include "lardata/DetectorInfoServices/DetectorClocksServiceStandard.h"

--- a/sbndcode/gallery/galleryAnalysis/CMakeLists.txt
+++ b/sbndcode/gallery/galleryAnalysis/CMakeLists.txt
@@ -79,7 +79,7 @@ link_directories(${GALLERY_LIBDIRS} ${LARSOFTOBJ_LIBDIRS} ${LARSOFT_LIBDIRS} ${S
 
 set(GALLERY_LIBS MF_MessageLogger fhiclcpp canvas cetlib_except cetlib gallery)
 set(ROOT_CORELIBS Core RIO Net Hist Graf Graf3d Gpad Tree Rint Postscript Matrix Physics MathCore Thread MultiProc pthread)
-set(LARSOFTOBJ_LIBS nusimdata_SimulationBase larcoreobj_SummaryData lardataobj_RawData lardataobj_OpticalDetectorData lardataobj_RecoBase lardataobj_AnalysisBase lardataobj_MCBase lardataobj_Simulation)
+set(LARSOFTOBJ_LIBS nusimdata_SimulationBase larcoreobj_SummaryData lardataobj_RawData lardataobj_RecoBase lardataobj_AnalysisBase lardataobj_MCBase lardataobj_Simulation)
 
 set(SBNDGEOMETRY_LIBS larcorealg_Geometry sbndcode_Geometry)
 set(SBNDDETINFO_LIBS lardataalg_DetectorInfo)

--- a/test/Geometry/geometry_iterator_loop_sbnd_test.cxx
+++ b/test/Geometry/geometry_iterator_loop_sbnd_test.cxx
@@ -18,7 +18,7 @@
 
 // LArSoft libraries
 #include "test/Geometry/geometry_unit_test_sbnd.h"
-#include "test/Geometry/GeometryIteratorLoopTestAlg.h"
+#include "larcorealg/test/Geometry/GeometryIteratorLoopTestAlg.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
 // utility libraries

--- a/test/Geometry/geometry_iterator_sbnd_test.cxx
+++ b/test/Geometry/geometry_iterator_sbnd_test.cxx
@@ -17,7 +17,7 @@
 
 // LArSoft libraries
 #include "test/Geometry/geometry_unit_test_sbnd.h"
-#include "test/Geometry/GeometryIteratorTestAlg.h"
+#include "larcorealg/test/Geometry/GeometryIteratorTestAlg.h"
 #include "larcorealg/TestUtils/boost_unit_test_base.h"
 
 //------------------------------------------------------------------------------

--- a/test/Geometry/geometry_sbnd_test.cxx
+++ b/test/Geometry/geometry_sbnd_test.cxx
@@ -16,7 +16,7 @@
 
 // LArSoft libraries
 #include "test/Geometry/geometry_unit_test_sbnd.h"
-#include "test/Geometry/GeometryTestAlg.h"
+#include "larcorealg/test/Geometry/GeometryTestAlg.h"
 #include "larcorealg/Geometry/GeometryCore.h"
 
 // utility libraries

--- a/test/Geometry/geometry_unit_test_sbnd.h
+++ b/test/Geometry/geometry_unit_test_sbnd.h
@@ -16,7 +16,7 @@
 #define TEST_GEOMETRY_UNIT_TEST_SBND_H
 
 // LArSoft libraries
-#include "test/Geometry/geometry_unit_test_base.h"
+#include "larcorealg/TestUtils/geometry_unit_test_base.h"
 // #include "sbndcode/Geometry/ChannelMapSBNDAlg.h"
 #include "larcorealg/Geometry/ChannelMapStandardAlg.h"
 


### PR DESCRIPTION
add headers needed for larsoft v09_50_00

Also, larcorealg test headers will move:
- `test/Geometry/geometry_unit_test_base.h` becomes `larcorealg/TestUtils/geometry_unit_test_base.h`
- `test/Geometry/GeometryTestAlg.h` becomes `larcorealg/test/Geometry/GeometryTestAlg.h`
- `test/Geometry/GeometryIteratorLoopTestAlg.h` becomes `larcorealg/test/Geometry/GeometryIteratorLoopTestAlg.h`
- `test/Geometry/GeometryIteratorTestAlg.h` becomes `larcorealg/test/Geometry/GeometryIteratorTestAlg.h`
