### PR TITLE
CRT Hit Timings

### DIFF
--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -322,8 +322,6 @@ sbn::crt::CRTHit CRTHitRecoAlg::FillCrtHit(std::vector<uint8_t> tfeb_id, std::ma
 
   sbn::crt::CRTHit crtHit;
 
-  std::cout << "Filling hit with time " << time << ", fTimeOffset " << fTimeOffset << std::endl;
-
   crtHit.feb_id      = tfeb_id;
   crtHit.pesmap      = tpesmap;
   crtHit.peshit      = peshit;
@@ -340,7 +338,9 @@ sbn::crt::CRTHit CRTHitRecoAlg::FillCrtHit(std::vector<uint8_t> tfeb_id, std::ma
   crtHit.z_pos       = z;
   crtHit.z_err       = ez;
   crtHit.tagger      = tagger;
-  std::cout << "\t and is in fact " << crtHit.ts0_ns << " " << crtHit.ts0_s << " " <<crtHit.ts1_ns << std::endl;
+
+  mf::LogInfo("CRTHitRecoAlg") << "Filling hit with time " << time << ", fTimeOffset " << fTimeOffset << '\n'
+			       << "\t and is in fact " << crtHit.ts0_ns << " " << crtHit.ts0_s << " " <<crtHit.ts1_ns << std::endl;
 
   return crtHit;
 

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.cc
@@ -187,7 +187,7 @@ std::vector<std::pair<sbn::crt::CRTHit, std::vector<int>>> CRTHitRecoAlg::Create
                            std::abs((overlap[5] - overlap[4])/2.));
 
             // Correct and average the time
-	    double time = CorrectTime(tagStrip.second[hit_i], taggerStrips[otherPlane][hit_j], mean) - fTimeOffset;
+            double time = CorrectTime(tagStrip.second[hit_i], taggerStrips[otherPlane][hit_j], mean) - fTimeOffset;
             //double pes = tagStrip.second[hit_i].pes + taggerStrips[otherPlane][hit_j].pes;
             double pes = CorrectNpe(tagStrip.second[hit_i], taggerStrips[otherPlane][hit_j], mean);
             int plane = sbnd::CRTCommonUtils::GetPlaneIndex(tagStrip.first.first);
@@ -344,7 +344,7 @@ sbn::crt::CRTHit CRTHitRecoAlg::FillCrtHit(std::vector<uint8_t> tfeb_id, std::ma
   crtHit.tagger      = tagger;
 
   mf::LogInfo("CRTHitRecoAlg") << "Filling hit with time " << time << ", fTimeOffset " << fTimeOffset << '\n'
-			       << "\t and is in fact " << crtHit.ts0_ns << " " << crtHit.ts0_s << " " <<crtHit.ts1_ns << std::endl;
+                               << "\t and is in fact " << crtHit.ts0_ns << " " << crtHit.ts0_s << " " <<crtHit.ts1_ns << std::endl;
 
   return crtHit;
 

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -115,6 +115,10 @@ namespace sbnd{
         Name("UseG4RefTimeOffset"),
         Comment("Wheater or not to use the G4RefTime as GlobalT0Offset"),
       };
+      fhicl::Atom<double> PropDelay {
+        Name("PropDelay"),
+        Comment("Delay in pulse arrival time [ns/m]"),
+      };
 
     };
 
@@ -159,6 +163,9 @@ namespace sbnd{
     // Function to correct number of photoelectrons by distance down strip
     double CorrectNpe(CRTStrip strip1, CRTStrip strip2, TVector3 position);
 
+    // Function to correct the time by distance down strip
+    double CorrectTime(CRTStrip strip1, CRTStrip strip2, TVector3 position);
+
   private:
 
     TPCGeoAlg fTpcGeo;
@@ -172,6 +179,7 @@ namespace sbnd{
     double fClockSpeedCRT;
     double fTimeOffset;
     bool fUseG4RefTimeOffset;
+    double fPropDelay;
 
   };
 

--- a/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
+++ b/sbndcode/CRT/CRTUtils/CRTHitRecoAlg.h
@@ -119,6 +119,23 @@ namespace sbnd{
         Name("PropDelay"),
         Comment("Delay in pulse arrival time [ns/m]"),
       };
+      fhicl::Atom<double> TDelayNorm {
+        Name("TDelayNorm"),
+        Comment("Time delay fit: Gaussian normalization"),
+      };
+      fhicl::Atom<double> TDelayShift {
+        Name("TDelayShift"),
+        Comment("Time delay fit: Gaussian x shift"),
+      };
+      fhicl::Atom<double> TDelaySigma {
+        Name("TDelaySigma"),
+        Comment("Time delay fit: Gaussian width"),
+      };
+      fhicl::Atom<double> TDelayOffset {
+        Name("TDelayOffset"),
+        Comment("Time delay fit: Gaussian baseline offset"),
+      };
+
 
     };
 
@@ -180,6 +197,10 @@ namespace sbnd{
     double fTimeOffset;
     bool fUseG4RefTimeOffset;
     double fPropDelay;
+    double fTDelayNorm;
+    double fTDelayShift;
+    double fTDelaySigma;
+    double fTDelayOffset;
 
   };
 

--- a/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
+++ b/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
@@ -13,6 +13,10 @@ standard_crtsimhitalg:
     TimeOffset:           @local::sbnd_crtsim.DetSimParams.GlobalT0Offset
     UseG4RefTimeOffset:   @local::sbnd_crtsim.DetSimParams.UseG4RefTimeOffset
     PropDelay:            @local::sbnd_crtsim.DetSimParams.PropDelay
+    TDelayNorm:           @local::sbnd_crtsim.DetSimParams.TDelayNorm
+    TDelayShift:          @local::sbnd_crtsim.DetSimParams.TDelayShift
+    TDelaySigma:          @local::sbnd_crtsim.DetSimParams.TDelaySigma
+    TDelayOffset:         @local::sbnd_crtsim.DetSimParams.TDelayOffset
 }
 
 

--- a/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
+++ b/sbndcode/CRT/crtsimhitproducer_sbnd.fcl
@@ -12,6 +12,7 @@ standard_crtsimhitalg:
     ClockSpeedCRT:        @local::sbnd_crtsim.DetSimParams.ClockSpeedCRT
     TimeOffset:           @local::sbnd_crtsim.DetSimParams.GlobalT0Offset
     UseG4RefTimeOffset:   @local::sbnd_crtsim.DetSimParams.UseG4RefTimeOffset
+    PropDelay:            @local::sbnd_crtsim.DetSimParams.PropDelay
 }
 
 

--- a/sbndcode/CRT/crtsimmodules_sbnd.fcl
+++ b/sbndcode/CRT/crtsimmodules_sbnd.fcl
@@ -27,7 +27,7 @@ standard_sbnd_crtsimparams: {
   ClockSpeedCRT: 1000.
 
   # Propagation delay [ns/cm]
-  PropDelay: 0.0061
+  PropDelay: 0.061
   PropDelayError: 0.007
 
   # Interpolator time resolution [ns]


### PR DESCRIPTION
I presented these changes at today's SBND Reco meeting (see [docDB#26626](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=26626)). Currently we simulate two key timing effects in the CRT strips. 

- Propagation delay (light takes time to travel along the fibre).
- Time walk (bigger pulses record an earlier time due to reaching the threshold earlier).
but we don't account for any of this in reconstruction.

This PR does the following:

- Corrects the propagation speed value (currently simulating 10x the speed it should)
- Adds a correction method to the CRT Hit Reconstruction to account for these two effects using reconstruction information.
- The relevant fcl parameters are all inherited directly from the ones used in detsim.
- Finally, [this](https://github.com/SBNSoftware/sbndcode/commit/3647e3c4c6a82dfa85195bc428d940cb899ae703) commit changes a std::cout to a LogInfo dump, is that okay @marcodeltutto?