### PR TITLE
Update for OpFlash t0

### DIFF
--- a/sbndcode/OpDetReco/OpFlash/CMakeLists.txt
+++ b/sbndcode/OpDetReco/OpFlash/CMakeLists.txt
@@ -71,5 +71,6 @@ install_fhicl()
 install_source()
 
 add_subdirectory(FlashFinder)
+add_subdirectory(FlashTools)
 add_subdirectory(job)
 

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/FlashFinderTypes.h
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/FlashFinderTypes.h
@@ -28,19 +28,21 @@ namespace lightana {
     std::vector<unsigned int> asshit_idx;
     double time;
     double time_err;
-    
+    int tpc;
+
     LiteOpFlash_t() : channel_pe(),
                      time(kINVALID_TIME)
     {}
 
     LiteOpFlash_t(double flash_time,
                   double flash_time_err,
+                  int flash_tpc,
                   std::vector<double>&& pe_array,
                   std::vector<unsigned int>&& hit_idx)
       : channel_pe(std::move(pe_array))
       , asshit_idx(std::move(hit_idx))
-    { time = flash_time; time_err = flash_time_err; }
-    
+    { time = flash_time; time_err = flash_time_err; tpc=flash_tpc; }
+
     void Register(size_t channel, double pe)
     {
       if(channel >= channel_pe.size()) channel_pe.resize(channel+1,0);

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.cxx
@@ -24,7 +24,7 @@ namespace lightana{
         _pre_sample    = p.get<double>("PreSample",0.1);
         _veto_time     = p.get<double>("VetoSize",8.);
         _time_res      = p.get<double>("TimeResolution",0.03);
-        _tpc           = p.get<int>("TPC",-1);
+        _tpc           = p.get<int>("TPC");
         //_pe_baseline_v.clear();
         //_pe_baseline_v = p.get<std::vector<double> >("PEBaseline",_pe_baseline_v);
 

--- a/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.h
+++ b/sbndcode/OpDetReco/OpFlash/FlashFinder/SimpleFlashAlgo.h
@@ -15,7 +15,7 @@ namespace lightana
     SimpleFlashAlgo(const std::string name);
 
     void Configure(const Config_t &p);
-    
+
     virtual ~SimpleFlashAlgo();
 
     LiteOpFlashArray_t RecoFlash(const LiteOpHitArray_t ophits);
@@ -36,6 +36,7 @@ namespace lightana
     double _veto_time;      // veto time
     double _time_res;       // time resolution of pe sum
     double _pre_sample;     // time pre-sample
+    int    _tpc;            // tpc
 
     std::vector<double> _pesum_v;        // pw aum array
     std::vector<double> _pe_baseline_v;  // calibration: PEs to be subtracted from each opdet
@@ -47,7 +48,7 @@ namespace lightana
     // list of opchannel to use
     std::vector<int> _opch_to_index_v;
     std::vector<int> _index_to_opch_v;
-                             
+
   };
 
   /**

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
@@ -1,0 +1,30 @@
+art_make(
+   TOOL_LIBRARIES
+         art::Utilities
+         larcore_Geometry_Geometry_service
+         lardataobj_RawData
+         lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
+         sbndcode_Utilities_SignalShapingServiceSBND_service
+         messagefacility::MF_MessageLogger
+         fhiclcpp::fhiclcpp
+         cetlib::cetlib
+         CLHEP::CLHEP
+         ${ROOT_BASIC_LIB_LIST}
+         art::Framework_Core
+         art::Framework_Principal
+         ${ART_FRAMEWORK_BASIC}
+         art::Framework_Services_Registry
+         ${ART_FRAMEWORK_SERVICES_OPTIONAL}
+
+         art::Persistency_Common
+         art::Persistency_Provenance
+         art::Utilities
+         cetlib::cetlib
+         cetlib_except::cetlib_except
+
+         sbndcode_OpDetSim
+)
+
+install_headers()
+install_fhicl()
+install_source()

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
@@ -1,28 +1,6 @@
 art_make(
    TOOL_LIBRARIES
-         art::Utilities
-         larcore_Geometry_Geometry_service
-         lardataobj_RawData
-         lardata_DetectorInfoServices_DetectorClocksServiceStandard_service
-         sbndcode_Utilities_SignalShapingServiceSBND_service
-         messagefacility::MF_MessageLogger
-         fhiclcpp::fhiclcpp
-         cetlib::cetlib
-         CLHEP::CLHEP
-         ${ROOT_BASIC_LIB_LIST}
-         art::Framework_Core
-         art::Framework_Principal
-         ${ART_FRAMEWORK_BASIC}
-         art::Framework_Services_Registry
-         ${ART_FRAMEWORK_SERVICES_OPTIONAL}
-
-         art::Persistency_Common
-         art::Persistency_Provenance
-         art::Utilities
-         cetlib::cetlib
-         cetlib_except::cetlib_except
-
-         sbndcode_OpDetSim
+    sbndcode_OpDetReco_OpFlash_FlashFinder
 )
 
 install_headers()

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorBase.hh
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorBase.hh
@@ -1,0 +1,31 @@
+///////////////////////////////////////////////////////////////////////
+/// File: DriftEstimatorBase.hh
+///
+/// Interface class for drift coordinate estimation from
+/// reco objects
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#ifndef SBND_DRIFTESTIMATORBASE_H
+#define SBND_DRIFTESTIMATORBASE_H
+
+namespace lightana
+{
+  class DriftEstimatorBase{
+
+  public:
+    // Default destructor
+    virtual ~DriftEstimatorBase() noexcept = default;
+
+    // Method giving the estimated drift coordinate
+    virtual double GetDriftPosition(std::vector<double> PE_v) = 0;
+
+    // Method giving the photon propagation
+    virtual double GetPropagationTime(double drift) = 0;
+
+
+  };
+}
+
+#endif

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
@@ -1,0 +1,183 @@
+///////////////////////////////////////////////////////////////////////
+/// File: DriftEstimatorPMTRatio_tool.cc
+///
+/// Base class: DriftEstimatorBase.hh
+///
+/// Tool description: .....
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "larcore/CoreUtils/ServiceUtil.h"
+#include "larcore/Geometry/Geometry.h"
+
+#include <vector>
+#include <string>
+
+#include "DriftEstimatorBase.hh"
+#include "sbndcode/OpDetSim/sbndPDMapAlg.hh"
+
+//ROOT includes
+#include "TProfile.h"
+#include "TFile.h"
+
+namespace lightana
+{
+  class DriftEstimatorPMTRatio : DriftEstimatorBase{
+
+  public:
+
+    //Configuration parameters
+    struct Config {
+
+      fhicl::Atom<std::string> CalibrationFile {
+        fhicl::Name("CalibrationFile"),
+        fhicl::Comment("Filepath to the calibration ROOT file")
+      };
+
+      fhicl::Atom<double> VGroupVUV {
+        fhicl::Name("VGroupVUV"),
+        fhicl::Comment("Group velocity for VUV photons")
+      };
+
+      fhicl::Atom<double> VGroupVIS {
+        fhicl::Name("VGroupVIS"),
+        fhicl::Comment("Group velocity for VIS photons")
+      };
+
+    };
+
+    // Default constructor
+    explicit DriftEstimatorPMTRatio(art::ToolConfigTable<Config> const& config);
+
+    // Method giving the estimated drift coordinate
+    double GetDriftPosition(std::vector<double> PE_v) override;
+
+    // Method giving the photon propagation
+    double GetPropagationTime(double drift) override;
+
+    // Method giving the photon propagation from PE vector
+    double PEToPropagationTime(std::vector<double> PE_v);
+
+  private:
+    double Interpolate(double val);
+
+    // Input filepah with calibration curve
+    std::string fCalibrationFile;
+
+    // Scintillation light group velocities
+    double fVGroupVUV;
+    double fVGroupVIS;
+    double fVGroupVUV_I;
+
+    //Geo properties
+    double fDriftDistance;
+    double fVISLightPropTime;
+    double fKinkDistance;
+
+    // Vectors with calibration variables
+    std::vector<double> fPMTRatioCal;
+    std::vector<double> fDriftCal;
+    int fNCalBins;
+    double fPMTRatio_MinVal;
+    double fPMTRatio_MaxVal;
+
+    // PDS mapping
+    opdet::sbndPDMapAlg fPDSMap;
+
+  };
+
+  DriftEstimatorPMTRatio::DriftEstimatorPMTRatio(art::ToolConfigTable<Config> const& config)
+    : fCalibrationFile { config().CalibrationFile() },
+    fVGroupVUV { config().VGroupVUV() },
+    fVGroupVIS { config().VGroupVIS() }
+  {
+
+    // Open input file
+    std::string file_name;
+    cet::search_path sp("FW_SEARCH_PATH");
+    if ( !sp.find_file(fCalibrationFile, file_name) )
+      throw cet::exception("DriftEstimatorPMTRatio") << "Calibration file " <<
+          fCalibrationFile << " not found in FW_SEARCH_PATH\n";
+
+    TFile* input_file = TFile::Open(file_name.c_str(), "READ");
+    TProfile * hProf_Calibration = (TProfile*)input_file->Get("PMTRatioCalibrationProfile");
+
+    //Fill calibration variables
+    fNCalBins = hProf_Calibration->GetNbinsX();
+    for (int ix=1; ix<=fNCalBins; ix++){
+      fPMTRatioCal.push_back( hProf_Calibration->GetBinCenter(ix) );
+      fDriftCal.push_back( hProf_Calibration->GetBinContent(ix) );
+    }
+    fPMTRatio_MinVal = hProf_Calibration->GetBinCenter(1);
+    fPMTRatio_MaxVal = hProf_Calibration->GetBinCenter(fNCalBins);
+
+    input_file->Close();
+
+    geo::GeometryCore const& geom = *(lar::providerFrom<geo::Geometry>());
+
+    fDriftDistance = geom.TPC(0.0).DriftDistance();
+    fVISLightPropTime = fDriftDistance/fVGroupVIS;
+    fKinkDistance = 0.5*fDriftDistance*(1-fVGroupVUV/fVGroupVIS);
+
+    fVGroupVUV_I = 1./fVGroupVUV;
+  }
+
+  double DriftEstimatorPMTRatio::GetDriftPosition(std::vector<double> PE_v){
+
+    double coatedPE=0, uncoatedPE=0;
+
+    for(size_t oc=0; oc<PE_v.size(); oc++){
+      if( fPDSMap.pdType(oc)=="pmt_coated" ) coatedPE+=PE_v[oc];
+      else if( fPDSMap.pdType(oc)=="pmt_uncoated" ) uncoatedPE+=PE_v[oc];
+    }
+
+    double pmtratio=1.;
+    if(coatedPE!=0)
+      pmtratio = 4*uncoatedPE/coatedPE;
+
+    double drift_distance;
+    if(pmtratio<=fPMTRatioCal[0])
+      drift_distance=fDriftCal[0];
+    else if(pmtratio>=fPMTRatioCal[fNCalBins-1])
+      drift_distance=fDriftCal[fNCalBins-1];
+    else
+      drift_distance=Interpolate(pmtratio);
+
+    return drift_distance;
+   }
+
+  double DriftEstimatorPMTRatio::GetPropagationTime(double drift){
+
+    // drift is here the X coordinate
+    // cathode: x=0 cm, PDS: x=200 cm
+    if(std::abs(drift) > fKinkDistance)
+      return (fDriftDistance-std::abs(drift)) * fVGroupVUV_I ;
+    else
+      return std::abs(drift) * fVGroupVUV_I + fVISLightPropTime;
+  }
+
+  double DriftEstimatorPMTRatio::PEToPropagationTime(std::vector<double> PE_v){
+
+    double _drift = GetDriftPosition(PE_v);
+
+    return GetPropagationTime(_drift);
+  }
+
+  double DriftEstimatorPMTRatio::Interpolate(double val){
+
+    size_t upix = std::upper_bound(fPMTRatioCal.begin(), fPMTRatioCal.end(), val)-fPMTRatioCal.begin();
+
+    double slope = ( fDriftCal[upix]-fDriftCal[upix] ) / ( fPMTRatioCal[upix]-fPMTRatioCal[upix-1] );
+
+    return fDriftCal[upix-1] + slope * ( val - fPMTRatioCal[upix-1] );
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(lightana::DriftEstimatorPMTRatio)

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
@@ -3,7 +3,12 @@
 ///
 /// Base class: DriftEstimatorBase.hh
 ///
-/// Tool description: .....
+/// Tool description: this tool estimates the drift coordinate
+/// from the ratio between the #PE reconstructed for the
+/// uncoated/coated PMTs. It requires a calibration curve
+/// (speficied in the CalibrationFile fhicl parameter).
+/// Once the drift has been estimated, the photon propagation
+/// time is calculated using the VUV and VIS light group velocities
 ///
 /// Created by Fran Nicolas, June 2022
 ////////////////////////////////////////////////////////////////////////

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBarycenter_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBarycenter_tool.cc
@@ -1,0 +1,99 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashGeoBarycenter_tool.cc
+///
+/// Base class: FlashGeoBase.hh
+///
+/// It computes the PMTs barycenter
+/// weighted by the reconstructed number of PE
+///
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "FlashGeoBase.hh"
+
+namespace lightana{
+
+  class FlashGeoBarycenter : FlashGeoBase
+  {
+
+  public:
+
+    //Configuration parameters
+     struct Config {
+
+       fhicl::Atom<unsigned int> WeightExp {
+         fhicl::Name("WeightExp"),
+         fhicl::Comment("Weight exponent for YZ barycenters")
+       };
+
+     };
+
+
+    // Default constructor
+    explicit FlashGeoBarycenter(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    void GetFlashLocation(std::vector<double> pePerOpChannel,
+                            double& Ycenter, double& Zcenter,
+                            double& Ywidth, double& Zwidth) override;
+
+  private:
+
+    unsigned int fWeightExp;
+
+  };
+
+
+  FlashGeoBarycenter::FlashGeoBarycenter(art::ToolConfigTable<Config> const& config)
+    : fWeightExp{ config().WeightExp() }
+  {
+  }
+
+
+  void FlashGeoBarycenter::GetFlashLocation(std::vector<double> pePerOpChannel,
+                                            double& Ycenter, double& Zcenter,
+                                            double& Ywidth, double& Zwidth)
+  {
+
+    // Reset variables
+    Ycenter = Zcenter = 0.;
+    Ywidth  = Zwidth  = -999.;
+    double totalPE = 0.;
+    double sumy = 0., sumz = 0., sumy2 = 0., sumz2 = 0.;
+    double weight =1.;
+    for (unsigned int opch = 0; opch < pePerOpChannel.size(); opch++) {
+      // Get physical detector location for this opChannel
+      double PMTxyz[3];
+      ::lightana::OpDetCenterFromOpChannel(opch, PMTxyz);
+
+      // Get weight for this channel
+      if(fWeightExp==1) weight = pePerOpChannel[opch];
+      else if(fWeightExp==2) weight = pePerOpChannel[opch]*pePerOpChannel[opch];
+      else weight = std::pow(pePerOpChannel[opch], fWeightExp);
+
+      // Add up the position, weighting with PEs
+      sumy    += weight*PMTxyz[1];
+      sumy2   += weight*PMTxyz[1]*PMTxyz[1];
+      sumz    += weight*PMTxyz[2];
+      sumz2   += weight*PMTxyz[2]*PMTxyz[2];
+      totalPE += weight;
+    }
+
+    Ycenter = sumy/totalPE;
+    Zcenter = sumz/totalPE;
+
+    // This is just sqrt(<x^2> - <x>^2)
+    if ( (sumy2*totalPE - sumy*sumy) > 0. )
+      Ywidth = std::sqrt(sumy2*totalPE - sumy*sumy)/totalPE;
+
+    if ( (sumz2*totalPE - sumz*sumz) > 0. )
+      Zwidth = std::sqrt(sumz2*totalPE - sumz*sumz)/totalPE;
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(lightana::FlashGeoBarycenter)

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBase.hh
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBase.hh
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashGeoBase.h
+///
+/// Interfacce class for a tool to calculate the recob::OpFlash
+/// Y and Z coordinates (PDS plane)
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#ifndef SBND_FLASHGEOBASE_H
+#define SBND_FLASHGEOBASE_H
+
+#include "sbndcode/OpDetReco/OpFlash/FlashFinder/FlashFinderFMWKInterface.h"
+
+namespace lightana
+{
+  class FlashGeoBase{
+
+  public:
+    // Default destructor
+    virtual ~FlashGeoBase() noexcept = default;
+
+    // Method to calculate flash geometric properties
+    virtual void GetFlashLocation(std::vector<double> pePerOpChannel,
+                                  double& Ycenter, double& Zcenter,
+                                  double& Ywidth, double& Zwidth) = 0 ;
+
+  private:
+
+  };
+}
+
+#endif

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0Base.hh
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0Base.hh
@@ -1,0 +1,31 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashT0Base.h
+///
+/// Interfacce class for a tool to calculate the recob::OpFlash t0
+/// from the associated recob::OpHits
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#ifndef SBND_FLASHT0BASE_H
+#define SBND_FLASHT0BASE_H
+
+#include "sbndcode/OpDetReco/OpFlash/FlashFinder/FlashFinderTypes.h"
+
+namespace lightana
+{
+  class FlashT0Base{
+
+  public:
+    // Default destructor
+    virtual ~FlashT0Base() noexcept = default;
+
+    // Method to calculate the OpFlash t0
+    virtual double GetFlashT0(double flash_peaktime, LiteOpHitArray_t ophit_list) = 0;
+
+  private:
+
+  };
+}
+
+#endif

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0FirstHit_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0FirstHit_tool.cc
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashT0FirstHit_tool.cc
+///
+/// Base class: FlashT0Base.hh
+///
+/// Algorithm description: The OpFlash t0 is set to the OpHit
+/// with the largest signal (#PE). Only OpHits above the
+/// MinHitPE cut are considered
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "FlashT0Base.hh"
+
+namespace lightana{
+
+  class FlashT0FirstHit : FlashT0Base
+  {
+
+  public:
+
+    //Configuration parameters
+    struct Config {
+
+      fhicl::Atom<double> MinHitPE {
+        fhicl::Name("MinHitPE"),
+        fhicl::Comment("Minimum number of reconstructed PE to consider the OpHit for the t0 calculation")
+      };
+
+    };
+
+    // Default constructor
+    explicit FlashT0FirstHit(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    double GetFlashT0(double flash_peaktime, LiteOpHitArray_t ophit_list) override;
+
+  private:
+
+    double fMinHitPE;
+
+  };
+
+  FlashT0FirstHit::FlashT0FirstHit(art::ToolConfigTable<Config> const& config)
+    : fMinHitPE{ config().MinHitPE() }
+  {
+  }
+
+  double FlashT0FirstHit::GetFlashT0(double flash_time, LiteOpHitArray_t ophit_list){
+
+    double start_time = flash_time;
+
+    for(auto & ophit : ophit_list){
+      if(ophit.peak_time<start_time && ophit.pe>fMinHitPE) start_time = ophit.peak_time;
+    }
+
+    return start_time;
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(lightana::FlashT0FirstHit)

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0SelectedChannels_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashT0SelectedChannels_tool.cc
@@ -1,0 +1,113 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashT0SelectedChannels_tool.cc
+///
+/// Base class: FlashT0Base.hh
+///
+/// Algorithm description: it averages the OpHit times
+/// for the photon detectors (PDs) containing a certain fraction (PDFraction)
+/// of the integrated signal. Only OpHit in the interval
+/// [FlashPeakTime-PreWindow, FlashPeakTime-PostWindow] and above
+/// MinHitPE are taken into account
+///
+/// Created by Fran Nicolas, June 2022
+////////////////////////////////////////////////////////////////////////
+
+#include "fhiclcpp/types/Atom.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "FlashT0Base.hh"
+
+namespace lightana{
+
+  class FlashT0SelectedChannels : FlashT0Base
+  {
+
+  public:
+
+    //Configuration parameters
+    struct Config {
+
+      fhicl::Atom<double> PDFraction {
+        fhicl::Name("PDFraction"),
+        fhicl::Comment("Consider PDs containg a PDFraction of the signal.")
+      };
+
+      fhicl::Atom<double> PreWindow {
+        fhicl::Name("PreWindow"),
+        fhicl::Comment("Consider OpHits in the interval [FlashPeakTime-PreWindow, FlashPeakTime-PostWindow]")
+      };
+
+      fhicl::Atom<double> PostWindow {
+        fhicl::Name("PostWindow"),
+        fhicl::Comment("Consider OpHits in the interval [FlashPeakTime-PreWindow, FlashPeakTime-PostWindow]")
+      };
+
+      fhicl::Atom<double> MinHitPE {
+        fhicl::Name("MinHitPE"),
+        fhicl::Comment("Minimum number of reconstructed PE to consider the OpHit for the t0 calculation")
+      };
+
+    };
+
+    // Default constructor
+    explicit FlashT0SelectedChannels(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    double GetFlashT0(double flash_peaktime, LiteOpHitArray_t ophit_list) override;
+
+  private:
+
+    double fPDFraction;
+    double fPreWindow;
+    double fPostWindow;
+    double fMinHitPE;
+
+  };
+
+  FlashT0SelectedChannels::FlashT0SelectedChannels(art::ToolConfigTable<Config> const& config)
+    : fPDFraction { config().PDFraction() },
+    fPreWindow  { config().PreWindow()  },
+    fPostWindow { config().PostWindow() },
+    fMinHitPE   { config().MinHitPE()   }
+  {
+  }
+
+  double FlashT0SelectedChannels::GetFlashT0(double flash_time, LiteOpHitArray_t ophit_list){
+
+    std::vector< std::pair<double, double> > selected_hits;
+    double pe_sum = 0;
+
+    // fill vector with selected hits in the specified window
+    for(auto const& hit : ophit_list) {
+      if( hit.peak_time<flash_time+fPostWindow && hit.peak_time>flash_time-fPreWindow && hit.pe>fMinHitPE){
+        selected_hits.push_back( std::make_pair(hit.pe, hit.peak_time));
+        pe_sum += hit.pe ;
+      }
+    }
+
+    if(pe_sum>0){
+      // sort vector by number of #PE (ascending order)
+      std::sort( selected_hits.begin(), selected_hits.end(), std::greater< std::pair<double, double> >() );
+
+      double flasht0_mean=0, pe_count=0;
+      int nophits=0;
+
+      // loop over selected ophits
+      for (size_t ix=0; ix<selected_hits.size(); ix++) {
+        pe_count += selected_hits[ix].first;
+        flasht0_mean += selected_hits[ix].second;
+        nophits++;
+        if( pe_count/pe_sum>fPDFraction ) break;
+      }
+
+      return flasht0_mean/nophits;
+    }
+    else
+      return flash_time;
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(lightana::FlashT0SelectedChannels)

--- a/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
+++ b/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
@@ -139,7 +139,7 @@ namespace opdet{
       ::lightana::LiteOpHit_t loph;
       if(trigger_time > 1.e20) trigger_time = oph->PeakTimeAbs() - oph->PeakTime();
 
-      else if(_ophit_input_time=="RiseTime") loph.peak_time = oph->StartTime()+oph->RiseTime();
+      if(_ophit_input_time=="RiseTime") loph.peak_time = oph->StartTime()+oph->RiseTime();
       else if(_ophit_input_time=="StartTime") loph.peak_time = oph->StartTime();
       else loph.peak_time = oph->PeakTime();
 

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_driftestimatoralgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_driftestimatoralgo.fcl
@@ -1,0 +1,13 @@
+#include "opticalsimparameterisations_sbnd.fcl"
+
+BEGIN_PROLOG
+
+DriftEstimatorPMTRatio:
+{
+  tool_type: "DriftEstimatorPMTRatio"
+  CalibrationFile: "OpDetReco/PMTRatioCalibration.root"
+  VGroupVUV: @local::sbnd_vuv_timing_parameterization.vuv_vgroup_mean
+  VGroupVIS: @local::sbnd_vis_timing_parameterization.vis_vmean
+}
+
+END_PROLOG

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
@@ -1,5 +1,7 @@
 #include "sbnd_flashalgo.fcl"
 #include "sbnd_flashcalib.fcl"
+#include "sbnd_flasht0algo.fcl"
+#include "sbnd_driftestimatoralgo.fcl"
 
 BEGIN_PROLOG
 
@@ -11,6 +13,11 @@ SBNDSimpleFlash:
   OpHitProducers  : ["ophitpmt","ophitarapuca"]
   OpFlashProducer : "opflash"
   PECalib         : @local::NoCalib
+  OpHitInputTime  : "PeakTime"
+  UseT0Tool       : false
+  FlashT0Config   : @local::FlashT0SelectedChannels
+  CorrectLightPropagation : false
+  DriftEstimatorConfig    : @local::DriftEstimatorPMTRatio
 }
 
 SBNDSimpleFlashTPC0: @local::SBNDSimpleFlash

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
@@ -1,5 +1,6 @@
 #include "sbnd_flashalgo.fcl"
 #include "sbnd_flashcalib.fcl"
+#include "sbnd_flashgeoalgo.fcl"
 #include "sbnd_flasht0algo.fcl"
 #include "sbnd_driftestimatoralgo.fcl"
 
@@ -14,6 +15,7 @@ SBNDSimpleFlash:
   OpFlashProducer : "opflash"
   PECalib         : @local::NoCalib
   OpHitInputTime  : "PeakTime"
+  FlashGeoConfig  : @local::FlashGeoBarycenter
   UseT0Tool       : false
   FlashT0Config   : @local::FlashT0SelectedChannels
   CorrectLightPropagation : false

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
@@ -1,0 +1,9 @@
+BEGIN_PROLOG
+
+FlashGeoBarycenter:
+{
+  tool_type: "FlashGeoBarycenter"
+  WeightExp: 2
+}
+
+END_PROLOG

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flasht0algo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flasht0algo.fcl
@@ -1,0 +1,18 @@
+BEGIN_PROLOG
+
+FlashT0FirstHit:
+{
+  tool_type: "FlashT0FirstHit"
+  MinHitPE: 1.
+}
+
+FlashT0SelectedChannels:
+{
+  tool_type: "FlashT0SelectedChannels"
+  PDFraction: 0.6
+  PreWindow:  0.02
+  PostWindow: 0.01
+  MinHitPE:   1.
+}
+
+END_PROLOG

--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -52,6 +52,18 @@
 #include <memory>
 #include <algorithm>
 
+namespace {
+  template <typename T>
+  pmtana::PMTPulseRecoBase* thresholdAlgorithm(fhicl::ParameterSet const& hit_alg_pset,
+                                            std::optional<fhicl::ParameterSet> const& rise_alg_pset)
+  {
+    if (rise_alg_pset)
+      return new T(hit_alg_pset, art::make_tool<pmtana::RiseTimeCalculatorBase>(*rise_alg_pset) );
+    else
+      return new T(hit_alg_pset, nullptr);
+  }
+}
+
 namespace opdet {
 
   class SBNDOpHitFinder : public art::EDProducer{
@@ -149,50 +161,26 @@ namespace opdet {
     }
 
     // Initialize the rise time calculator tool
-    using RTC = pmtana::RiseTimeCalculatorBase;
-    using PS = fhicl::ParameterSet;
-
-    PS rise_alg_pset;
-    bool computeRiseTime = pset.get_if_present< PS >("RiseTimeCalculator", rise_alg_pset);
+    auto const rise_alg_pset = pset.get_if_present<fhicl::ParameterSet>("RiseTimeCalculator");
 
     // Initialize the hit finder algorithm
     auto const hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
     std::string threshAlgName = hit_alg_pset.get<std::string>("Name");
-    if (threshAlgName == "Threshold"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoThreshold(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "SiPM"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoSiPM(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "SlidingWindow"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoSlidingWindow(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "FixedWindow"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoFixedWindow(hit_alg_pset, nullptr);
-    }
-    else if (threshAlgName == "CFD"){
-      if(computeRiseTime)
-        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, art::make_tool<RTC>(rise_alg_pset));
-      else
-        fThreshAlg = new pmtana::AlgoCFD(hit_alg_pset, nullptr);
-    }
-    else{
+    if (threshAlgName == "Threshold")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoThreshold>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "SiPM")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoSiPM>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "SlidingWindow")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoSlidingWindow>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "FixedWindow")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoFixedWindow>(hit_alg_pset, rise_alg_pset);
+    else if (threshAlgName == "CFD")
+      fThreshAlg = thresholdAlgorithm<pmtana::AlgoCFD>(hit_alg_pset, rise_alg_pset);
+    else
       throw art::Exception(art::errors::UnimplementedFeature)
         << "Cannot find implementation for " << threshAlgName << " algorithm.\n";
-    }
 
+    // Initialize the pedestal estimation algorithm
     auto const ped_alg_pset = pset.get< fhicl::ParameterSet >("PedAlgoPset");
     std::string pedAlgName = ped_alg_pset.get< std::string >("Name");
     if      (pedAlgName == "Edges")

--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -282,7 +282,7 @@ namespace opdet {
           WaveformVector.push_back(wf);
         }
       }
-    
+
       RunHitFinder(WaveformVector,
                    *HitPtr,
                    fPulseRecoMgr,
@@ -304,6 +304,8 @@ namespace opdet {
       (*HitPtrFinal).emplace_back(h.OpChannel(),
                                   h.PeakTime() + clockData.TriggerTime(),
                                   h.PeakTimeAbs(),
+                                  h.StartTime() + clockData.TriggerTime(),
+                                  h.RiseTime() + clockData.TriggerTime(),
                                   h.Frame(),
                                   h.Width(),
                                   h.Area(),

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -19,6 +19,8 @@ sbnd_ophit_finder:
   reco_man:       @local::standard_preco_manager
   HitAlgoPset:    @local::sbnd_opreco_hit_slidingwindow
   PedAlgoPset:    @local::sbnd_opreco_pedestal_rmsslider
+  #uncomment to calculate risetime
+  #RiseTimeCalculator:   @local::sbnd_opreco_risetimecalculator
 }
 
 #

--- a/sbndcode/OpDetReco/OpHit/job/ophitconfig_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophitconfig_sbnd.fcl
@@ -1,4 +1,5 @@
 #include "opticaldetectormodules.fcl"
+#include "risetimecalculator_tool.fcl"
 
 BEGIN_PROLOG
 
@@ -62,5 +63,11 @@ sbnd_opreco_hit_cfd.Delay:       2
 sbnd_opreco_hit_cfd.PeakThresh:  7.5
 sbnd_opreco_hit_cfd.StartThresh: 5.0
 sbnd_opreco_hit_cfd.EndThresh:   1.5
+
+#
+# RiseTime calculator
+#
+sbnd_opreco_risetimecalculator: @local::RiseTimeThreshold
+sbnd_opreco_risetimecalculator.PeakRatio: 0.15
 
 END_PROLOG


### PR DESCRIPTION
This PR adds new features to the OpFlash t0 estimation. A detailed description can be found in [docdb-25743](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=25743) and section 6 of [this](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=26422) tech note.

Summary:
- Update OpHit producer to fill StartTime and RiseTime new attributes (see [PR26](https://github.com/LArSoft/lardataobj/pull/26) in lardataobj)
- Add option in OpFlash producer to use the OpHit StartTime/RiseTime
- Add tool for drift coordinate estimation and light propagation time correction
- Add tools for better estimate the OpFlash t0
- Flash barycenter is now calculated by a configurable external tool. Y and Z position of the PMTs is weighted by default by the squared number of PE (better describes photon attenuation with the distance/reduces border effects)

Note: requires new file "OpDetReco/PMTRatioCalibration.root" in sbnd_data
Depends on LArSoft/larana#19