### PR TITLE
Update fcls and MVA weights for improved hit finding

### DIFF
--- a/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
@@ -8,7 +8,7 @@ sbnd_calorimetryalgdata:    @local::standard_calorimetryalgdata
 sbnd_calorimetryalgmc:      @local::standard_calorimetryalgmc
 sbnd_calorimetryalgmc.CalAreaConstants:  [ 0.0200906, 0.0200016, 0.0201293 ]
 # amplitude constants below are arbitrary and have not yet been tuned
-sbnd_calorimetryalgmc.CalAmpConstants:   	[ 0.588726e-3, 0.588726e-3, 1.18998e-3 ]
+sbnd_calorimetryalgmc.CalAmpConstants:    [ 0.588726e-3, 0.588726e-3, 1.18998e-3 ]
 
 sbnd_calodata:              @local::standard_calodata
 sbnd_calodata.CaloAlg:      @local::sbnd_calorimetryalgdata
@@ -16,8 +16,9 @@ sbnd_calodata.CaloAlg:      @local::sbnd_calorimetryalgdata
 sbnd_calomc:                @local::standard_calomc
 sbnd_calomc.CaloAlg:        @local::sbnd_calorimetryalgmc
 
-sbnd_gnewcalomc:            @local::standard_gnocchicalo
+sbnd_gnewcalomc:              @local::standard_gnocchicalo
+sbnd_gnewcalomc.CaloAlg:      @local::sbnd_calorimetryalgmc
+sbnd_gnewcalomc.ChargeMethod: 3
 sbnd_gnewcalomc.SpacePointModuleLabel: @erase
-sbnd_gnewcalomc.CaloAlg:    @local::sbnd_calorimetryalgmc
 
 END_PROLOG

--- a/sbndcode/LArSoftConfigurations/hitfindermodules_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/hitfindermodules_sbnd.fcl
@@ -6,14 +6,30 @@ sbnd_hitfinder:               @local::standard_hitfinder
 sbnd_mc_hitfinder:            @local::standard_hitfinder
 sbnd_mc_hitfinder.AreaNorms:  [ 12.89, 14.51 ]
 
+sbnd_candhitfinder_morphological: @local::candhitfinder_morphological
+sbnd_candhitfinder_morphological.MinDeltaTicks: 2
+sbnd_candhitfinder_morphological.Plane: 999 # Set the defualt plane to fail and make sure we overridde the individual planes
+sbnd_candhitfinder_morphological_0: @local::sbnd_candhitfinder_morphological
+sbnd_candhitfinder_morphological_0.Plane: 0
+sbnd_candhitfinder_morphological_0.MinHitHeight: 12
+sbnd_candhitfinder_morphological_1: @local::sbnd_candhitfinder_morphological
+sbnd_candhitfinder_morphological_1.Plane: 1
+sbnd_candhitfinder_morphological_1.MinHitHeight: 15
+sbnd_candhitfinder_morphological_2: @local::sbnd_candhitfinder_morphological
+sbnd_candhitfinder_morphological_2.Plane: 2
+sbnd_candhitfinder_morphological_2.MinHitHeight: 8
+
 # generic (ArgoNeuT) GausHitFinder configuration from LArSoft 4.24.00:
 sbnd_gaushitfinder:                                                   @local::gaus_hitfinder
-sbnd_gaushitfinder.AreaNorms:                                         [ 13.25, 13.25, 26.31 ]  # normalizations that put signal area in 
-				                                                                               # same scale as peak height. 
-sbnd_gaushitfinder.TryNplus1Fits:                                     false                    # whether to try to re-fit poorly modled hits with n+1 gaussians
-sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane0.RoiThreshold: 14.
-sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane1.RoiThreshold: 17.
-sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane2.RoiThreshold: 10.
+sbnd_gaushitfinder.AreaNorms:                                         [ 13.25, 13.25, 26.31 ]  # normalizations that put signal area in
+                                                                                               # same scale as peak height.
+sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane0:              @local::sbnd_candhitfinder_morphological_0
+sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane1:              @local::sbnd_candhitfinder_morphological_1
+sbnd_gaushitfinder.HitFinderToolVec.CandidateHitsPlane2:              @local::sbnd_candhitfinder_morphological_2
+sbnd_gaushitfinder.PeakFitter.Refit:                                  true
+sbnd_gaushitfinder.LongMaxHits:                                     [ 25, 25, 25] # max widths for hits in long pulse trains
+sbnd_gaushitfinder.LongPulseWidth:                                  [ 10, 10, 10] # max number hits in long pulse trains
+sbnd_gaushitfinder.Chi2NDF:                                           500
 
 sbnd_fasthitfinder:                     @local::standard_fasthitfinder
 sbnd_fasthitfinder.DigitModuleLabel:    "daq"

--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -92,7 +92,9 @@ sbnd_showerlinearenergy.Gradients: [0.00155644, 0.00173915, 0.00153631]
 sbnd_showerlinearenergy.Intercepts: [5.92931, -2.13307, 5.19711]
 sbnd_showernumelectronsenergy.CalorimetryAlg: @local::sbnd_calorimetryalgmc
 sbnd_showerunidirectiondedx.CalorimetryAlg:   @local::sbnd_calorimetryalgmc
+sbnd_showerunidirectiondedx.SumHitSnippets:   true
 sbnd_showertrajpointdedx.CalorimetryAlg:      @local::sbnd_calorimetryalgmc
+sbnd_showertrajpointdedx.SumHitSnippets:      true
 sbnd_showerbayesiantrucatingdedx.PriorFname: "PandoraMVAs/ShowerBayesdEdxPriors.root"
 
 sbnd_basic_pandoraModularShowerCreation.ShowerFinderTools: [

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -254,7 +254,7 @@ libdir	fq_dir		lib
 product		version		qual	flags		<table_format=2>
 sbncode		v09_66_00	-
 cetmodules	v3_20_00	-	only_for_build
-sbnd_data	v01_16_00	-	optional
+sbnd_data	v01_17_00	-	optional
 sbndutil	v09_66_00	-	optional
 end_product_list
 ####################################


### PR DESCRIPTION
This PR enables the morphological hit finder and enables the `N+1` added in https://github.com/LArSoft/larreco/pull/51 to improve the performance of the hit finding. 

The calorimetry for tracks and showers are also updated to better handle cases when hits are split in https://github.com/LArSoft/larreco/pull/52 and https://github.com/LArSoft/larpandora/pull/34  respectively. 

Finally, the version of `sbnd_data` is bumped corresponding to the new MVA weights that have been retrained using the improved hit finding as an input. This includes updates to,all three of the MVAs within Pandora, the Razzle-Dazzle PID, and the CRUMBS cosmic rejection BDT. 