### PR TITLE
Update ci_tests.cfg

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -446,7 +446,7 @@ STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=10:102
-mem_usage_range=100000:400002
+mem_usage_range=500000:700000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 
@@ -467,8 +467,8 @@ STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=100:252
-mem_usage_range=200000:500002
+cpu_usage_range=1200:1600
+mem_usage_range=3500000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -490,8 +490,8 @@ STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=150:452
-mem_usage_range=400000:900002
+cpu_usage_range=1050:1200
+mem_usage_range=3500000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -513,8 +513,8 @@ STAGE_NAME=reco1
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=600:1102
-mem_usage_range=1100000:2000000
+cpu_usage_range=300:450
+mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -536,8 +536,8 @@ STAGE_NAME=reco2
 INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=600:1102
-mem_usage_range=1100000:2000000
+cpu_usage_range=1900:2200
+mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -558,8 +558,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=130:180
-mem_usage_range=2000000:4000000
+cpu_usage_range=80:110
+mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -814,8 +814,8 @@ testlist=nucosmics_gen_quick_test_sbndcode nucosmics_g4_quick_test_sbndcode nuco
 STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=400:1500
-mem_usage_range=800000:1800003
+cpu_usage_range=600:900
+mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)snucosmics_%(STAGE_NAME)s_seq_test_sbndcode.fcl
@@ -835,8 +835,8 @@ STAGE_NAME=g4
 INPUT_STAGE_NAME=gen
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=400:18003
-mem_usage_range=2200000:3000000
+cpu_usage_range=3500:4200
+mem_usage_range=4500000:5500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -858,8 +858,8 @@ STAGE_NAME=detsim
 INPUT_STAGE_NAME=g4
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=500:1400
-mem_usage_range=2200000:4100003
+cpu_usage_range=1100:1400
+mem_usage_range=3500000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -881,8 +881,8 @@ STAGE_NAME=reco1
 INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=300:1500
-mem_usage_range=1000000:3000003
+cpu_usage_range=600:800
+mem_usage_range=3000000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -904,8 +904,8 @@ STAGE_NAME=reco2
 INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=150:1250
-mem_usage_range=800000:2500003
+cpu_usage_range=2200:2500
+mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -926,8 +926,8 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
-cpu_usage_range=200:500
-mem_usage_range=2000000:4000000
+cpu_usage_range=3300:4300
+mem_usage_range=3500000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -491,7 +491,7 @@ INPUT_STAGE_NAME=g4
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=1050:1200
-mem_usage_range=3500000:4500000
+mem_usage_range=3000000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -514,7 +514,7 @@ INPUT_STAGE_NAME=detsim
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
 cpu_usage_range=300:450
-mem_usage_range=2500000:3500000
+mem_usage_range=2500000:4000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -269,7 +269,7 @@ STAGE_NAME=gen
 NEVENTS=5
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=0:100
-mem_usage_range=200000:600000
+mem_usage_range=400000:800000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 FHiCL_FILE=%(CI_FHICL_PREFIX_SBNDCODE)ssingle_%(STAGE_NAME)s_quick_test_sbndcode.fcl

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -927,7 +927,7 @@ INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=3300:4300
-mem_usage_range=3000000:4500000
+mem_usage_range=3000000:5000000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -537,7 +537,7 @@ INPUT_STAGE_NAME=reco1
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
 cpu_usage_range=1900:2200
-mem_usage_range=2500000:3500000
+mem_usage_range=2000000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=single_%(INPUT_STAGE_NAME)s_seq_test_sbndcode
@@ -558,7 +558,7 @@ STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_SINGLE_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180306
-cpu_usage_range=80:110
+cpu_usage_range=80:150
 mem_usage_range=2500000:3500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
@@ -927,7 +927,7 @@ INPUT_STAGE_NAME=reco2
 NEVENTS=%(NEVENTS_SEQ_NUCOSMICS_SBNDCODE)s
 # calibrated on sbndbuild01.fnal.gov on 20180305
 cpu_usage_range=3300:4300
-mem_usage_range=3500000:4500000
+mem_usage_range=3000000:4500000
 
 script=%(EXPSCRIPT_SBNDCODE)s
 requires=nucosmics_%(INPUT_STAGE_NAME)s_seq_test_sbndcode


### PR DESCRIPTION
Reflecting current memory usage.

Have also updated the seq tests to have more sensible resource requirements. This is because they run more events than the quick tests (5 vs. 2) and we have never tuned the values. We've recently started using this test more so would be helpful to have these limits added!