### PR TITLE
Change default pandora nu score

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Master_SBND.xml
@@ -33,6 +33,7 @@
         <MvaFileName>PandoraMVAs/PandoraBdt_SBND.xml</MvaFileName>
         <MvaName>NeutrinoId</MvaName>
         <MinimumNeutrinoProbability>0</MinimumNeutrinoProbability>
+        <DefaultProbability>-1</DefaultProbability>
         <MaximumNeutrinos>999</MaximumNeutrinos>
         <PersistFeatures>true</PersistFeatures>
       </tool>


### PR DESCRIPTION
Accompanying PR to PandoraPFA/LArContent#207, should not be tested / merged until the pandora PR has gone into `larpandoracontent`.

This will activate a new feature in the slice ID algorithm allowing us to manually set the default probability to -1. The previous default was 0 which was meant to indicate cosmic status but because we save all ambiguous slices as _neutrinos_ this was being saved with a neutrino ID but none of the calculated score variables. This was picked up by @fjnicolas via CRUMBS.

This will allow us to immediately identify slices for which some aspect of the reconstruction didn't succeed and as such not try to process it like other _neutrino_ slices.