### PR TITLE
Run CRUMBS as standalone producer

### DIFF
--- a/sbndcode/JobConfigurations/standard/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/CMakeLists.txt
@@ -6,5 +6,6 @@ add_subdirectory(caf)
 add_subdirectory(anatree)
 add_subdirectory(workshops)
 add_subdirectory(deprecated)
+add_subdirectory(ana)
 
 install_fhicl()

--- a/sbndcode/JobConfigurations/standard/ana/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/ana/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
@@ -5,8 +5,6 @@
 #include "sbn_crumbs_producer.fcl"
 
 #include "rootoutput_sbnd.fcl"
-#include "geometry_sbnd.fcl"
-#include "messages_sbnd.fcl"
 #include "services_sbnd.fcl"
 
 process_name: CRUMBS
@@ -14,10 +12,7 @@ process_name: CRUMBS
 services:
 {
    TFileService: { fileName: @local::sbnd_tfileoutput.fileName }
-   Geometry: @local::sbnd_geo
-   ExptGeoHelperInterface:    @local::sbnd_geometry_helper
    @table::sbnd_services
-   @table::sbnd_resourcemonitorservices
 }
 
 source: {
@@ -30,12 +25,9 @@ physics:
    {
       crumbs: @local::crumbs_sbnd
    }
-   
+
    runcrumbs: [ crumbs ]
    stream1:   [ out1 ]
-
-   trigger_paths: [ runcrumbs ]
-   end_paths:	  [ stream1 ]
 }
 
 outputs:

--- a/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
@@ -1,0 +1,48 @@
+#
+# fcl file to run CRUMBS on a reco2 file
+#
+
+#include "sbn_crumbs_producer.fcl"
+
+#include "rootoutput_sbnd.fcl"
+#include "geometry_sbnd.fcl"
+#include "messages_sbnd.fcl"
+#include "services_sbnd.fcl"
+
+process_name: CRUMBS
+
+services:
+{
+   TFileService: { fileName: @local::sbnd_tfileoutput.fileName }
+   Geometry: @local::sbnd_geo
+   ExptGeoHelperInterface:    @local::sbnd_geometry_helper
+   @table::sbnd_services
+   @table::sbnd_resourcemonitorservices
+}
+
+source: {
+   module_type: RootInput
+}
+
+physics:
+{
+   producers:
+   {
+      crumbs: @local::crumbs_sbnd
+   }
+   
+   runcrumbs: [ crumbs ]
+   stream1:   [ out1 ]
+
+   trigger_paths: [ runcrumbs ]
+   end_paths:	  [ stream1 ]
+}
+
+outputs:
+{
+   out1:
+   { 
+      @table::sbnd_rootoutput
+      dataTier: "reconstructed"
+   }
+}


### PR DESCRIPTION
This adds a fcl for running CRUMBS as a standalone producer. As mentioned by issue SBNSoftware/sbncode#164 CRUMBS and other high-level reco / analysis tools are run as part of the CAF fcl stage. In future the idea is to move most of these producers into the reco2 stage but in the meanwhile it is useful to have a fcl that demonstrates how to run CRUMBS on artroot files if you don't want to use the CAFs.