### PR TITLE
CRUMBS Multi Signal

### DIFF
--- a/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/crumbs_sbnd.fcl
@@ -6,6 +6,7 @@
 
 #include "rootoutput_sbnd.fcl"
 #include "services_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
 
 process_name: CRUMBS
 
@@ -13,6 +14,8 @@ services:
 {
    TFileService: { fileName: @local::sbnd_tfileoutput.fileName }
    @table::sbnd_services
+   BackTrackerService: @local::sbnd_backtrackerservice
+   ParticleInventoryService: @local::sbnd_particleinventoryservice
 }
 
 source: {

--- a/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_cosmic_only.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_cosmic_only.fcl
@@ -1,0 +1,17 @@
+#
+# fcl file to produce CRUMBS training trees
+# to be run on files containing just true
+# cosmics
+#
+
+#include "crumbs_sbnd.fcl"
+
+physics.producers.crumbs.TrainingMode:     true
+physics.producers.crumbs.ProcessNeutrinos: false
+
+# This line removes the artroot output
+physics.stream1: []
+
+# To still produce artroot output with the calcluated
+# CRUMBS score remove the above line and uncomment this
+# physics.producers.crumbs.EvaluateResultInTrainingMode: true

--- a/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_nu_cosmics.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_nu_cosmics.fcl
@@ -1,0 +1,16 @@
+#
+# fcl file to produce CRUMBS training trees
+# to be run on files containing true neutrinos
+# and true cosmics
+#
+
+#include "crumbs_sbnd.fcl"
+
+physics.producers.crumbs.TrainingMode: true
+
+# This line removes the artroot output
+physics.stream1: []
+
+# To still produce artroot output with the calcluated
+# CRUMBS score remove the above line and uncomment this
+# physics.producers.crumbs.EvaluateResultInTrainingMode: true

--- a/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_nu_only.fcl
+++ b/sbndcode/JobConfigurations/standard/ana/produce_crumbs_training_trees_nu_only.fcl
@@ -1,0 +1,17 @@
+#
+# fcl file to produce CRUMBS training trees
+# to be run on files containing just true
+# neutrinos
+#
+
+#include "crumbs_sbnd.fcl"
+
+physics.producers.crumbs.TrainingMode:   true
+physics.producers.crumbs.ProcessCosmics: false
+
+# This line removes the artroot output
+physics.stream1: []
+
+# To still produce artroot output with the calcluated
+# CRUMBS score remove the above line and uncomment this
+# physics.producers.crumbs.EvaluateResultInTrainingMode: true

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -36,7 +36,7 @@ fwdir   product_dir scripts
 product          version
 
 sbncode          v09_58_02_01
-sbnd_data        v01_14_00 - optional
+sbnd_data        v01_15_00 - optional
 sbndutil         v09_58_02_01 - optional
 
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -35,7 +35,6 @@ fwdir   product_dir scripts
 
 product          version
 
-
 sbncode          v09_59_00
 sbnd_data        v01_15_00 - optional
 sbndutil         v09_59_00 - optional


### PR DESCRIPTION
Contains fcl updates to run the updated version of CRUMBS with different versions per signal. Also adds fcls for producing the training trees from different samples.