### PR TITLE
Enable neutrino time of flight in genie fcl

### DIFF
--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -281,6 +281,7 @@ sbnd_genie: {
   #EventGeneratorList:      "Default+CCMEC+NCMEC" # Only needed to generate partial samples in GENIE v3
    DefinedVtxHistRange: true
    VtxPosHistRange:     [ -210, 210, -210, 210, -10, 510 ]
+   AddGenieVtxTime: true		#Enable adding time of flight to neutrino vertex
 } # sbnd_genie
 
 sbnd_genie_hist: {


### PR DESCRIPTION
Following the flux file update in PR#320, now enables neutrino time of flight in the standard genie fcl
