### PR TITLE
TPB time not implemented for simphotonslite vis-XARAPUCAs

### DIFF
--- a/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiArapucaSBNDAlg.cc
@@ -246,7 +246,7 @@ namespace opdet {
       acceptedPhotons = CLHEP::RandPoissonQ::shoot(fEngine, meanPhotons);
       for(size_t i = 0; i < acceptedPhotons; i++) {
         tphoton = (CLHEP::RandExponential::shoot(fEngine, fParams.DecayTXArapucaVIS));
-        tphoton += photonMember.first - t_min;
+        tphoton += photonMember.first - t_min + fTimeTPB->fire();
         if(tphoton < 0.) continue; // discard if it didn't made it to the acquisition
         if(fParams.CrossTalk > 0.0 && (CLHEP::RandFlat::shoot(fEngine, 1.0)) < fParams.CrossTalk) nCT = 2;
         else nCT = 1;


### PR DESCRIPTION
Small bugfix, TPB time added to single constructor of simphotonslite.
60% of the TPB is expected to have a decay exp time of 1-10 ns (https://arxiv.org/abs/1411.4524). Small changes(extra time bias) in the visible digitized waveforms are expected.