### PR TITLE
Persist PFO BDT features

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -318,6 +318,7 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
+    <PersistFeatures>true</PersistFeatures>
     <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT1</MvaName>
     <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileNameNoChargeInfo>
@@ -425,6 +426,7 @@
     <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileNameNoChargeInfo>
     <MvaNameNoChargeInfo>PfoCharBDTNoChargeInfo2</MvaNameNoChargeInfo>
     <MinProbabilityCut>0.51</MinProbabilityCut>
+    <PersistFeatures>true</PersistFeatures>
     <FeatureTools>
       <tool type = "LArThreeDLinearFitFeatureTool"/>
       <tool type = "LArThreeDVertexDistanceFeatureTool"/>

--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -318,7 +318,6 @@
     <TrackPfoListName>TrackParticles3D</TrackPfoListName>
     <ShowerPfoListName>ShowerParticles3D</ShowerPfoListName>
     <UseThreeDInformation>true</UseThreeDInformation>
-    <PersistFeatures>true</PersistFeatures>
     <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
     <MvaName>PfoCharBDT1</MvaName>
     <MvaFileNameNoChargeInfo>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileNameNoChargeInfo>


### PR DESCRIPTION
The sbnd equivalent edition to SBNSoftware/icaruscode#447

Changes the pandora xml to utilise newly added features in LArContent to persist extra metadata (PFO characterisation variables). CIwise it shouldn't change anything other than adding fields to PFOs in the CAFs.