### PR TITLE
Convert CI to use SCE enabled fcls

### DIFF
--- a/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_caf_quick_test_sbndcode.fcl
@@ -1,4 +1,4 @@
-#include "cafmakerjob_sbnd_genie_and_fluxwgt.fcl"
+#include "cafmakerjob_sbnd_sce_genie_and_fluxwgt.fcl"
 
 services.NuRandomService.policy: "perEvent"
 

--- a/test/ci/sbnd_ci_nucosmics_detsim_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_detsim_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_detsim_sbnd.fcl"
+#include "detsim_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_nucosmics_g4_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_g4_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_g4_sbnd.fcl"
+#include "g4_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_nucosmics_reco1_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_reco1_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_reco1_sbnd.fcl"
+#include "reco1_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_nucosmics_reco2_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_nucosmics_reco2_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_reco2_sbnd.fcl"
+#include "reco2_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_caf_quick_test_sbndcode.fcl
@@ -1,4 +1,4 @@
-#include "cafmakerjob_sbnd.fcl"
+#include "cafmakerjob_sbnd_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"
 

--- a/test/ci/sbnd_ci_single_detsim_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_detsim_quick_test_sbndcode.fcl
@@ -1,4 +1,4 @@
-#include "standard_detsim_sbnd.fcl"
+#include "detsim_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"
 

--- a/test/ci/sbnd_ci_single_g4_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_g4_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_g4_sbnd.fcl"
+#include "g4_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_single_reco1_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_reco1_quick_test_sbndcode.fcl
@@ -1,3 +1,3 @@
-#include "standard_reco1_sbnd.fcl"
+#include "reco1_sce.fcl"
 
 services.NuRandomService.policy: "perEvent"

--- a/test/ci/sbnd_ci_single_reco2_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_reco2_quick_test_sbndcode.fcl
@@ -1,4 +1,4 @@
-#include "standard_reco2_sbnd.fcl"
+#include "reco2_sce.fcl"
 
 # rig the output file name to be the one expected by the C.I. configuration
 services.TFileService.fileName: "standard_g4_sbnd_Reco-current_hist.root"


### PR DESCRIPTION
Production have been using SCE as standard for quite a while. I thought we had updated the CI to reflect this quite a long time back. Checking my notes, we held off because we didn't have an operational sequential test to validate this with. 

This is a breaking change to the standard CI because the input files for the caf stage won't contain the SCE-type reconstruction products. I have run the [sequential](https://dbweb9.fnal.gov:8443/TestCI/app/ns:SBND/build_detail/phase_details?build_id=sbnd_ci/10387&platform=Linux%203.10.0-1160.71.1.el7.x86_64&phase=ci_tests&buildtype=slf7%20e20:prof) tests on this PR. I'm happy with the results and I think we should make this change as part of this week's release (not before testing other PRs) so we can reset before the next release.

Not entirely sure who should review so I've cast a little net... ;) 