### PR TITLE
Turn off blinding in cafmaker for MC

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -122,6 +122,9 @@ physics.producers.vertexStub.CaloAlg: @local::sbnd_calorimetryalgmc
 physics.producers.cafmaker: @local::standard_cafmaker
 physics.producers.cafmaker.CosmicGenLabel: "corsika"
 
+# Blinding not needed for MC
+physics.producers.cafmaker.CreateBlindedCAF: false
+
 # Overwrite weight_functions label:
 physics.producers.genieweight.weight_functions: @local::physics.producers.genieweight.weight_functions_genie
 physics.producers.fluxweight.weight_functions: @local::physics.producers.fluxweight.weight_functions_flux


### PR DESCRIPTION
Turn off newly added blinding code in cafmaker for MC since it's only needed for data (and SBND has no data cafmaker fcls right now). Added to cafmakerjob_sbnd.fcl which should propagate to other cafmaker fcls.