### PR TITLE
Bring the fast sim/reco unit tests into the 2020s

### DIFF
--- a/test/JobConfigurations/CMakeLists.txt
+++ b/test/JobConfigurations/CMakeLists.txt
@@ -1,6 +1,6 @@
 # for PREBUILT tests, the test name is the executable name, and no argument is allowed
-cet_test(prodsingle_reconstruction_test.sh PREBUILT)
-cet_test(fast_simulation_reconstruction_test.sh PREBUILT)
+cet_test(fast_simulation_reconstruction_test_electrons.sh PREBUILT)
+cet_test(fast_simulation_reconstruction_test_muons.sh PREBUILT)
 
 cet_test(prodcosmics_cry_test HANDBUILT
   TEST_EXEC lar

--- a/test/JobConfigurations/fast_simulation_reconstruction_test_electrons.sh
+++ b/test/JobConfigurations/fast_simulation_reconstruction_test_electrons.sh
@@ -7,10 +7,11 @@
 ###  Tests to be executed in chain:
 ###
 declare -ar TestNames=(
-  'prod_eminus_0.1_0.9_sbnd'
-  'standard_g4_sbnd'
-  'standard_detsim_sbnd'
-  'standard_reco_sbnd_basic'
+    'prodsingle_electron_bnblike_newflux'
+    'g4_sce'
+    'detsim_sce'
+    'reco1_sce'
+    'reco2_sce'
 )
 #############################################################################
 

--- a/test/JobConfigurations/fast_simulation_reconstruction_test_muons.sh
+++ b/test/JobConfigurations/fast_simulation_reconstruction_test_muons.sh
@@ -7,8 +7,11 @@
 ###  Tests to be executed in chain:
 ###
 declare -ar TestNames=(
-	prodsingle_sbnd
-	standard_reco_sbnd_basic
+    'prodsingle_mu_bnblike_newflux'
+    'g4_sce'
+    'detsim_sce'
+    'reco1_sce'
+    'reco2_sce'
 )
 #############################################################################
 


### PR DESCRIPTION
We have two unit tests in SBND that run the sim/reco chain quickly on a single particle gun. These tests rarely fail so I have never paid to much attention to them. They did fail this week (whilst testing SBNSoftware/sbndcode#311) so I did... and I noticed:

- They are pretty out of date (using old fcls etc).
- They have slightly confusing names (the aim seems to be the same but with electrons and muons).

Thanks to @PetrilloAtWork I have done a little tinkering to rename them consistently and make use of newer, more appropriate fcls.