### PR TITLE
added lines to track and shower creation blocks to run the creations …

### DIFF
--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -125,7 +125,6 @@ sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools: [
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[8].ShowerDirectionOutputLabel: "TrajDirection"
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].FirstDirectionInputLabel: "TrajDirection"
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].SecondDirectionInputLabel: "ShowerDirection"
-sbnd_incremental_pandoraModularShowerCreation.UseAllParticles: true
 
 sbnd_cheat_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::sbnd_showerstartpositioncheater,

--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -68,6 +68,8 @@ sbnd_showertrackfindercheater.HitModuleLabel: "gaushit"
 sbnd_showertrackfindercheater.LArPandoraShowerCheatingAlg: @local::sbnd_larpandorashowercheatingalg
 
 # Pandora Shower Configurations
+standard_pandoraModularShowerCreation.UseAllParticles: true
+
 sbnd_legacy_pandoraModularShowerCreation:      @local::legacy_pandoraModularShowerCreation
 sbnd_basic_pandoraModularShowerCreation:       @local::standard_pandoraModularShowerCreation
 sbnd_3dTraj_pandoraModularShowerCreation:      @local::standard_pandoraModularShowerCreation
@@ -123,6 +125,7 @@ sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools: [
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[8].ShowerDirectionOutputLabel: "TrajDirection"
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].FirstDirectionInputLabel: "TrajDirection"
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].SecondDirectionInputLabel: "ShowerDirection"
+sbnd_incremental_pandoraModularShowerCreation.UseAllParticles: true
 
 sbnd_cheat_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::sbnd_showerstartpositioncheater,

--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -42,11 +42,13 @@ sbnd_pandoraTrackCreation:
 {
     module_type:                                                    "LArPandoraTrackCreation"
     PFParticleLabel:                                                "pandora"
+    UseAllParticles:                                                true
 }
 
 sbnd_pandoraShowerCreation:
 {
     module_type:                                                    "LArPandoraShowerCreation"
+    UseAllParticles:                                                true
 }
 
 # Need to set up sbnd specific versions of the cheating tools to accomodate the change in input label


### PR DESCRIPTION
…over all PFOs

Matched to the similar PR here for icaruscode https://github.com/SBNSoftware/icaruscode/pull/424

also matched to the following PRs in sbnanaobj, sbnana, and sbncode

https://github.com/SBNSoftware/sbnanaobj/pull/66
https://github.com/SBNSoftware/sbnana/tree/feature/rh_testCAF
https://github.com/SBNSoftware/sbncode/tree/feature/rh_allPFOs