### PR TITLE
Add back tracking algorithm

### DIFF
--- a/sbndcode/CRT/CRTBackTracker/CMakeLists.txt
+++ b/sbndcode/CRT/CRTBackTracker/CMakeLists.txt
@@ -1,0 +1,10 @@
+art_make_library(
+                 LIBRARY_NAME sbndcode_CRT_CRTBackTracker
+                 SOURCE       CRTBackTrackerAlg.cc
+                 LIBRARIES
+                        sbnobj_SBND_CRT
+                        sbndcode_GeoWrappers
+                        larsim::MCCheater_ParticleInventoryService_service
+)
+
+install_fhicl()

--- a/sbndcode/CRT/CRTBackTracker/CMakeLists.txt
+++ b/sbndcode/CRT/CRTBackTracker/CMakeLists.txt
@@ -1,5 +1,4 @@
 art_make_library(
-                 LIBRARY_NAME sbndcode_CRT_CRTBackTracker
                  SOURCE       CRTBackTrackerAlg.cc
                  LIBRARIES
                         sbnobj_SBND_CRT

--- a/sbndcode/CRT/CRTBackTracker/CRTBackTrackerAlg.cc
+++ b/sbndcode/CRT/CRTBackTracker/CRTBackTrackerAlg.cc
@@ -1,0 +1,587 @@
+#include "CRTBackTrackerAlg.h"
+
+namespace sbnd::crt {
+  
+  CRTBackTrackerAlg::CRTBackTrackerAlg(const Config& config)
+  {
+    this->reconfigure(config);
+  }
+  
+  CRTBackTrackerAlg::CRTBackTrackerAlg(){}
+  
+  CRTBackTrackerAlg::~CRTBackTrackerAlg(){}
+
+  void CRTBackTrackerAlg::reconfigure(const Config& config)
+  {
+    fSimModuleLabel = config.SimModuleLabel();
+    fSimDepositModuleLabel = config.SimDepositModuleLabel();
+    fFEBDataModuleLabel = config.FEBDataModuleLabel();
+    fStripHitModuleLabel = config.StripHitModuleLabel();
+    fClusterModuleLabel = config.ClusterModuleLabel();
+    fSpacePointModuleLabel = config.SpacePointModuleLabel();
+    fTrackModuleLabel = config.TrackModuleLabel();
+
+    return;
+  }
+
+  void CRTBackTrackerAlg::SetupMaps(const art::Event &event)
+  {
+    fTrueDepositsPerTaggerMap.clear();
+    fTrueDepositsMap.clear();
+    fTrueTrackInfosMap.clear();
+    fTrackIDSpacePointRecoMap.clear();
+    fTrackIDTrackRecoMap.clear();
+    fMCPIDEsEnergyPerTaggerMap.clear();
+    fMCPIDEsEnergyMap.clear();
+    fMCPStripHitsMap.clear();
+    fTrackIDMotherMap.clear();
+    fStripHitMCPMap.clear();
+
+    art::Handle<std::vector<sim::ParticleAncestryMap>> droppedTrackIDMapVecHandle;
+    event.getByLabel(fSimModuleLabel, droppedTrackIDMapVecHandle);
+
+    if(droppedTrackIDMapVecHandle.isValid())
+      {
+	for(auto const& droppedTrackIdMap : *droppedTrackIDMapVecHandle)
+	  {
+	    for(auto const& [mother, ids] : droppedTrackIdMap.GetMap())
+	      {
+		for(auto const& id : ids)
+		  fTrackIDMotherMap[id] = mother;
+	      }
+	  }
+      }
+
+    art::Handle<sim::ParticleAncestryMap> droppedTrackIDMapHandle;
+    event.getByLabel(fSimModuleLabel, droppedTrackIDMapHandle);
+
+    if(droppedTrackIDMapHandle.isValid())
+      {
+	auto const& droppedTrackIdMap = droppedTrackIDMapHandle->GetMap();
+
+	for(auto const& [mother, ids] : droppedTrackIdMap)
+	  {
+	    for(auto const& id : ids)
+	      fTrackIDMotherMap[id] = mother;
+	  }
+      }
+
+    art::Handle<std::vector<sim::AuxDetIDE>> ideHandle;
+    event.getByLabel(fFEBDataModuleLabel, ideHandle);
+    std::vector<art::Ptr<sim::AuxDetIDE>> ideVec;
+    art::fill_ptr_vector(ideVec, ideHandle);
+
+    std::set<Category> depositCategories;
+    std::set<int>      depositTrackIDs;
+
+    std::map<Category, double> categoryToEnergyMap, categoryToXMap, categoryToYMap,
+      categoryToZMap, categoryToTimeMap;
+    std::map<Category, uint> categoryToNIDEsMap;
+
+    std::map<int, double> idToEnergyMap, idToXMap, idToYMap,
+      idToZMap, idToTimeMap;
+    std::map<int, uint> idToNIDEsMap;
+
+    std::map<Category, double> coreCategoryToEnergyMap, coreCategoryToXMap, coreCategoryToYMap,
+      coreCategoryToZMap, coreCategoryToTimeMap;
+    std::map<Category, uint> coreCategoryToNIDEsMap;
+
+    for(auto const ide : ideVec)
+      {
+        const double x = (ide->entryX + ide->exitX) / 2.;
+        const double y = (ide->entryY + ide->exitY) / 2.;
+        const double z = (ide->entryZ + ide->exitZ) / 2.;
+        const CRTTagger tagger = fCRTGeoAlg.WhichTagger(x, y, z);
+
+        const int rollUpID = RollUpID(ide->trackID);
+
+        Category category(rollUpID, tagger);
+        depositCategories.insert(category);
+        depositTrackIDs.insert(rollUpID);
+
+        fTrackIDSpacePointRecoMap[category] = false;
+        fTrackIDTrackRecoMap[rollUpID]      = { false, false };
+
+        categoryToEnergyMap[category] += ide->energyDeposited;
+        categoryToXMap[category]      += x;
+        categoryToYMap[category]      += y;
+        categoryToZMap[category]      += z;
+        categoryToTimeMap[category]   += (ide->entryT + ide->exitT) / 2.;
+
+        idToEnergyMap[rollUpID] += ide->energyDeposited;
+        idToXMap[rollUpID]      += x;
+        idToYMap[rollUpID]      += y;
+        idToZMap[rollUpID]      += z;
+        idToTimeMap[rollUpID]   += (ide->entryT + ide->exitT) / 2.;
+
+        Category coreCategory(ide->trackID, tagger);
+        coreCategoryToEnergyMap[coreCategory] += ide->energyDeposited;
+        coreCategoryToXMap[coreCategory]      += x;
+        coreCategoryToYMap[coreCategory]      += y;
+        coreCategoryToZMap[coreCategory]      += z;
+        coreCategoryToTimeMap[coreCategory]   += (ide->entryT + ide->exitT) / 2.;
+
+        if(categoryToNIDEsMap.find(category) == categoryToNIDEsMap.end())
+          categoryToNIDEsMap[category] = 0;
+
+        ++categoryToNIDEsMap[category];
+
+        if(idToNIDEsMap.find(rollUpID) == idToNIDEsMap.end())
+          idToNIDEsMap[rollUpID] = 0;
+
+        ++idToNIDEsMap[rollUpID];
+
+        if(coreCategoryToNIDEsMap.find(coreCategory) == coreCategoryToNIDEsMap.end())
+          coreCategoryToNIDEsMap[coreCategory] = 0;
+
+        ++coreCategoryToNIDEsMap[coreCategory];
+      }
+
+    for(auto const category : depositCategories)
+      {
+        fMCPIDEsEnergyPerTaggerMap[category] = 0.;
+        
+        const double x      = categoryToXMap[category] / categoryToNIDEsMap[category];
+        const double y      = categoryToYMap[category] / categoryToNIDEsMap[category];
+        const double z      = categoryToZMap[category] / categoryToNIDEsMap[category];
+        const double time   = categoryToTimeMap[category] / categoryToNIDEsMap[category];
+        const double energy = categoryToEnergyMap[category];
+
+        const double coreX      = coreCategoryToXMap[category] / coreCategoryToNIDEsMap[category];
+        const double coreY      = coreCategoryToYMap[category] / coreCategoryToNIDEsMap[category];
+        const double coreZ      = coreCategoryToZMap[category] / coreCategoryToNIDEsMap[category];
+        const double coreTime   = coreCategoryToTimeMap[category] / coreCategoryToNIDEsMap[category];
+        const double coreEnergy = coreCategoryToEnergyMap[category];
+
+        int pdg;
+        double particle_energy, particle_time;
+        TrueParticlePDGEnergyTime(category.trackid, pdg, particle_energy, particle_time);
+
+        fTrueDepositsPerTaggerMap[category] = TrueDeposit(category.trackid, pdg, category.tagger,
+                                                          energy, time, x, y, z, true,
+                                                          coreEnergy, coreTime, coreX, coreY, coreZ);
+      }
+
+    for(auto const trackID : depositTrackIDs)
+      {
+        fMCPIDEsEnergyMap[trackID] = 0.;
+        
+        const double x      = idToXMap[trackID] / idToNIDEsMap[trackID];
+        const double y      = idToYMap[trackID] / idToNIDEsMap[trackID];
+        const double z      = idToZMap[trackID] / idToNIDEsMap[trackID];
+        const double time   = idToTimeMap[trackID] / idToNIDEsMap[trackID];
+        const double energy = idToEnergyMap[trackID];
+
+        int pdg;
+        double particle_energy, particle_time;
+        TrueParticlePDGEnergyTime(trackID, pdg, particle_energy, particle_time);
+
+        struct SortTagger {
+          double    time;
+          double    energy;
+          CRTTagger tagger;
+        };
+
+        std::vector<SortTagger> taggers;
+
+        for(auto const& [category, deposit] : fTrueDepositsPerTaggerMap)
+          {
+            if(category.trackid == trackID)
+              taggers.push_back({deposit.time, deposit.energy, category.tagger});
+          }
+
+        std::sort(taggers.begin(), taggers.end(),
+                  [](const SortTagger &a, const SortTagger &b)
+                  { return a.time < b.time; });
+
+        Category category1, category2;
+
+        if(taggers.size() == 1)
+          {         
+            category1 = {trackID, taggers[0].tagger};
+            category2 = {trackID, taggers[0].tagger};
+          }
+        else if(taggers.size() == 2)
+          {
+            category1 = {trackID, taggers[0].tagger};
+            category2 = {trackID, taggers[1].tagger};
+          }
+        else if(taggers.size() == 3)
+          {
+            category1 = {trackID, taggers[0].tagger};
+            category2 = {trackID, taggers[2].tagger};
+          }
+        else if(taggers.size() > 3)
+          {
+            std::sort(taggers.begin(), taggers.end(),
+                      [](const auto &a, const auto &b)
+                      { return a.energy < b.energy; });
+
+            const unsigned n = taggers.size();
+
+            if(taggers[n-1].time < taggers[n-2].time)
+              {
+                category1 = {trackID, taggers[n-1].tagger};
+                category2 = {trackID, taggers[n-2].tagger};
+              }
+            else
+              {
+                category1 = {trackID, taggers[n-2].tagger};
+                category2 = {trackID, taggers[n-1].tagger};
+              }
+          }
+
+        fTrueTrackInfosMap[trackID] = TrueTrackInfo(trackID, pdg, particle_energy,
+                                                    fTrueDepositsPerTaggerMap[category1],
+                                                    fTrueDepositsPerTaggerMap[category2]);
+
+        fTrueDepositsMap[trackID] = TrueDeposit(trackID, pdg, kUndefinedTagger,
+                                                energy, time, x, y, z, taggers.size() > 1);
+      }
+
+    for(auto const ide : ideVec)
+      {
+        const double x = (ide->entryX + ide->exitX) / 2.;
+        const double y = (ide->entryY + ide->exitY) / 2.;
+        const double z = (ide->entryZ + ide->exitZ) / 2.;
+        const CRTTagger tagger = fCRTGeoAlg.WhichTagger(x, y, z);
+
+        const int rollUpID = RollUpID(ide->trackID);
+        Category category(rollUpID, tagger);
+
+        fMCPIDEsEnergyPerTaggerMap[category] += ide->energyDeposited;
+        fMCPIDEsEnergyMap[rollUpID]          += ide->energyDeposited;
+      }
+
+    art::Handle<std::vector<CRTStripHit>> stripHitHandle;
+    event.getByLabel(fStripHitModuleLabel, stripHitHandle);
+    std::vector<art::Ptr<CRTStripHit>> stripHitVec;
+    art::fill_ptr_vector(stripHitVec, stripHitHandle);
+
+    for(auto const stripHit : stripHitVec)
+      {
+        const CRTTagger tagger = fCRTGeoAlg.ChannelToTaggerEnum(stripHit->Channel());
+        TruthMatchMetrics truthMatch = TruthMatching(event, stripHit);
+
+        fStripHitMCPMap[stripHit.key()] = truthMatch.trackid;
+
+        Category category(truthMatch.trackid, tagger);
+        if(fMCPStripHitsMap.find(category) == fMCPStripHitsMap.end())
+          fMCPStripHitsMap[category] = 0;
+
+        ++fMCPStripHitsMap[{truthMatch.trackid, tagger}];
+      }
+  }
+
+  int CRTBackTrackerAlg::RollUpID(const int &id)
+  {
+    if(fTrackIDMotherMap.find(id) != fTrackIDMotherMap.end())
+      return fTrackIDMotherMap[id];
+
+    return id;
+  }
+
+  void CRTBackTrackerAlg::RunSpacePointRecoStatusChecks(const art::Event &event)
+  {
+    art::Handle<std::vector<CRTSpacePoint>> spacePointHandle;
+    event.getByLabel(fSpacePointModuleLabel, spacePointHandle);
+
+    art::FindManyP<CRTCluster> spacePointsToClusters(spacePointHandle, event, fSpacePointModuleLabel);
+
+    for(unsigned i = 0; i < spacePointHandle->size(); ++i)
+      {
+        const art::Ptr<CRTSpacePoint> spacePoint(spacePointHandle, i);
+        const art::Ptr<CRTCluster> cluster = spacePointsToClusters.at(spacePoint.key())[0];
+
+        TruthMatchMetrics truthMatch = TruthMatching(event, cluster);
+
+        Category category(truthMatch.trackid, cluster->Tagger());
+        fTrackIDSpacePointRecoMap[category] = true;
+      }
+  }
+
+  void CRTBackTrackerAlg::RunTrackRecoStatusChecks(const art::Event &event)
+  {
+    art::Handle<std::vector<CRTTrack>> trackHandle;
+    event.getByLabel(fTrackModuleLabel, trackHandle);
+
+    for(unsigned i = 0; i < trackHandle->size(); ++i)
+      {
+        const art::Ptr<CRTTrack> track(trackHandle, i);
+
+        TruthMatchMetrics truthMatch = TruthMatching(event, track);
+
+        fTrackIDTrackRecoMap[truthMatch.trackid] = { true, track->Triple()};
+      }
+  }
+
+  std::map<CRTBackTrackerAlg::Category, bool> CRTBackTrackerAlg::GetSpacePointRecoStatusMap()
+  {
+    return fTrackIDSpacePointRecoMap;
+  }
+
+  std::map<int, std::pair<bool, bool>> CRTBackTrackerAlg::GetTrackRecoStatusMap()
+  {
+    return fTrackIDTrackRecoMap;
+  }
+
+  CRTBackTrackerAlg::TrueDeposit CRTBackTrackerAlg::GetTrueDeposit(Category category)
+  {
+    return fTrueDepositsPerTaggerMap[category];
+  }
+
+  CRTBackTrackerAlg::TrueDeposit CRTBackTrackerAlg::GetTrueDeposit(int trackid)
+  {
+    return fTrueDepositsMap[trackid];
+  }
+
+  CRTBackTrackerAlg::TruthMatchMetrics CRTBackTrackerAlg::TruthMatching(const art::Event &event, const art::Ptr<CRTStripHit> &stripHit)
+  {  
+    art::Handle<std::vector<FEBData>> febDataHandle;
+    event.getByLabel(fFEBDataModuleLabel, febDataHandle);
+
+    art::Handle<std::vector<CRTStripHit>> stripHitHandle;
+    event.getByLabel(fStripHitModuleLabel, stripHitHandle);
+
+    art::FindManyP<sim::AuxDetIDE, FEBTruthInfo> febDataToIDEs(febDataHandle, event, fFEBDataModuleLabel);
+    art::FindOneP<FEBData> stripHitToFEBData(stripHitHandle, event, fStripHitModuleLabel);
+    const CRTTagger tagger = fCRTGeoAlg.ChannelToTaggerEnum(stripHit->Channel());
+
+    auto const febData = stripHitToFEBData.at(stripHit.key());
+    auto const assnIDEVec = febDataToIDEs.at(febData.key());
+
+    std::map<int, double> idToEnergyMap;
+    double totalEnergy = 0., x = 0., y = 0., z = 0., t = 0.;
+    uint nides = 0;
+
+    for(unsigned i = 0; i < assnIDEVec.size(); ++i)
+      {
+        const art::Ptr<sim::AuxDetIDE> ide = assnIDEVec[i];
+        const FEBTruthInfo *febTruthInfo = febDataToIDEs.data(febData.key())[i];
+        if((uint) febTruthInfo->GetChannel() == (stripHit->Channel() % 32))
+          {
+            idToEnergyMap[RollUpID(ide->trackID)] += ide->energyDeposited;
+            totalEnergy                           += ide->energyDeposited;
+
+            x                                     += (ide->entryX + ide->exitX) / 2.;
+            y                                     += (ide->entryY + ide->exitY) / 2.;
+            z                                     += (ide->entryZ + ide->exitZ) / 2.;
+            t                                     += (ide->entryT + ide->exitT) / 2.;
+
+            ++nides;
+          }
+      }
+
+    x /= nides;
+    y /= nides;
+    z /= nides;
+    t /= nides;
+
+    double bestPur = 0., comp = 0.;
+    int trackid = -99999;
+
+    for(auto const [id, en] : idToEnergyMap)
+      {
+        double pur = en / totalEnergy;
+        if(pur > bestPur)
+          {
+            Category category(id, tagger);
+
+            trackid = id;
+            bestPur = pur;
+            comp    = en / fMCPIDEsEnergyPerTaggerMap[category];
+          }
+      }
+
+    TrueDeposit deposit(trackid, -999999, tagger, totalEnergy, t, x, y, z, true);
+
+    return TruthMatchMetrics(trackid, comp, bestPur, 1., 1., deposit);
+  }
+
+  CRTBackTrackerAlg::TruthMatchMetrics CRTBackTrackerAlg::TruthMatching(const art::Event &event, const art::Ptr<CRTCluster> &cluster)
+  {
+    art::Handle<std::vector<FEBData>> febDataHandle;
+    event.getByLabel(fFEBDataModuleLabel, febDataHandle);
+
+    art::Handle<std::vector<CRTStripHit>> stripHitHandle;
+    event.getByLabel(fStripHitModuleLabel, stripHitHandle);
+
+    art::Handle<std::vector<CRTCluster>> clusterHandle;
+    event.getByLabel(fClusterModuleLabel, clusterHandle);
+
+    art::FindManyP<sim::AuxDetIDE, FEBTruthInfo> febDataToIDEs(febDataHandle, event, fFEBDataModuleLabel);
+    art::FindManyP<FEBData> stripHitToFEBData(stripHitHandle, event, fStripHitModuleLabel);
+    art::FindManyP<CRTStripHit> clusterToStripHits(clusterHandle, event, fClusterModuleLabel);
+
+    std::map<int, double> idToEnergyMap;
+    double totalEnergy = 0.;
+    std::map<int, uint> idToNHitsMap;
+
+    auto const assnStripHitVec = clusterToStripHits.at(cluster.key());
+
+    for(auto const stripHit : assnStripHitVec)
+      {
+        auto const febData = stripHitToFEBData.at(stripHit.key());
+        assert(febData.size() == 1);
+        auto const assnIDEVec = febDataToIDEs.at(febData.at(0).key());
+        for(unsigned i = 0; i < assnIDEVec.size(); ++i)
+          {
+            const art::Ptr<sim::AuxDetIDE> ide = assnIDEVec[i];
+            const FEBTruthInfo *febTruthInfo = febDataToIDEs.data(febData.at(0).key())[i];
+            if((uint) febTruthInfo->GetChannel() == (stripHit->Channel() % 32))
+              {
+                idToEnergyMap[RollUpID(ide->trackID)] += ide->energyDeposited;
+                totalEnergy                           += ide->energyDeposited;
+              }
+          }
+
+        if(idToNHitsMap.find(fStripHitMCPMap[stripHit.key()]) == idToNHitsMap.end())
+          idToNHitsMap[fStripHitMCPMap[stripHit.key()]] = 0;
+        
+        ++idToNHitsMap[fStripHitMCPMap[stripHit.key()]];
+      }
+
+    double bestPur = 0., comp = 0.;
+    int trackid = -99999;
+
+    for(auto const [id, en] : idToEnergyMap)
+      {
+        double pur = en / totalEnergy;
+        if(pur > bestPur)
+          {
+            Category category(id, cluster->Tagger());
+
+            trackid = id;
+            bestPur = pur;
+            comp    = en / fMCPIDEsEnergyPerTaggerMap[category];
+          }
+      }
+
+    Category category(trackid, cluster->Tagger());
+
+    double hitComp = idToNHitsMap[trackid] / (double) fMCPStripHitsMap[category];
+    double hitPur  = idToNHitsMap[trackid] / (double) assnStripHitVec.size();
+
+    return TruthMatchMetrics(trackid, comp, bestPur, hitComp, hitPur, 
+                             fTrueDepositsPerTaggerMap[category]);
+  }
+
+  CRTBackTrackerAlg::TruthMatchMetrics CRTBackTrackerAlg::TruthMatching(const art::Event &event, const art::Ptr<CRTTrack> &track)
+  {
+    art::Handle<std::vector<FEBData>> febDataHandle;
+    event.getByLabel(fFEBDataModuleLabel, febDataHandle);
+
+    art::Handle<std::vector<CRTStripHit>> stripHitHandle;
+    event.getByLabel(fStripHitModuleLabel, stripHitHandle);
+
+    art::Handle<std::vector<CRTCluster>> clusterHandle;
+    event.getByLabel(fClusterModuleLabel, clusterHandle);
+
+    art::Handle<std::vector<CRTSpacePoint>> spacePointHandle;
+    event.getByLabel(fSpacePointModuleLabel, spacePointHandle);
+
+    art::Handle<std::vector<CRTTrack>> trackHandle;
+    event.getByLabel(fTrackModuleLabel, trackHandle);
+
+    art::FindManyP<sim::AuxDetIDE, FEBTruthInfo> febDataToIDEs(febDataHandle, event, fFEBDataModuleLabel);
+    art::FindManyP<FEBData> stripHitToFEBData(stripHitHandle, event, fStripHitModuleLabel);
+    art::FindManyP<CRTStripHit> clusterToStripHits(clusterHandle, event, fClusterModuleLabel);
+    art::FindOneP<CRTCluster> spacePointToCluster(spacePointHandle, event, fSpacePointModuleLabel);
+    art::FindManyP<CRTSpacePoint> trackToSpacePoints(trackHandle, event, fTrackModuleLabel);
+
+    std::map<int, double> idToEnergyMap;
+    double totalEnergy = 0.;
+
+    auto const spacePointVec = trackToSpacePoints.at(track.key());
+
+    for(auto const spacePoint : spacePointVec)
+      {
+        auto const cluster     = spacePointToCluster.at(spacePoint.key());
+        auto const stripHitVec = clusterToStripHits.at(cluster.key());
+        
+        for(auto const stripHit : stripHitVec)
+          {
+            auto const febData = stripHitToFEBData.at(stripHit.key());
+            assert(febData.size() == 1);
+            auto const assnIDEVec = febDataToIDEs.at(febData.at(0).key());
+
+            for(unsigned i = 0; i < assnIDEVec.size(); ++i)
+              {
+                const art::Ptr<sim::AuxDetIDE> ide = assnIDEVec[i];
+                const FEBTruthInfo *febTruthInfo = febDataToIDEs.data(febData.at(0).key())[i];
+                if((uint) febTruthInfo->GetChannel() == (stripHit->Channel() % 32))
+                  {
+                    idToEnergyMap[RollUpID(ide->trackID)] += ide->energyDeposited;
+                    totalEnergy                           += ide->energyDeposited;
+                  }
+              }
+          }
+      }
+
+    double bestPur = 0., comp = 0.;
+    int trackid = -99999;
+    
+    for(auto const [id, en] : idToEnergyMap)
+      {
+        double pur = en / totalEnergy;
+        if(pur > bestPur)
+          {
+            trackid = id;
+            bestPur = pur;
+            comp    = en / fMCPIDEsEnergyMap[id];
+          }
+      }
+
+    return TruthMatchMetrics(trackid, comp, bestPur, 1., 1., fTrueDepositsMap[trackid],
+                             fTrueTrackInfosMap[trackid]);
+  }
+
+  std::pair<double, geo::Point_t> CRTBackTrackerAlg::LineTaggerIntersectionPoint(const geo::Point_t &start, 
+                                                                                 const geo::Vector_t &dir, 
+                                                                                 const CRTTagger &tagger)
+  {
+    const CoordSet constrainedPlane = CRTCommonUtils::GetTaggerDefinedCoordinate(tagger);
+    const CRTTaggerGeo taggerGeo    = fCRTGeoAlg.GetTagger(CRTCommonUtils::GetTaggerName(tagger));
+    double k;
+
+    switch(constrainedPlane)
+      {
+      case kX:
+        {
+          const double x = (taggerGeo.maxX + taggerGeo.minX) / 2.;
+          k =  (x - start.X()) / dir.X();
+        }
+        break;
+      case kY:
+        {
+          const double y = (taggerGeo.maxY + taggerGeo.minY) / 2.;
+          k = (y - start.Y()) / dir.Y();
+        }
+        break;
+      case kZ:
+        {
+          const double z = (taggerGeo.maxZ + taggerGeo.minZ) / 2.;
+          k = (z - start.Z()) / dir.Z();
+        }
+        break;
+      default:
+        std::cout << "Tagger not defined in one plane" << std::endl;
+        k = std::numeric_limits<double>::max();
+        break;
+      }
+    
+    if(!fCRTGeoAlg.IsPointInsideCRTLimits(start + k * dir))
+      return {999999., {999999., 999999., 999999.}};
+    
+    return {k, start + k * dir};
+  }
+
+  void CRTBackTrackerAlg::TrueParticlePDGEnergyTime(const int trackID, int &pdg, double &energy, double &time)
+  {
+    const simb::MCParticle* particle = particleInv->TrackIdToParticle_P(trackID);
+
+    pdg    = particle == NULL ? -std::numeric_limits<int>::max()    : particle->PdgCode();
+    energy = particle == NULL ? -std::numeric_limits<double>::max() : particle->E();
+    time   = particle == NULL ? -std::numeric_limits<double>::max() : particle->T();
+  }
+}

--- a/sbndcode/CRT/CRTBackTracker/CRTBackTrackerAlg.h
+++ b/sbndcode/CRT/CRTBackTracker/CRTBackTrackerAlg.h
@@ -1,0 +1,256 @@
+#ifndef CRTBACKTRACKERALG_H_SEEN
+#define CRTBACKTRACKERALG_H_SEEN
+
+///////////////////////////////////////////////
+// CRTBackTrackerAlg.h
+//
+// Truth Matching Utilities for CRT analysis
+// Henry Lay (h.lay@lancaster.ac.uk)
+// November 2022
+///////////////////////////////////////////////
+
+// framework
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Core/ModuleMacros.h"
+#include "fhiclcpp/ParameterSet.h" 
+#include "art/Framework/Principal/Handle.h" 
+#include "canvas/Persistency/Common/Ptr.h" 
+#include "art/Framework/Services/Registry/ServiceHandle.h" 
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+
+// Utility libraries
+#include "fhiclcpp/ParameterSet.h"
+#include "fhiclcpp/types/Table.h"
+#include "fhiclcpp/types/Atom.h"
+
+// sbnobj
+#include "sbnobj/SBND/CRT/FEBData.hh"
+#include "sbnobj/SBND/CRT/FEBTruthInfo.hh"
+#include "sbnobj/SBND/CRT/CRTStripHit.hh"
+#include "sbnobj/SBND/CRT/CRTCluster.hh"
+#include "sbnobj/SBND/CRT/CRTSpacePoint.hh"
+#include "sbnobj/SBND/CRT/CRTTrack.hh"
+
+// sbndcode
+#include "sbndcode/Geometry/GeometryWrappers/CRTGeoAlg.h"
+
+// larsim
+#include "larsim/MCCheater/ParticleInventoryService.h"
+
+// larcorealg
+#include "larcorealg/CoreUtils/enumerate.h"
+
+// lardataobj
+#include "lardataobj/Simulation/ParticleAncestryMap.h"
+
+namespace sbnd::crt {
+  
+  class CRTBackTrackerAlg {
+  public:
+    
+    struct Config {
+      using Name = fhicl::Name;
+      using Comment = fhicl::Comment;
+      
+      fhicl::Atom<art::InputTag> SimModuleLabel {
+        Name("SimModuleLabel"),
+          };
+      fhicl::Atom<art::InputTag> SimDepositModuleLabel {
+        Name("SimDepositModuleLabel"),
+          };
+      fhicl::Atom<art::InputTag> FEBDataModuleLabel {
+        Name("FEBDataModuleLabel"),
+          };
+      fhicl::Atom<art::InputTag> StripHitModuleLabel {
+        Name("StripHitModuleLabel"),
+          };
+      fhicl::Atom<art::InputTag> ClusterModuleLabel {
+        Name("ClusterModuleLabel"),
+          };
+      fhicl::Atom<art::InputTag> SpacePointModuleLabel {
+        Name("SpacePointModuleLabel"),
+          };
+
+      fhicl::Atom<art::InputTag> TrackModuleLabel {
+        Name("TrackModuleLabel"),
+          };
+    };
+
+    struct Category {
+      int       trackid;
+      CRTTagger tagger;
+
+      Category(int _trackid = -999999, CRTTagger _tagger = kUndefinedTagger)
+      {
+        trackid = _trackid;
+        tagger  = _tagger;
+      }
+
+      bool operator<(const Category &other) const
+      {
+        if(trackid == other.trackid)
+          return tagger < other.tagger;
+
+        return trackid < other.trackid;
+      }
+    };
+
+
+    struct TrueDeposit {
+      int       trackid;
+      int       pdg;
+      CRTTagger tagger;
+      double    energy;
+      double    time;
+      double    x;
+      double    y;
+      double    z;
+      bool      reconstructable;
+      double    coreEnergy;
+      double    coreTime;
+      double    coreX;
+      double    coreY;
+      double    coreZ;
+
+      TrueDeposit(int _trackid = -999999, int _pdg = -999999, CRTTagger _tagger = kUndefinedTagger,
+                  double _energy = -999999., double _time = -999999.,
+                  double _x = -999999., double _y = -999999., double _z = -999999.,
+                  bool _reconstructable = false,
+                  double _coreEnergy = -999999., double _coreTime = -999999.,
+                  double _coreX = -999999., double _coreY = -999999., double _coreZ = -999999.)
+      {
+        trackid         = _trackid;
+        pdg             = _pdg;
+        tagger          = _tagger;
+        energy          = _energy;
+        time            = _time;
+        x               = _x;
+        y               = _y;
+        z               = _z;
+        reconstructable = _reconstructable;
+        coreEnergy      = _coreEnergy;
+        coreTime        = _coreTime;
+        coreX           = _coreX;
+        coreY           = _coreY;
+        coreZ           = _coreZ;
+      }
+    };
+
+    struct TrueTrackInfo {
+      int trackid;
+      int pdg;
+      double energy;
+      TrueDeposit deposit1;
+      TrueDeposit deposit2;
+
+      TrueTrackInfo()
+      {
+        trackid    = -std::numeric_limits<int>::max();
+        pdg        = -std::numeric_limits<int>::max();
+        energy     = -std::numeric_limits<double>::max();
+        deposit1   = TrueDeposit();
+        deposit2   = TrueDeposit();
+      }
+
+      TrueTrackInfo(int _trackid, int _pdg, double _energy, TrueDeposit &_deposit1,
+                    TrueDeposit &_deposit2)
+      {
+        trackid    = _trackid;
+        pdg        = _pdg;
+        energy     = _energy;
+        deposit1   = _deposit1;
+        deposit2   = _deposit2;
+      }
+    };
+
+    struct TruthMatchMetrics {
+      int           trackid;
+      double        completeness;
+      double        purity;
+      double        hitcompleteness;
+      double        hitpurity;
+      TrueDeposit   deposit;
+      TrueTrackInfo trackinfo;
+
+      TruthMatchMetrics(int _trackid, double _completeness, double _purity,
+                        double _hitcompleteness, double _hitpurity, TrueDeposit _deposit,
+                        TrueTrackInfo _trackinfo = TrueTrackInfo())
+      {
+        trackid         = _trackid;
+        completeness    = _completeness;
+        purity          = _purity;
+        hitcompleteness = _hitcompleteness;
+        hitpurity       = _hitpurity;
+        deposit         = _deposit;
+        trackinfo       = _trackinfo;
+      }
+    };
+
+    CRTBackTrackerAlg(const Config& config);
+    
+    CRTBackTrackerAlg(const fhicl::ParameterSet& pset) :
+    CRTBackTrackerAlg(fhicl::Table<Config>(pset, {})()) {}
+    
+    CRTBackTrackerAlg();
+
+    ~CRTBackTrackerAlg();
+
+    void reconfigure(const Config& config);
+
+    void SetupMaps(const art::Event &event);
+
+    int RollUpID(const int &id);
+
+    void RunSpacePointRecoStatusChecks(const art::Event &event);
+
+    void RunTrackRecoStatusChecks(const art::Event &event);
+    
+    std::map<Category, bool> GetSpacePointRecoStatusMap();
+
+    std::map<int, std::pair<bool, bool>> GetTrackRecoStatusMap();
+
+    TrueDeposit GetTrueDeposit(Category category);
+
+    TrueDeposit GetTrueDeposit(int trackid);
+
+    TruthMatchMetrics TruthMatching(const art::Event &event, const art::Ptr<CRTStripHit> &stripHit);
+
+    TruthMatchMetrics TruthMatching(const art::Event &event, const art::Ptr<CRTCluster> &cluster);
+
+    TruthMatchMetrics TruthMatching(const art::Event &event, const art::Ptr<CRTTrack> &track);
+
+    std::pair<double, geo::Point_t> LineTaggerIntersectionPoint(const geo::Point_t &start, 
+                                                                const geo::Vector_t &dir, 
+                                                                const CRTTagger &tagger);
+
+    void TrueParticlePDGEnergyTime(const int trackID, int &pdg, double &energy, double &time);
+
+  private:
+    
+    CRTGeoAlg fCRTGeoAlg;
+    art::ServiceHandle<cheat::ParticleInventoryService> particleInv;
+
+    art::InputTag fSimModuleLabel;
+    art::InputTag fSimDepositModuleLabel;
+    art::InputTag fFEBDataModuleLabel;
+    art::InputTag fStripHitModuleLabel;
+    art::InputTag fClusterModuleLabel;
+    art::InputTag fSpacePointModuleLabel;
+    art::InputTag fTrackModuleLabel;
+
+    std::map<Category, TrueDeposit>      fTrueDepositsPerTaggerMap;
+    std::map<int, TrueDeposit>           fTrueDepositsMap;
+    std::map<int, TrueTrackInfo>         fTrueTrackInfosMap;
+    std::map<Category, bool>             fTrackIDSpacePointRecoMap;
+    std::map<int, std::pair<bool, bool>> fTrackIDTrackRecoMap;
+    std::map<Category, double>           fMCPIDEsEnergyPerTaggerMap;
+    std::map<int, double>                fMCPIDEsEnergyMap;
+    std::map<Category, int>              fMCPStripHitsMap;
+    std::map<int, int>                   fTrackIDMotherMap;
+    std::map<int, int>                   fStripHitMCPMap;
+    
+  };
+}
+
+#endif

--- a/sbndcode/CRT/CRTBackTracker/crtbacktrackeralg_sbnd.fcl
+++ b/sbndcode/CRT/CRTBackTracker/crtbacktrackeralg_sbnd.fcl
@@ -1,0 +1,14 @@
+BEGIN_PROLOG
+
+crtbacktrackeralg_sbnd:
+{
+   SimModuleLabel:         "largeant"
+   SimDepositModuleLabel:  "genericcrt"
+   FEBDataModuleLabel:     "crtsim"
+   StripHitModuleLabel:    "crtstrips"
+   ClusterModuleLabel:     "crtclustering"
+   SpacePointModuleLabel:  "crtspacepoints"
+   TrackModuleLabel:       "crttracks"
+}
+
+END_PROLOG


### PR DESCRIPTION
Following extensive work to rewrite the CRT reconstruction for SBND the PR strategy has been agreed to be a series of PRs against a common branch (`feature/hlay_crt_clustering_base`) for the (inevitably very long) review stage. Please don't use CI tests yet. They will be used on the final PR when the common branch is compared to `develop`. At this stage the individual branches may not each compile on their own. The fully merged branch can be viewed here for completeness [feature/hlay_crt_clustering_merged](https://github.com/SBNSoftware/sbndcode/tree/feature/hlay_crt_clustering_merged).

This PR creates a back tracking module mainly to provide information for the new analyser and event displays.