### PR TITLE
Add event display algorithm and module

### DIFF
--- a/sbndcode/CRT/CRTEventDisplay/CMakeLists.txt
+++ b/sbndcode/CRT/CRTEventDisplay/CMakeLists.txt
@@ -1,5 +1,4 @@
 art_make_library(
-		 LIBRARY_NAME sbndcode_CRT_CRTEventDisplay
 		 SOURCE	      CRTEventDisplayAlg.cc
 		 LIBRARIES
 			larsim::Utils

--- a/sbndcode/CRT/CRTEventDisplay/CMakeLists.txt
+++ b/sbndcode/CRT/CRTEventDisplay/CMakeLists.txt
@@ -1,0 +1,17 @@
+art_make_library(
+		 LIBRARY_NAME sbndcode_CRT_CRTEventDisplay
+		 SOURCE	      CRTEventDisplayAlg.cc
+		 LIBRARIES
+			larsim::Utils
+			ROOT::Graf3d
+	 		sbnobj::SBND_CRT
+	 		sbndcode_GeoWrappers
+			sbndcode_CRT_CRTBackTracker
+)
+
+simple_plugin(
+	      CRTEventDisplay module
+	      sbndcode_CRT_CRTEventDisplay
+)
+
+install_fhicl()

--- a/sbndcode/CRT/CRTEventDisplay/CRTEventDisplayAlg.cc
+++ b/sbndcode/CRT/CRTEventDisplay/CRTEventDisplayAlg.cc
@@ -1,0 +1,484 @@
+#include "CRTEventDisplayAlg.h"
+
+namespace sbnd::crt {
+  
+  CRTEventDisplayAlg::CRTEventDisplayAlg(const Config& config)
+    : fCRTGeoAlg(config.GeoAlgConfig())
+    , fCRTBackTrackerAlg(config.BackTrackerAlgConfig())
+  {
+    this->reconfigure(config);
+  }
+  
+  CRTEventDisplayAlg::CRTEventDisplayAlg(){}
+  
+  CRTEventDisplayAlg::~CRTEventDisplayAlg(){}
+
+  void CRTEventDisplayAlg::reconfigure(const Config& config)
+  {
+    fSimLabel = config.SimLabel();
+    fSimDepositLabel = config.SimDepositLabel();
+    fStripHitLabel = config.StripHitLabel();
+    fClusterLabel = config.ClusterLabel();
+    fSpacePointLabel = config.SpacePointLabel();
+    fTrackLabel = config.TrackLabel();
+
+    fDrawTaggers = config.DrawTaggers();
+    fDrawModules = config.DrawModules();
+    fDrawFEBs = config.DrawFEBs();
+    fDrawFEBEnds = config.DrawFEBEnds();
+    fDrawStrips = config.DrawStrips();
+    fDrawTpc = config.DrawTpc();
+    fDrawTrueTracks = config.DrawTrueTracks();
+    fDrawSimDeposits = config.DrawSimDeposits();
+    fDrawStripHits = config.DrawStripHits();
+    fDrawClusters = config.DrawClusters();
+    fDrawSpacePoints = config.DrawSpacePoints();
+    fDrawTracks = config.DrawTracks();
+
+    fChoseTaggers = config.ChoseTaggers();
+    fChosenTaggers = config.ChosenTaggers();
+
+    fTaggerColour = config.TaggerColour();
+    fFEBColour = config.FEBColour();
+    fFEBEndColour = config.FEBEndColour();
+    fTpcColour = config.TpcColour();
+    fTrueTrackColour = config.TrueTrackColour();
+    fSimDepositColour = config.SimDepositColour();
+    fStripHitColour = config.StripHitColour();
+    fClusterStartingColour = config.ClusterStartingColour();
+    fClusterColourInterval = config.ClusterColourInterval();
+    fSpacePointColour = config.SpacePointColour();
+    fTrackColour = config.TrackColour();
+
+    fMinTime = config.MinTime();
+    fMaxTime = config.MaxTime();
+
+    fPrint = config.Print();
+
+    fLineWidth = config.LineWidth();
+
+    return;
+  }
+ 
+  void CRTEventDisplayAlg::SetDrawTaggers(bool tf)
+  {
+    fDrawTaggers = tf;
+  }
+
+  void CRTEventDisplayAlg::SetDrawTpc(bool tf)
+  {
+    fDrawTpc = tf;
+  }
+
+  void CRTEventDisplayAlg::SetDrawTrueTracks(bool tf)
+  {
+    fDrawTrueTracks = tf;
+  }
+
+  void CRTEventDisplayAlg::SetDrawSimDeposits(bool tf)
+  {
+    fDrawSimDeposits = tf;
+  }
+
+  void CRTEventDisplayAlg::SetDrawStripHits(bool tf)
+  {
+    fDrawStripHits = tf;
+  }
+
+  void CRTEventDisplayAlg::SetDrawClusters(bool tf)
+  {
+    fDrawClusters = tf;
+  }
+
+  void CRTEventDisplayAlg::SetPrint(bool tf)
+  {
+    fPrint = tf;
+  }
+
+  void CRTEventDisplayAlg::DrawCube(TCanvas *c1, double *rmin, double *rmax, int colour)
+  {
+    c1->cd();
+    TList *outline = new TList;
+    TPolyLine3D *p1 = new TPolyLine3D(4);
+    TPolyLine3D *p2 = new TPolyLine3D(4);
+    TPolyLine3D *p3 = new TPolyLine3D(4);
+    TPolyLine3D *p4 = new TPolyLine3D(4);
+    p1->SetLineColor(colour);
+    p1->SetLineWidth(fLineWidth);
+    p1->Copy(*p2);
+    p1->Copy(*p3);
+    p1->Copy(*p4);
+    outline->Add(p1);
+    outline->Add(p2);
+    outline->Add(p3);
+    outline->Add(p4); 
+    TPolyLine3D::DrawOutlineCube(outline, rmin, rmax);
+    p1->Draw();
+    p2->Draw();
+    p3->Draw();
+    p4->Draw();
+  }
+
+  void CRTEventDisplayAlg::Draw(detinfo::DetectorClocksData const& clockData,
+                                const art::Event& event)
+  {
+    fCRTBackTrackerAlg.SetupMaps(event);
+
+    double G4RefTime(clockData.G4ToElecTime(0) * 1e3);
+    if(fPrint) std::cout << "G4RefTime: " << G4RefTime << std::endl;
+
+    // Create a canvas 
+    TCanvas *c1 = new TCanvas("c1","",700,700);
+    
+    std::vector<double> crtLims = fCRTGeoAlg.CRTLimits();
+    crtLims[0] -= 100; crtLims[1] -= 100; crtLims[2] -= 100;
+    crtLims[3] += 100; crtLims[4] += 100; crtLims[5] += 100;
+
+
+    // Draw the CRT taggers
+    if(fDrawTaggers)
+      {
+        for(auto const &[name, tagger] : fCRTGeoAlg.GetTaggers())
+          {
+            if(fChoseTaggers && std::find(fChosenTaggers.begin(), fChosenTaggers.end(), CRTCommonUtils::GetTaggerEnum(name)) == fChosenTaggers.end())
+              continue;
+               
+            double rmin[3] = {tagger.minX, 
+                              tagger.minY, 
+                              tagger.minZ};
+            double rmax[3] = {tagger.maxX, 
+                              tagger.maxY, 
+                              tagger.maxZ};
+            DrawCube(c1, rmin, rmax, fTaggerColour);
+          }
+      }
+    
+    // Draw individual CRT modules
+    if(fDrawModules)
+      {
+        for(auto const &[name, module] : fCRTGeoAlg.GetModules())
+          {
+            if(fChoseTaggers && std::find(fChosenTaggers.begin(), fChosenTaggers.end(), CRTCommonUtils::GetTaggerEnum(module.taggerName)) == fChosenTaggers.end())
+              continue;
+
+            double rmin[3] = {module.minX, 
+                              module.minY, 
+                              module.minZ};
+            double rmax[3] = {module.maxX, 
+                              module.maxY, 
+                              module.maxZ};
+            DrawCube(c1, rmin, rmax, fTaggerColour);
+
+            if(fDrawFEBs)
+              {
+                const std::array<double, 6> febPos = fCRTGeoAlg.FEBWorldPos(module);
+                
+                double rmin[3] = {febPos[0],
+                                  febPos[2],
+                                  febPos[4]};
+
+                double rmax[3] = {febPos[1],
+                                  febPos[3],
+                                  febPos[5]};
+
+                DrawCube(c1, rmin, rmax, fFEBColour);
+
+                if(fDrawFEBEnds)
+                  {
+                    const std::array<double, 6> febCh0Pos = fCRTGeoAlg.FEBChannel0WorldPos(module);
+
+                    double rminCh0[3] = {febCh0Pos[0],
+                                         febCh0Pos[2],
+                                         febCh0Pos[4]};
+
+                    double rmaxCh0[3] = {febCh0Pos[1],
+                                         febCh0Pos[3],
+                                         febCh0Pos[5]};
+
+                    DrawCube(c1, rminCh0, rmaxCh0, fFEBEndColour);
+                  }
+              }
+          }
+      }
+    
+    // Draw individual CRT strips
+    if(fDrawStrips)
+      {
+        for(auto const &[name, strip] : fCRTGeoAlg.GetStrips())
+          {
+            if(fChoseTaggers && std::find(fChosenTaggers.begin(), fChosenTaggers.end(), fCRTGeoAlg.ChannelToTaggerEnum(strip.channel0)) == fChosenTaggers.end())
+              continue;
+
+            double rmin[3] = {strip.minX, 
+                              strip.minY, 
+                              strip.minZ};
+            double rmax[3] = {strip.maxX, 
+                              strip.maxY, 
+                              strip.maxZ};
+            DrawCube(c1, rmin, rmax, fTaggerColour);
+          }
+      }
+    
+    // Draw the TPC with central cathode
+    if(fDrawTpc)
+      {
+        double rmin[3] = {fTPCGeoAlg.MinX(), 
+                          fTPCGeoAlg.MinY(), 
+                          fTPCGeoAlg.MinZ()};
+        double rmax[3] = {-fTPCGeoAlg.CpaWidth(), 
+                          fTPCGeoAlg.MaxY(), 
+                          fTPCGeoAlg.MaxZ()};
+        DrawCube(c1, rmin, rmax, fTpcColour);
+        double rmin2[3] = {fTPCGeoAlg.CpaWidth(), 
+                           fTPCGeoAlg.MinY(), 
+                           fTPCGeoAlg.MinZ()};
+        double rmax2[3] = {fTPCGeoAlg.MaxX(), 
+                           fTPCGeoAlg.MaxY(), 
+                           fTPCGeoAlg.MaxZ()};
+        DrawCube(c1, rmin2, rmax2, fTpcColour);
+      }
+    
+    // Draw true track trajectories for visible particles that cross the CRT
+    if(fDrawTrueTracks)
+      { 
+        auto particleHandle = event.getValidHandle<std::vector<simb::MCParticle>>(fSimLabel);
+
+        for(auto const& part : *particleHandle)
+          {
+            if(part.T() < fMinTime || part.T() > fMaxTime)
+              continue;
+
+            size_t npts = part.NumberTrajectoryPoints();
+            TPolyLine3D *line = new TPolyLine3D(npts);
+            int ipt = 0;
+            bool first = true;
+            geo::Point_t start {0,0,0};
+            geo::Point_t end {0,0,0};
+            for(size_t i = 0; i < npts; i++)
+              {
+                geo::Point_t pos {part.Vx(i), part.Vy(i), part.Vz(i)};
+              
+                // Don't draw trajectories outside of the CRT volume
+                if(pos.X() < crtLims[0] || pos.X() > crtLims[3] || pos.Y() < crtLims[1] 
+                   || pos.Y() > crtLims[4] || pos.Z() < crtLims[2] || pos.Z() > crtLims[5]) continue;
+              
+                if(first)
+                  {
+                    first = false;
+                    start = pos;
+                  }
+                end = pos;
+              
+                line->SetPoint(ipt, pos.X(), pos.Y(), pos.Z());
+                ipt++;
+              }
+            line->SetLineColor(fTrueTrackColour);
+            line->SetLineWidth(fLineWidth+4);
+            line->SetLineStyle(9);
+            line->Draw();
+          
+            if(fPrint) std::cout<<"MCParticle, Track ID: " << part.TrackId() << " PDG: " << part.PdgCode() << ", traj points: "<<npts<<", start = ("<<start.X()<<", "<<start.Y()<<", "
+                                <<start.Z()<<"), end = ("<<end.X()<<", "<<end.Y()<<", "<<end.Z()<<")\n";
+          }
+      }
+
+    if(fDrawSimDeposits)
+      {
+        auto simDepositsHandle = event.getValidHandle<std::vector<sim::AuxDetSimChannel>>(fSimDepositLabel);
+
+        for(auto const simDep : *simDepositsHandle)
+          {
+            for(auto const ide : simDep.AuxDetIDEs())
+              {
+                double x = (ide.entryX + ide.exitX) / 2.;
+                double y = (ide.entryY + ide.exitY) / 2.;
+                double z = (ide.entryZ + ide.exitZ) / 2.;
+                double t = (ide.entryT + ide.exitT) / 2.;
+
+                if(t < fMinTime || t > fMaxTime)
+                  continue;
+
+                double ex = std::abs(ide.entryX - ide.exitX) / 2.;
+                double ey = std::abs(ide.entryY - ide.exitY) / 2.;
+                double ez = std::abs(ide.entryZ - ide.exitZ) / 2.;
+
+                ex = std::max(ex, 1.);
+                ey = std::max(ey, 1.);
+                ez = std::max(ez, 1.);
+
+                double rmin[3] = { x - ex, y - ey, z - ez};
+                double rmax[3] = { x + ex, y + ey, z + ez};
+
+                if(fPrint)
+                  std::cout << "Sim Energy Deposit: (" << x << ", " << y << ", " << z 
+                            << ")  +/- (" << ex << ", " << ey << ", " << ez << ") by trackID: " 
+                            << ide.trackID << " at t = " << t << std::endl;
+
+                DrawCube(c1, rmin, rmax, fSimDepositColour);
+              }
+          }     
+      }
+
+    if(fDrawStripHits)
+      {
+        auto stripHitsHandle = event.getValidHandle<std::vector<CRTStripHit>>(fStripHitLabel);
+        std::vector<art::Ptr<CRTStripHit>> stripHitsVec;
+        art::fill_ptr_vector(stripHitsVec, stripHitsHandle);
+
+        for(auto const stripHit : stripHitsVec)
+          {
+            if(stripHit->Ts1() - G4RefTime < fMinTime || stripHit->Ts1() - G4RefTime > fMaxTime)
+              continue;
+
+            CRTStripGeo strip = fCRTGeoAlg.GetStrip(stripHit->Channel());
+
+            double rmin[3] = {strip.minX, strip.minY, strip.minZ};
+            double rmax[3] = {strip.maxX, strip.maxY, strip.maxZ};
+
+            CRTBackTrackerAlg::TruthMatchMetrics truthMatch = fCRTBackTrackerAlg.TruthMatching(event, stripHit);
+
+            if(fPrint)
+              std::cout << "Strip Hit: (" 
+                        << rmin[0] << ", " << rmin[1] << ", " << rmin[2] << ") --> ("
+                        << rmax[0] << ", " << rmax[1] << ", " << rmax[2] << ") at t1 = " << stripHit->Ts1()
+                        << " (" << stripHit->Ts1() - G4RefTime << ")"
+                        << "\t Matches to trackID: " << truthMatch.trackid 
+                        << " with completeness: " << truthMatch.completeness 
+                        << " and purity: " << truthMatch.purity << std::endl;
+
+            DrawCube(c1, rmin, rmax, fStripHitColour);
+          }
+      }
+
+    if(fDrawClusters || fDrawSpacePoints)
+      {
+        auto clustersHandle = event.getValidHandle<std::vector<CRTCluster>>(fClusterLabel);
+        std::vector<art::Ptr<CRTCluster>> clustersVec;
+        art::fill_ptr_vector(clustersVec, clustersHandle);
+        art::FindManyP<CRTStripHit> clustersToStripHits(clustersHandle, event, fClusterLabel);
+        art::FindManyP<CRTSpacePoint> clustersToSpacePoints(clustersHandle, event, fSpacePointLabel);
+
+        int colour = fClusterStartingColour;
+
+        for(auto const cluster : clustersVec)
+          {
+            if(cluster->Ts1() - G4RefTime < fMinTime || cluster->Ts1() - G4RefTime > fMaxTime)
+              continue;
+
+            auto stripHitVec   = clustersToStripHits.at(cluster.key());
+            auto spacePointVec = clustersToSpacePoints.at(cluster.key());
+
+            if(fDrawClusters)
+              {
+                for(auto stripHit : stripHitVec)
+                  {
+                    CRTStripGeo strip = fCRTGeoAlg.GetStrip(stripHit->Channel());
+                    
+                    double rmin[3] = {strip.minX, strip.minY, strip.minZ};
+                    double rmax[3] = {strip.maxX, strip.maxY, strip.maxZ};
+                    
+                    DrawCube(c1, rmin, rmax, colour);
+                  }
+
+                CRTBackTrackerAlg::TruthMatchMetrics truthMatch = fCRTBackTrackerAlg.TruthMatching(event, cluster);
+
+                if(fPrint)
+                  std::cout << "Cluster of " << cluster->NHits() << " hits at t1 = " << cluster->Ts1()
+                            << " (" << cluster->Ts1() - G4RefTime << ")"
+                            << "\t Matches to trackID: " << truthMatch.trackid
+                            << " with completeness: " << truthMatch.completeness
+                            << " and purity: " << truthMatch.purity << std::endl;
+
+                colour += fClusterColourInterval;
+              }
+            
+            if(fDrawSpacePoints)
+              {
+                if(spacePointVec.size() == 1)
+                  {
+                    const art::Ptr<CRTSpacePoint> spacepoint = spacePointVec[0];
+                    const geo::Point_t pos = spacepoint->Pos();
+                    const geo::Point_t err = spacepoint->Err();
+
+                    double rmin[3] = {pos.X() - err.X(), pos.Y() - err.Y(), pos.Z() - err.Z()};
+                    double rmax[3] = {pos.X() + err.X(), pos.Y() + err.Y(), pos.Z() + err.Z()};
+
+                    DrawCube(c1, rmin, rmax, fSpacePointColour);
+
+                    if(fPrint)
+                      std::cout << "Space Point: (" 
+                                << rmin[0] << ", " << rmin[1] << ", " << rmin[2] << ") --> ("
+                                << rmax[0] << ", " << rmax[1] << ", " << rmax[2] << ") at t1 = "
+                                << spacepoint->Time() << " (" << spacepoint->Time() - G4RefTime << ")"
+                                << " with PE " << spacepoint->PE()
+                                << std::endl;
+                  }
+                else if(spacePointVec.size() != 0)
+                  std::cout << "What an earth is going on here then..." << std::endl;
+              }
+          }
+      }
+
+    if(fDrawTracks)
+      {
+        auto tracksHandle = event.getValidHandle<std::vector<CRTTrack>>(fTrackLabel);
+        std::vector<art::Ptr<CRTTrack>> tracksVec;
+        art::fill_ptr_vector(tracksVec, tracksHandle);
+
+        for(auto track : tracksVec)
+          {
+            if(track->Time() - G4RefTime < fMinTime || track->Time() - G4RefTime > fMaxTime)
+              continue;
+
+            const geo::Point_t start = track->Start();
+            const geo::Vector_t dir  = track->Direction();
+
+            TPolyLine3D *line = new TPolyLine3D(2);
+            geo::Point_t a {0,0,0};
+            geo::Point_t b {0,0,0};
+
+            int i = 0;
+            do
+              {
+                a = start + i * dir;
+                ++i;
+              }
+            while(IsPointInsideBox(crtLims, a));
+
+            i = 0;
+            do
+              {
+                b = start + i * dir;
+                --i;
+              }
+            while(IsPointInsideBox(crtLims, b));
+
+            line->SetPoint(0, a.X(), a.Y(), a.Z());
+            line->SetPoint(1, b.X(), b.Y(), b.Z());
+
+            line->SetLineColor(fTrackColour);
+            line->SetLineWidth(fLineWidth);
+            line->Draw();
+
+            if(fPrint)
+              std::cout << "Track at (" << start.X() << ", " << start.Y() << ", " << start.Z() << ")\n"
+                        << "\twith direction (" << dir.X() << ", " << dir.Y() << ", " << dir.Z() << ")\n"
+                        << "\tdrawn between (" << a.X() << ", " << a.Y() << ", " << a.Z() << ")\n"
+                        << "\tand (" << b.X() << ", " << b.Y() << ", " << b.Z() << ")\n"
+                        << "\tat time " << track->Time() << " (" << track->Time() - G4RefTime << ")\n"
+                        << "\tfrom three hits? " << track->Triple() << std::endl;
+
+          }
+      }
+
+    c1->SaveAs(Form("crtEventDisplayEvent%d.root", event.event()));
+    delete c1;
+  }
+
+  bool CRTEventDisplayAlg::IsPointInsideBox(const std::vector<double> &lims, const geo::Point_t &p)
+  {
+    return (p.X() > lims[0] && p.X() < lims[3])
+      && (p.Y() > lims[1] && p.Y() < lims[4])
+      && (p.Z() > lims[2] && p.Z() < lims[5]);
+  }
+}

--- a/sbndcode/CRT/CRTEventDisplay/CRTEventDisplayAlg.h
+++ b/sbndcode/CRT/CRTEventDisplay/CRTEventDisplayAlg.h
@@ -1,0 +1,262 @@
+#ifndef CRTEVENTDISPLAYALG_H_SEEN
+#define CRTEVENTDISPLAYALG_H_SEEN
+
+///////////////////////////////////////////////
+// CRTEventDisplayAlg.h
+//
+// Quick and dirty event display for SBND CRT
+// T Brooks (tbrooks@fnal.gov), November 2018
+// Edited heavily - Henry Lay, November 2022
+///////////////////////////////////////////////
+
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "fhiclcpp/ParameterSet.h" 
+#include "art/Framework/Principal/Handle.h" 
+#include "canvas/Persistency/Common/Ptr.h" 
+#include "art/Framework/Services/Registry/ServiceHandle.h" 
+#include "canvas/Persistency/Common/FindManyP.h"
+
+// Utility libraries
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
+
+//larsoft
+#include "lardataalg/DetectorInfo/DetectorClocksData.h"
+
+// sbnobj
+#include "sbnobj/SBND/CRT/CRTStripHit.hh"
+#include "sbnobj/SBND/CRT/CRTCluster.hh"
+#include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
+#include "sbnobj/SBND/CRT/CRTTrack.hh"
+
+// sbndcode
+#include "sbndcode/Geometry/GeometryWrappers/TPCGeoAlg.h"
+#include "sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h"
+#include "sbndcode/CRT/CRTBackTracker/CRTBackTrackerAlg.h"
+
+// ROOT
+#include "TPolyLine3D.h"
+#include "TCanvas.h"
+
+namespace detinfo { class DetectorClocksData; }
+
+namespace sbnd::crt {
+  
+  class CRTEventDisplayAlg {
+  public:
+    
+    struct Config {
+      using Name = fhicl::Name;
+      using Comment = fhicl::Comment;
+      
+      fhicl::Table<fhicl::ParameterSet> GeoAlgConfig {
+        Name("CRTGeoAlg"),
+        Comment("Configuration parameters for the CRT geometry algorithm"),
+        fhicl::ParameterSet()
+      };
+
+      fhicl::Table<CRTBackTrackerAlg::Config> BackTrackerAlgConfig {
+        Name("CRTBackTrackerAlg"),
+        Comment("Configuration parameters for the CRT back tracking algorithm")
+      };
+      
+      fhicl::Atom<art::InputTag> SimLabel {
+        Name("SimLabel")
+          };
+      fhicl::Atom<art::InputTag> SimDepositLabel {
+        Name("SimDepositLabel")
+          };
+      fhicl::Atom<art::InputTag> StripHitLabel {
+        Name("StripHitLabel")
+          };
+      fhicl::Atom<art::InputTag> ClusterLabel {
+        Name("ClusterLabel")
+          };
+      fhicl::Atom<art::InputTag> SpacePointLabel {
+        Name("SpacePointLabel")
+          };
+      fhicl::Atom<art::InputTag> TrackLabel {
+        Name("TrackLabel")
+          };
+
+      fhicl::Atom<bool> DrawTaggers {
+        Name("DrawTaggers")
+          };
+      fhicl::Atom<bool> DrawModules {
+        Name("DrawModules")
+          };
+      fhicl::Atom<bool> DrawFEBs {
+        Name("DrawFEBs")
+          };
+      fhicl::Atom<bool> DrawFEBEnds {
+        Name("DrawFEBEnds")
+          };
+      fhicl::Atom<bool> DrawStrips {
+        Name("DrawStrips")
+          };
+      fhicl::Atom<bool> DrawTpc {
+        Name("DrawTpc")
+          };
+      fhicl::Atom<bool> DrawTrueTracks {
+        Name("DrawTrueTracks")
+          };
+      fhicl::Atom<bool> DrawSimDeposits {
+        Name("DrawSimDeposits")
+          };
+      fhicl::Atom<bool> DrawStripHits {
+        Name("DrawStripHits")
+          };
+      fhicl::Atom<bool> DrawClusters {
+        Name("DrawClusters")
+          };
+      fhicl::Atom<bool> DrawSpacePoints {
+        Name("DrawSpacePoints")
+          };
+      fhicl::Atom<bool> DrawTracks {
+        Name("DrawTracks")
+          };
+
+      fhicl::Atom<bool> ChoseTaggers {
+        Name("ChoseTaggers")
+          };
+      fhicl::Sequence<int> ChosenTaggers {
+        Name("ChosenTaggers")
+          };
+
+      fhicl::Atom<int> TaggerColour {
+        Name("TaggerColour")
+          };
+      fhicl::Atom<int> FEBColour {
+        Name("FEBColour")
+          };
+      fhicl::Atom<int> FEBEndColour {
+        Name("FEBEndColour")
+          };
+      fhicl::Atom<int> TpcColour {
+        Name("TpcColour")
+          };
+      fhicl::Atom<int> TrueTrackColour {
+        Name("TrueTrackColour")
+          };
+      fhicl::Atom<int> SimDepositColour {
+        Name("SimDepositColour")
+          };
+      fhicl::Atom<int> StripHitColour {
+        Name("StripHitColour")
+          };
+      fhicl::Atom<int> ClusterStartingColour {
+        Name("ClusterStartingColour")
+          };
+      fhicl::Atom<int> ClusterColourInterval {
+        Name("ClusterColourInterval")
+          };
+      fhicl::Atom<int> SpacePointColour {
+        Name("SpacePointColour")
+          };
+      fhicl::Atom<int> TrackColour {
+        Name("TrackColour")
+          };
+
+      fhicl::Atom<double> MinTime {
+        Name ("MinTime"),
+        Comment ("Ignore truth & reco products before this time"),
+        0.
+      };
+      fhicl::Atom<double> MaxTime {
+        Name ("MaxTime"),
+        Comment ("Ignore truth & reco products after this time"),
+        3.2e6
+      };
+
+      fhicl::Atom<bool> Print {
+        Name("Print")
+          };
+
+      fhicl::Atom<double> LineWidth {
+        Name("LineWidth")
+          };
+    };
+    
+    CRTEventDisplayAlg(const Config& config);
+    
+    CRTEventDisplayAlg(const fhicl::ParameterSet& pset) :
+      CRTEventDisplayAlg(fhicl::Table<Config>(pset, {})()) {}
+    
+    CRTEventDisplayAlg();
+
+    ~CRTEventDisplayAlg();
+
+    void reconfigure(const Config& config);
+
+    void SetDrawTaggers(bool tf);
+    void SetDrawTpc(bool tf);
+    void SetDrawTrueTracks(bool tf);
+    void SetDrawSimDeposits(bool tf);
+    void SetDrawStripHits(bool tf);
+    void SetDrawClusters(bool tf);
+
+    void SetPrint(bool tf);
+
+    void DrawCube(TCanvas *c1, double *rmin, double *rmax, int colour);
+
+    void Draw(detinfo::DetectorClocksData const& clockData, const art::Event& event);
+
+    bool IsPointInsideBox(const std::vector<double> &lims, const geo::Point_t &p);
+
+  private:
+    
+    TPCGeoAlg         fTPCGeoAlg;
+    CRTGeoAlg         fCRTGeoAlg;
+    CRTBackTrackerAlg fCRTBackTrackerAlg;
+
+    art::ServiceHandle<cheat::ParticleInventoryService> particleInv;
+    
+    art::InputTag fSimLabel;
+    art::InputTag fSimDepositLabel;
+    art::InputTag fStripHitLabel;
+    art::InputTag fClusterLabel;
+    art::InputTag fSpacePointLabel;
+    art::InputTag fTrackLabel;
+
+    bool fDrawTaggers;
+    bool fDrawModules;
+    bool fDrawFEBs;
+    bool fDrawFEBEnds;
+    bool fDrawStrips;
+    bool fDrawTpc;
+    bool fDrawTrueTracks;
+    bool fDrawSimDeposits;
+    bool fDrawStripHits;
+    bool fDrawClusters;
+    bool fDrawSpacePoints;
+    bool fDrawTracks;
+
+    bool             fChoseTaggers;
+    std::vector<int> fChosenTaggers;
+
+    int fTaggerColour;
+    int fFEBColour;
+    int fFEBEndColour;
+    int fTpcColour;
+    int fTrueTrackColour;
+    int fSimDepositColour;
+    int fStripHitColour;
+    int fClusterStartingColour;
+    int fClusterColourInterval;
+    int fSpacePointColour;
+    int fTrackColour;
+
+    double fMinTime;
+    double fMaxTime;
+
+    bool fPrint;
+
+    double fLineWidth;
+  };
+}
+
+#endif

--- a/sbndcode/CRT/CRTEventDisplay/CRTEventDisplay_module.cc
+++ b/sbndcode/CRT/CRTEventDisplay/CRTEventDisplay_module.cc
@@ -1,0 +1,68 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       CRTEventDisplay
+// Plugin Type: analyzer (Unknown Unknown)
+// File:        CRTEventDisplay_module.cc
+//
+// Generated at Thu Oct  6 09:32:09 2022 by Henry Lay using cetskelgen
+// from  version .
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Framework/Core/EDAnalyzer.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h"
+#include "art/Framework/Principal/SubRun.h"
+#include "canvas/Utilities/InputTag.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+
+#include "lardata/DetectorInfoServices/DetectorClocksService.h"
+#include "sbndcode/CRT/CRTEventDisplay/CRTEventDisplayAlg.h"
+
+namespace sbnd::crt {
+  class CRTEventDisplay;
+}
+
+class sbnd::crt::CRTEventDisplay : public art::EDAnalyzer {
+public:
+
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+ 
+    fhicl::Table<CRTEventDisplayAlg::Config> EventDisplayConfig {
+      Name("EventDisplayConfig"),
+        };
+  };
+
+  using Parameters = art::EDAnalyzer::Table<Config>;
+
+  explicit CRTEventDisplay(Parameters const &config);
+
+  CRTEventDisplay(CRTEventDisplay const&) = delete;
+  CRTEventDisplay(CRTEventDisplay&&) = delete;
+  CRTEventDisplay& operator=(CRTEventDisplay const&) = delete;
+  CRTEventDisplay& operator=(CRTEventDisplay&&) = delete;
+
+  void analyze(art::Event const& e) override;
+
+private:
+
+  CRTEventDisplayAlg fCRTEventDisplayAlg;
+};
+
+
+sbnd::crt::CRTEventDisplay::CRTEventDisplay(Parameters const& config)
+  : EDAnalyzer{config}
+  , fCRTEventDisplayAlg(config().EventDisplayConfig())
+  {
+  }
+
+void sbnd::crt::CRTEventDisplay::analyze(art::Event const& e)
+{
+  auto const clockData = art::ServiceHandle<detinfo::DetectorClocksService const>()->DataFor(e);
+  fCRTEventDisplayAlg.Draw(clockData, e);
+}
+
+DEFINE_ART_MODULE(sbnd::crt::CRTEventDisplay)

--- a/sbndcode/CRT/CRTEventDisplay/crteventdisplay_sbnd.fcl
+++ b/sbndcode/CRT/CRTEventDisplay/crteventdisplay_sbnd.fcl
@@ -1,0 +1,17 @@
+#include "crteventdisplayalg_sbnd.fcl"
+
+BEGIN_PROLOG
+
+crteventdisplay_sbnd:
+{
+   EventDisplayConfig: @local::crteventdisplayalg_sbnd
+   module_type:        "CRTEventDisplay"
+}
+
+crteventdisplay_sbnd_feb_layout_debug:
+{
+   EventDisplayConfig: @local::crteventdisplayalg_sbnd_feb_layout_debug
+   module_type:        "CRTEventDisplay"
+}
+
+END_PROLOG

--- a/sbndcode/CRT/CRTEventDisplay/crteventdisplayalg_sbnd.fcl
+++ b/sbndcode/CRT/CRTEventDisplay/crteventdisplayalg_sbnd.fcl
@@ -1,0 +1,78 @@
+#include "crtsimmodules_sbnd.fcl"
+#include "crtbacktrackeralg_sbnd.fcl"
+
+BEGIN_PROLOG
+
+crteventdisplayalg_sbnd:
+{
+   CRTBackTrackerAlg: @local::crtbacktrackeralg_sbnd
+
+   SimLabel:         "largeant"
+   SimDepositLabel:  "genericcrt"
+   StripHitLabel:    "crtstrips"
+   ClusterLabel:     "crtclustering"
+   SpacePointLabel:  "crtspacepoints"
+   TrackLabel:       "crttracks"
+
+   DrawTaggers:      true
+   DrawModules:      false
+   DrawFEBs:         false
+   DrawFEBEnds:      false
+   DrawStrips:       false
+   DrawTpc:          true
+   DrawTrueTracks:   true
+   DrawSimDeposits:  false
+   DrawStripHits:    true
+   DrawClusters:     true
+   DrawSpacePoints:  true
+   DrawTracks:       true
+
+   ## If chose taggers is set to true then the vector ChosenTaggers
+   ## is used to determine which taggers are drawn. The integer values
+   ## represent taggers as they are numbered in the enum CRTTagger.
+   ## (see sbnobj/SBND/CRT/CRTEnums.h)
+   ## 0 - Bottom
+   ## 1 - South (upstream)
+   ## 2 - North (downstream)
+   ## 3 - West (beam right)
+   ## 4 - East (beam left)
+   ## 5 - Top Low
+   ## 6 - Top High
+   ChoseTaggers:  false
+   ChosenTaggers: [ 0, 1, 2, 3, 4, 5, 6 ]
+   
+   TaggerColour:             1
+   FEBColour:                2
+   FEBEndColour:             4
+   TpcColour:                15
+   TrueTrackColour:          2
+   SimDepositColour:         8
+   StripHitColour:           4
+   ClusterStartingColour:    800
+   ClusterColourInterval:    20
+   SpacePointColour:         6
+   TrackColour:              9
+
+   MinTime: -200000
+   MaxTime: -150000
+
+   Print:            true
+
+   LineWidth:        3.
+}
+
+crteventdisplayalg_sbnd_feb_layout_debug: @local::crteventdisplayalg_sbnd
+
+crteventdisplayalg_sbnd_feb_layout_debug.DrawTaggers:      false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawModules:      true
+crteventdisplayalg_sbnd_feb_layout_debug.DrawFEBs:         true
+crteventdisplayalg_sbnd_feb_layout_debug.DrawFEBEnds:      true
+crteventdisplayalg_sbnd_feb_layout_debug.DrawStrips:       false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawTpc:          false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawTrueTracks:   false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawSimDeposits:  false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawStripHits:    false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawClusters:     false
+crteventdisplayalg_sbnd_feb_layout_debug.DrawSpacePoints:  false
+
+END_PROLOG

--- a/sbndcode/CRT/CRTEventDisplay/run_crteventdisplay.fcl
+++ b/sbndcode/CRT/CRTEventDisplay/run_crteventdisplay.fcl
@@ -1,0 +1,30 @@
+#include "services_sbnd.fcl"
+#include "particleinventoryservice.fcl"
+#include "crteventdisplay_sbnd.fcl"
+
+process_name: CRTEventDisplay
+
+services:
+{
+  @table::sbnd_services
+  ParticleInventoryService: @local::standard_particleinventoryservice
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1 
+
+}
+
+physics:
+{
+  analyzers:
+  {
+    crtevd:   @local::crteventdisplay_sbnd
+  }
+
+  ana: [ crtevd ]
+
+  end_paths: [ ana ]
+}

--- a/sbndcode/CRT/CRTEventDisplay/run_crteventdisplay_feb_layout_debug.fcl
+++ b/sbndcode/CRT/CRTEventDisplay/run_crteventdisplay_feb_layout_debug.fcl
@@ -1,0 +1,30 @@
+#include "services_sbnd.fcl"
+#include "particleinventoryservice.fcl"
+#include "crteventdisplay_sbnd.fcl"
+
+process_name: CRTEventDisplay
+
+services:
+{
+  @table::sbnd_services
+  ParticleInventoryService: @local::standard_particleinventoryservice
+}
+
+source:
+{
+  module_type: RootInput
+  maxEvents:   -1 
+
+}
+
+physics:
+{
+  analyzers:
+  {
+    crtevd:   @local::crteventdisplay_sbnd_feb_layout_debug
+  }
+
+  ana: [ crtevd ]
+
+  end_paths: [ ana ]
+}


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbndcode/tree/feature/hlay_crt_clustering_merged).

This PR is based on Tom's old CRT event display but with some heavy edits to improve its functionality and changes to represent the new objects in the new reconstruction. This is a utility and is obviously outside of production running.