### PR TITLE
Remove conflicting sbnd_crtsim table

### DIFF
--- a/sbndcode/CRT/crtsim_sbnd.fcl
+++ b/sbndcode/CRT/crtsim_sbnd.fcl
@@ -11,7 +11,6 @@
 # modules
 #
 
-#include "detsimmodules_sbnd.fcl"
 #include "crtsimmodules_sbnd.fcl"
 #include "crtslimmer_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"

--- a/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
+++ b/sbndcode/DetectorSim/detsimmodules_sbnd.fcl
@@ -31,12 +31,6 @@ sbnd_simwireana:
 
 }
 
-sbnd_crtsim:
-{
-  module_type: "sbndcode/CRT/CRTSimDigits"
-  ADSCLabel: "sim::AuxDetSimChannel"
-}
-
 sbnd_wienerfilterana: @local::standard_wienerfilterana
 
 END_PROLOG


### PR DESCRIPTION
In all of today's CI fun & games I found another small issue we should probably address.

Since the CRT simulation updates we have had two definitions of the table sbnd_crtsim

One in [detsimmodules_sbnd.fcl](https://github.com/SBNSoftware/sbndcode/blob/develop/sbndcode/DetectorSim/detsimmodules_sbnd.fcl#L34) and one in [crtsimmodules_sbnd.fcl](https://github.com/SBNSoftware/sbndcode/blob/develop/sbndcode/CRT/crtsimmodules_sbnd.fcl#L73).

The former is a legacy definition which utilises a module that no longer exists, the latter is the current widely used detector simulation parameters for the CRT.

We've got away without problems because in the examples where both fcls have been included in a job fcl the order has been the 'correct' way around to define the one we want.

Given the alternative module no longer exists I think we should remove the former table not rename it. I have also removed an un-needed inclusion of the detsimmodules_sbnd fcl in the crtsim_sbnd fcl.

Sorry, very wordy explanation for a very simple change :rofl: 