### PR TITLE
Necessary updates to utilise new geometry in gallery tests

### DIFF
--- a/sbndcode/gallery/galleryAnalysis/HitAnalysisAlg.cpp
+++ b/sbndcode/gallery/galleryAnalysis/HitAnalysisAlg.cpp
@@ -53,9 +53,9 @@ void HitAnalysisAlg::setup(const geo::GeometryCore&           geometry,
     // Make a directory for these histograms
 //    art::TFileDirectory dir = tfs->mkdir(fLocalDirName.c_str());
 
-    fHitsByWire[0]            = std::make_unique<TH1D>("HitsByWire0", ";Wire #", fGeometry->Nwires(0), 0., fGeometry->Nwires(0));
-    fHitsByWire[1]            = std::make_unique<TH1D>("HitsByWire1", ";Wire #", fGeometry->Nwires(1), 0., fGeometry->Nwires(1));
-    fHitsByWire[2]            = std::make_unique<TH1D>("HitsByWire2", ";Wire #", fGeometry->Nwires(2), 0., fGeometry->Nwires(2));
+    fHitsByWire[0]            = std::make_unique<TH1D>("HitsByWire0", ";Wire #", fGeometry->Nwires(geo::PlaneID(0, 0, 0)), 0., fGeometry->Nwires(geo::PlaneID(0, 0, 0)));
+    fHitsByWire[1]            = std::make_unique<TH1D>("HitsByWire1", ";Wire #", fGeometry->Nwires(geo::PlaneID(0, 0, 1)), 0., fGeometry->Nwires(geo::PlaneID(0, 0, 1)));
+    fHitsByWire[2]            = std::make_unique<TH1D>("HitsByWire2", ";Wire #", fGeometry->Nwires(geo::PlaneID(0, 0, 2)), 0., fGeometry->Nwires(geo::PlaneID(0, 0, 2)));
     
     fDriftTimes[0]            = std::make_unique<TH1D>("DriftTime0",  ";time(ticks)", 3200, 0., 9600.);
     fDriftTimes[1]            = std::make_unique<TH1D>("DriftTime1",  ";time(ticks)", 3200, 0., 9600.);
@@ -122,7 +122,7 @@ void HitAnalysisAlg::setup(const geo::GeometryCore&           geometry,
     
     fBadWPulseHeight          = std::make_unique<TH1D>("BWPulseHeight", "PH (ADC)",  300,  0.,  150.);
     fBadWPulseHVsWidth        = std::make_unique<TH2D>("BWPHVsWidth",   ";PH;Width", 100,  0.,  100., 100,  0., 10.);
-    fBadWHitsByWire           = std::make_unique<TH1D>("BWHitsByWire",  ";Wire #", fGeometry->Nwires(2), 0., fGeometry->Nwires(2));
+    fBadWHitsByWire           = std::make_unique<TH1D>("BWHitsByWire",  ";Wire #", fGeometry->Nwires(geo::PlaneID(0, 0, 2)), 0., fGeometry->Nwires(geo::PlaneID(0, 0, 2)));
     
     fSPHvsIdx[0]              = std::make_unique<TH2D>("SPHVsIdx0",     ";PH;Idx", 30,  0.,  30., 100,  0., 100.);
     fSPHvsIdx[1]              = std::make_unique<TH2D>("SPHVsIdx1",     ";PH;Idx", 30,  0.,  30., 100,  0., 100.);

--- a/sbndcode/gallery/galleryAnalysis/MCAssociations.cpp
+++ b/sbndcode/gallery/galleryAnalysis/MCAssociations.cpp
@@ -393,7 +393,7 @@ double MCAssociations::length(const simb::MCParticle& part, double dx,
         {
             const geo::TPCGeo& tpcGeo = fGeometry->PositionToTPC(geo::vect::toPoint(pos));
             
-            TVector3 activePos = posVec - tpcGeo.GetActiveVolumeCenter();
+            geo::Vector_t activePos = geo::vect::toPoint(posVec) - tpcGeo.GetActiveVolumeCenter();
             
             if (part.TrackId() == findTrackID)
                 std::cout << "   --> traj point: " << i << ", pos: " << posVec.X() << "/" << posVec.Y() << "/" << posVec.Z() << ", active pos: " << activePos.X() << "/" << activePos.Y() << "/" << activePos.Z() << std::endl;


### PR DESCRIPTION
Make some changes to the gallery compilation code to make it compatible with the new geometry framework. 

This forms part of the compilation regression test. It is only compiled when the test is run, hence won't have shown up in standard compilations. The use of PlaneID illustrates that these histograms only cover one of the two SBND TPC's, however, all I am doing here is restoring the previous default behaviour. I have tested offline that this test is now successful.

@knoepfel I can't seem to formally request you for a review but if you have a moment to cast your eyes over this it would be appreciated.