### PR TITLE
crt clustering fcls

### DIFF
--- a/sbndcode/CRT/CRTReco/run_crtclustering.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtclustering.fcl
@@ -1,0 +1,38 @@
+#include "services_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+
+process_name: CRTClustering
+
+services:
+{
+  @table::sbnd_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crtclustering: @local::crtclusterproducer_sbnd
+  }
+
+  reco:    [ crtclustering ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ stream1 ]
+}

--- a/sbndcode/CRT/CRTReco/run_crtreco.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtreco.fcl
@@ -1,0 +1,41 @@
+#include "services_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+
+process_name: CRTReco
+
+services:
+{
+  @table::sbnd_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crtstrips:      @local::crtstriphitproducer_sbnd
+    crtclustering:  @local::crtclusterproducer_sbnd
+    crtspacepoints: @local::crtspacepointproducer_sbnd
+    crttracks:      @local::crttrackproducer_sbnd
+  }
+
+  reco:    [ crtstrips, crtclustering, crtspacepoints, crttracks ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ stream1 ]
+}

--- a/sbndcode/CRT/CRTReco/run_crtrecoana.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtrecoana.fcl
@@ -1,0 +1,55 @@
+#include "services_sbnd.fcl"
+#include "particleinventoryservice.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+#include "crtbacktrackeralg_sbnd.fcl"
+
+process_name: CRTRecoAna
+
+services:
+{
+  TFileService: { fileName: "crtana_sbnd.root" }
+  @table::sbnd_basic_services
+  ParticleInventoryService: @local::standard_particleinventoryservice
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crtstrips:      @local::crtstriphitproducer_sbnd
+    crtclustering:  @local::crtclusterproducer_sbnd
+    crtspacepoints: @local::crtspacepointproducer_sbnd
+    crttracks:      @local::crttrackproducer_sbnd
+  }
+
+  analyzers:
+  {
+    crtana:
+    {
+      module_type:       "CRTAnalysis"
+      CRTBackTrackerAlg: @local::crtbacktrackeralg_sbnd
+    }
+  }
+
+  reco:    [ crtstrips, crtclustering, crtspacepoints, crttracks ]
+  ana:     [ crtana ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ ana, stream1 ]
+}

--- a/sbndcode/CRT/CRTReco/run_crtspacepointreco.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtspacepointreco.fcl
@@ -1,0 +1,38 @@
+#include "services_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+
+process_name: CRTSpacePointReco
+
+services:
+{
+  @table::sbnd_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crtspacepoints: @local::crtspacepointproducer_sbnd
+  }
+
+  reco:    [ crtspacepoints ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ stream1 ]
+}

--- a/sbndcode/CRT/CRTReco/run_crtstriphitreco.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtstriphitreco.fcl
@@ -1,0 +1,38 @@
+#include "services_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+
+process_name: CRTStripHitReco
+
+services:
+{
+  @table::sbnd_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crtstrips: @local::crtstriphitproducer_sbnd
+  }
+
+  reco:    [ crtstrips ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ stream1 ]
+}

--- a/sbndcode/CRT/CRTReco/run_crttrackreco.fcl
+++ b/sbndcode/CRT/CRTReco/run_crttrackreco.fcl
@@ -1,0 +1,38 @@
+#include "services_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+
+process_name: CRTTrackReco
+
+services:
+{
+  @table::sbnd_services
+}
+
+source:
+{
+  module_type: RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  producers:
+  {
+    crttracks: @local::crttrackproducer_sbnd
+  }
+
+  reco:    [ crttracks ]
+  stream1: [ out1 ]
+
+  trigger_paths: [ reco ]
+  end_paths:     [ stream1 ]
+}

--- a/sbndcode/JobConfigurations/base/reco_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/reco_sbnd.fcl
@@ -40,11 +40,8 @@
 #include "particleid_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 
-#include "crtsimhitproducer_sbnd.fcl"
-##include "crttzeroproducer_sbnd.fcl"
-#include "crttrackproducer_sbnd.fcl"
-#include "crtt0matchingalg_sbnd.fcl"
-#include "crttrackmatchingalg_sbnd.fcl"
+#include "crtrecoproducers_sbnd.fcl"
+#include "crttpcmatchingproducers_sbnd.fcl"
 
 #include "opt0finder_sbnd.fcl"
 
@@ -165,13 +162,17 @@ physics:
   pmatrackcalo:        @local::sbnd_calomc
   pmatrackpid:         @local::sbnd_chi2pid
 
-  crthit:              @local::standard_crtsimhitproducer
-  #crttzero:            @local::standard_crttzeroproducer
-  crttrack:            @local::standard_crttrackproducer
-  crthitt0:            @local::sbnd_crthitt0producer
-  crttrackt0:          @local::sbnd_crttrackt0producer
-  crthitt0SCE:         @local::sbnd_crthitt0producer
-  crttrackt0SCE:       @local::sbnd_crttrackt0producer
+  ### CRT reconstruction
+  crtstrips:      @local::crtstriphitproducer_sbnd
+  crtclustering:  @local::crtclusterproducer_sbnd
+  crtspacepoints: @local::crtspacepointproducer_sbnd
+  crttracks:      @local::crttrackproducer_sbnd
+
+  ### CRT-TPC matching
+  crtspacepointmatching:    @local::crtspacepointmatchproducer_sbnd
+  crttrackmatching:         @local::crttrackmatchproducer_sbnd
+  crtspacepointmatchingSCE: @local::crtspacepointmatchproducer_sbnd
+  crttrackmatchingSCE:      @local::crttrackmatchproducer_sbnd
 
   ### flash-matching
   fmatch:              @local::sbnd_simple_flashmatch
@@ -203,6 +204,7 @@ physics:
    #      , rffhit
    #      , corner
    #      , fuzzycluster
+         , crtstrips
  ]
 
  reco2_no_opt0finder: [
@@ -220,13 +222,13 @@ physics:
   #       , pmatrackcalo
   #       , pmatrackpid
   #        , emshower
-         , crthit
-   #      , crttzero
-         , crttrack
-         , crthitt0
-         , crttrackt0
-         , fmatch
-	 , caloskimCalorimetry
+          , crtclustering
+          , crtspacepoints
+          , crttracks
+          , crtspacepointmatching
+          , crttrackmatching
+          , fmatch
+          , caloskimCalorimetry
  ]
 
 
@@ -324,11 +326,6 @@ physics.producers.pandoraSCEPid.CalorimetryModuleLabel:             "pandoraSCEC
 
 physics.producers.opt0finderSCE.SliceProducer: "pandoraSCE"
 
-physics.producers.crthitt0SCE.TpcTrackModuleLabel: "pandoraSCETrack"
-physics.producers.crthitt0SCE.T0Alg.TPCTrackLabel: "pandoraSCETrack"
-physics.producers.crttrackt0SCE.TpcTrackModuleLabel: "pandoraSCETrack"
-physics.producers.crttrackt0SCE.CrtTrackAlg.TPCTrackLabel: "pandoraSCETrack"
-
 #physics.producers.trackkalmanhit.HitModuleLabel:   "gaushit"
 #physics.producers.trackkalmanhit.ClusterModuleLabel:   "fuzzycluster"
 #physics.producers.trackkalmanhit.ClusterModuleLabel:   "cccluster"
@@ -373,5 +370,13 @@ physics.producers.pandoraSCEShowerSBN.PFParticleLabel:           "pandoraSCE"
 #physics.producers.gaushitTruthMatch.HitParticleAssociations:                        @local::DirectHitParticleAssnsTool
 physics.producers.gaushitTruthMatch.HitParticleAssociations.HitModuleLabel:         "gaushit"
 #physics.producers.gaushitTruthMatch.HitParticleAssociations.MCParticleModuleLabelVec:  ["largeant"]
+
+physics.producers.crtspacepointmatchingSCE.TPCTrackModuleLabel:       "pandoraSCETrack"
+physics.producers.crtspacepointmatchingSCE.PFPModuleLabel:            "pandoraSCE"
+physics.producers.crtspacepointmatchingSCE.MatchingAlg.TPCTrackLabel: "pandoraSCETrack"
+
+physics.producers.crttrackmatchingSCE.TPCTrackModuleLabel:            "pandoraSCETrack"
+physics.producers.crttrackmatchingSCE.PFPModuleLabel:                 "pandoraSCE"
+physics.producers.crttrackmatchingSCE.MatchingAlg.TPCTrackLabel:      "pandoraSCETrack"
 
 services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"

--- a/sbndcode/JobConfigurations/standard/detsim/detsim_crt_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detsim_crt_sbnd.fcl
@@ -1,0 +1,9 @@
+#include "standard_detsim_sbnd.fcl"
+
+process_name: DetSimCRT
+
+physics.simulate: [ rns, crtsim ]
+
+# Remove unnecesary processes
+physics.producers.daq:   @erase
+physics.producers.opdaq: @erase

--- a/sbndcode/JobConfigurations/standard/g4/g4_crt_dirt_filter_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_crt_dirt_filter_sbnd.fcl
@@ -1,0 +1,19 @@
+#include "standard_g4_sbnd.fcl"
+
+process_name: G4CRT
+
+physics.simulate: [ rns
+                    , genericcrt
+                  ]
+
+# Remove unnecesary processes
+physics.producers.ionandscint:    @erase
+physics.producers.ionandscintout: @erase
+physics.producers.pdfastsim:      @erase
+physics.producers.pdfastsimout:   @erase
+physics.producers.simdrift:       @erase
+physics.producers.mcreco:         @erase
+physics.producers.loader:         @erase
+physics.producers.largeant:       @erase
+
+outputs.out1.outputCommands: [ "keep *_*_*_*" ]

--- a/sbndcode/JobConfigurations/standard/g4/g4_crt_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_crt_sbnd.fcl
@@ -1,0 +1,19 @@
+#include "standard_g4_sbnd.fcl"
+
+process_name: G4CRT
+
+physics.simulate: [ rns
+                    , loader
+                    , largeant
+                    , genericcrt
+                  ]
+
+# Remove unnecesary processes
+physics.producers.ionandscint:    @erase
+physics.producers.ionandscintout: @erase
+physics.producers.pdfastsim:      @erase
+physics.producers.pdfastsimout:   @erase
+physics.producers.simdrift:       @erase
+physics.producers.mcreco:         @erase
+
+outputs.out1.outputCommands: [ "keep *_*_*_*" ]

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_keep_corsika_trajectories.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_keep_corsika_trajectories.fcl
@@ -1,0 +1,3 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_sce.fcl"
+
+services.ParticleListAction.keepGenTrajectories: [ "generator", "corsika" ]

--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce.fcl
@@ -13,7 +13,7 @@
 process_name: Reco2
 
 physics.reco2_sce: [@sequence::physics.reco2,
-            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, crthitt0SCE, crttrackt0SCE, fmatchSCE, opt0finderSCE]
+            pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCEShowerSBN, pandoraSCECalo, pandoraSCEPid, crtspacepointmatchingSCE, crttrackmatchingSCE, fmatchSCE, opt0finderSCE]
 
 physics.trigger_paths: [ reco2_sce ]
 

--- a/sbndcode/JobConfigurations/standard/reco/reco2_sce_no_opt0finder.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_sce_no_opt0finder.fcl
@@ -13,12 +13,9 @@
 process_name: Reco2
 
 physics.reco2_sce: [@sequence::physics.reco2_no_opt0finder,
-                    pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCECalo, pandoraSCEPid]
+                    pandoraSCE, pandoraSCETrack, pandoraSCEShower, pandoraSCECalo, pandoraSCEPid, crtspacepointmatchingSCE, crttrackmatchingSCE, fmatchSCE]
 
 physics.trigger_paths: [ reco2_sce ]
 
 # turn on space charge service
-services.SpaceCharge.EnableCalSpatialSCE: true
-services.SpaceCharge.EnableSimSpatialSCE: true
-services.SpaceCharge.EnableSimEfieldSCE: true
-services.SpaceCharge.EnableCalEfieldSCE: true
+#include "enable_spacecharge_services_sbnd.fcl"

--- a/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
@@ -29,7 +29,6 @@
 
 #include "detsimmodules_sbnd.fcl"
 #include "crtsimmodules_sbnd.fcl"
-#include "crtslimmer_sbnd.fcl"
 #include "opdetdigitizer_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 
@@ -63,12 +62,11 @@ physics:
     rns:       { module_type: "RandomNumberSaver" }
     daq:       @local::sbnd_simwire
     crtsim:    @local::sbnd_crtsim
-    crt:       @local::sbnd_crtslimmer
     opdaq:     @local::sbnd_opdetdigitizer
   }
 
   #define the producer and filter modules for this path, order matters,
-  simulate:  [ rns, daq, crtsim, crt, opdaq]
+  simulate:  [ rns, daq, crtsim, opdaq]
 
 
   #define the output stream, there could be more than one if using filters


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbndcode/tree/feature/hlay_crt_clustering_merged).

This PR adds / adds to existing fcls to run the new reconstruction independently and as part of the production workflow.