### PR TITLE
XARAPUCA's SimpleFlashAlgo chain with hits from deconvolved waveforms

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/flashfinder_deco_sbnd.fcl
@@ -77,4 +77,28 @@ SBNDDecoOpHitFinderXArapuca.PedAlgoPset.NumSampleFront:50
 SBNDDecoOpHitFinderXArapuca.PedAlgoPset.NumSampleTail:500
 SBNDDecoOpHitFinderXArapuca.PedAlgoPset.Method:0
 
+####OpFlash finder for XArapucas deconvolved waveforms#####
+###TPC0
+SBNDDecoSimpleFlashTPC0Arapuca: @local::SBNDSimpleFlashTPC0
+SBNDDecoSimpleFlashTPC0Arapuca.PECalib.SPEAreaGain: 500
+SBNDDecoSimpleFlashTPC0Arapuca.OpHitProducers: ["ophitdecoxarapuca"]
+SBNDDecoSimpleFlashTPC0Arapuca.OpFlashProducer: "opflasharapuca"
+SBNDDecoSimpleFlashTPC0Arapuca.AlgoConfig.PD: ["xarapuca_vuv","xarapuca_vis"]
+#TPC1
+SBNDDecoSimpleFlashTPC1Arapuca: @local::SBNDSimpleFlashTPC1
+SBNDDecoSimpleFlashTPC1Arapuca.PECalib.SPEAreaGain: 500
+SBNDDecoSimpleFlashTPC1Arapuca.OpHitProducers: ["ophitdecoxarapuca"]
+SBNDDecoSimpleFlashTPC1Arapuca.OpFlashProducer: "opflasharapuca"
+SBNDDecoSimpleFlashTPC1Arapuca.AlgoConfig.PD: ["xarapuca_vuv","xarapuca_vis"]
+
+physics.producers.opflashdecotpc0arapuca.AlgoConfig.MinMultCoinc: 3
+physics.producers.opflashdecotpc0arapuca.AlgoConfig.PEThreshold: 30
+physics.producers.opflashdecotpc0arapuca.AlgoConfig.TimeResolution: 0.06
+
+physics.producers.opflashdecotpc1arapuca.AlgoConfig.MinMultCoinc: 3
+physics.producers.opflashdecotpc1arapuca.AlgoConfig.PEThreshold: 30
+physics.producers.opflashdecotpc1arapuca.AlgoConfig.TimeResolution: 0.06
+
+
+
 END_PROLOG

--- a/sbndcode/OpDetReco/OpDeconvolution/run_decohitfinder.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/run_decohitfinder.fcl
@@ -47,8 +47,8 @@ physics:
 
     opdecoxarapuca:     @local::SBNDOpDeconvolutionXARAPUCA
     ophitdecoxarapuca:  @local::SBNDDecoOpHitFinderXArapuca
-    # opflashdecotpc0:   @local::SBNDDecoSimpleFlashTPC0
-    # opflashdecotpc1:   @local::SBNDDecoSimpleFlashTPC1
+    opflashdecotpc0arapuca:   @local::SBNDDecoSimpleFlashTPC0Arapuca
+    opflashdecotpc1arapuca:   @local::SBNDDecoSimpleFlashTPC1Arapuca
 
   }
 
@@ -59,9 +59,9 @@ physics:
     opflashdecotpc1,
 
     opdecoxarapuca,
-    ophitdecoxarapuca
-    # opflashdecotpc0,
-    # opflashdecotpc1
+    ophitdecoxarapuca,
+    opflashdecotpc0arapuca,
+    opflashdecotpc1arapuca
   ]
 
 


### PR DESCRIPTION
Tune of the SimpleFlashAlgo for XARAPUCA deconvolved signals. Based on the studies presented at CM([docdb 26809](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=26809) )