### PR TITLE
Feature/fnicolas pdssim

### DIFF
--- a/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
@@ -27,8 +27,10 @@ sbnd_opticalproperties: {
     
     ScintByParticleType: true
 
-    ScintPreScale:  0.03   # QE x TPB_FW x TPB_Absorption (15% x 50% x 45%)
-                           # MUST match between g4 and detsim
+    # ScintPreScale MUST be equal/larger than the largest detection efficiency applied at DetSim stage
+    # This corresponds to the uncoated PMTs detection efficiency (9.6%)
+    # See sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+    ScintPreScale:  0.19
 
     EnableCerenkovLight: false # Cerenkov light OFF by default
 

--- a/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
@@ -28,7 +28,7 @@ sbnd_opticalproperties: {
     ScintByParticleType: true
 
     # ScintPreScale MUST be equal/larger than the largest detection efficiency applied at DetSim stage
-    # This corresponds to the uncoated PMTs detection efficiency (9.6%)
+    # This corresponds to the uncoated PMTs detection efficiency (19%)
     # See sbndcode/OpDetSim/digi_pmt_sbnd.fcl
     ScintPreScale:  0.19
 

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
@@ -5,11 +5,11 @@ OpDeconvolutionAlg:
 {
   tool_type: "OpDeconvolutionAlgWiener"
   Debug: false
-  MaxFFTSizePow: 15
+  MaxFFTSizePow: 16
   OpDetDataFile: "OpDetSim/digi_pmt_sbnd_v2int0.root"
   PositivePolarity: false
   UseSaturated: false
-  ADCSaturationValue: 988
+  ADCSaturationValue: 0
   ApplyExpoAvSmooth: true
   ApplyUnAvSmooth: true
   ExpoAvSmoothPar: 0.3

--- a/sbndcode/OpDetReco/OpDeconvolution/job/opdeconvolution_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/opdeconvolution_sbnd.fcl
@@ -15,6 +15,10 @@ SBNDOpDeconvolutionPMT: @local::SBNDOpDeconvolution
 SBNDOpDeconvolutionPMT.PDTypes: ["pmt_coated", "pmt_uncoated"]
 SBNDOpDeconvolutionPMT.Electronics: [""]
 SBNDOpDeconvolutionPMT.OpDecoAlg.OpDetDataFile: "OpDetSim/digi_pmt_sbnd_v2int0.root"
+SBNDOpDeconvolutionPMT.OpDecoAlg.UseParamFilter: true
+SBNDOpDeconvolutionPMT.OpDecoAlg.FilterParams: [0.049, 2] #Freq in GHz
+SBNDOpDeconvolutionPMT.OpDecoAlg.Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))" #Gauss filter, remove DC component F(0)=0
+SBNDOpDeconvolutionPMT.OpDecoAlg.DecoWaveformPrecision: 0.005
 
 SBNDOpDeconvolutionXARAPUCA: @local::SBNDOpDeconvolution
 SBNDOpDeconvolutionXARAPUCA.PDTypes: ["xarapuca_vuv", "xarapuca_vis"]

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -5,7 +5,7 @@ BEGIN_PROLOG
 ####OpFlash finder for PMT deconvolved waveforms#####
 ###TPC0
 SBNDDecoSimpleFlashTPC0: @local::SBNDSimpleFlashTPC0
-SBNDDecoSimpleFlashTPC0.PECalib.SPEAreaGain: 500
+SBNDDecoSimpleFlashTPC0.PECalib.SPEAreaGain: 200
 SBNDDecoSimpleFlashTPC0.OpHitProducers: ["ophitpmt"]
 SBNDDecoSimpleFlashTPC0.OpHitInputTime: "RiseTime"
 SBNDDecoSimpleFlashTPC0.UseT0Tool: true
@@ -14,7 +14,7 @@ SBNDDecoSimpleFlashTPC0.CorrectLightPropagation: true
 
 #TPC1
 SBNDDecoSimpleFlashTPC1: @local::SBNDSimpleFlashTPC1
-SBNDDecoSimpleFlashTPC1.PECalib.SPEAreaGain: 500
+SBNDDecoSimpleFlashTPC1.PECalib.SPEAreaGain: 200
 SBNDDecoSimpleFlashTPC1.OpHitProducers: ["ophitpmt"]
 SBNDDecoSimpleFlashTPC1.OpHitInputTime: "RiseTime"
 SBNDDecoSimpleFlashTPC1.UseT0Tool: true

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -32,12 +32,14 @@ SBNDDecoSimpleFlashTPC0Arapuca.PECalib.SPEAreaGain: 500
 SBNDDecoSimpleFlashTPC0Arapuca.OpHitProducers: ["ophitxarapuca"]
 SBNDDecoSimpleFlashTPC0Arapuca.OpFlashProducer: "opflasharapuca"
 SBNDDecoSimpleFlashTPC0Arapuca.AlgoConfig.PD: ["xarapuca_vuv","xarapuca_vis"]
+SBNDDecoSimpleFlashTPC0Arapuca.FlashGeoConfig.PDTypes: ["xarapuca_vuv","xarapuca_vis"]
 #TPC1
 SBNDDecoSimpleFlashTPC1Arapuca: @local::SBNDSimpleFlashTPC1
 SBNDDecoSimpleFlashTPC1Arapuca.PECalib.SPEAreaGain: 500
 SBNDDecoSimpleFlashTPC1Arapuca.OpHitProducers: ["ophitxarapuca"]
 SBNDDecoSimpleFlashTPC1Arapuca.OpFlashProducer: "opflasharapuca"
 SBNDDecoSimpleFlashTPC1Arapuca.AlgoConfig.PD: ["xarapuca_vuv","xarapuca_vis"]
+SBNDDecoSimpleFlashTPC1Arapuca.FlashGeoConfig.PDTypes: ["xarapuca_vuv","xarapuca_vis"]
 
 SBNDDecoSimpleFlashTPC0Arapuca.AlgoConfig.MinMultCoinc: 3
 SBNDDecoSimpleFlashTPC0Arapuca.AlgoConfig.PEThreshold: 30

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_ophitfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_ophitfinder_deco.fcl
@@ -5,13 +5,13 @@ BEGIN_PROLOG
 #####OpHit finder for PMT deconvolved waveforms#####
 SBNDDecoOpHitFinderPMT: @local::sbnd_ophit_finder_pmt
 ####SPE area must be 1./DecoWaveformPrecision
-SBNDDecoOpHitFinderPMT.SPEArea: 500
+SBNDDecoOpHitFinderPMT.SPEArea: 200
 SBNDDecoOpHitFinderPMT.InputModule: "opdecopmt"
 SBNDDecoOpHitFinderPMT.HitThreshold: 1
 SBNDDecoOpHitFinderPMT.RiseTimeCalculator:   @local::sbnd_opreco_risetimecalculator
 
 #HitAlgoPset
-SBNDDecoOpHitFinderPMT.HitAlgoPset.ADCThreshold: 30
+SBNDDecoOpHitFinderPMT.HitAlgoPset.ADCThreshold: 12
 SBNDDecoOpHitFinderPMT.HitAlgoPset.NSigmaThreshold: 3
 SBNDDecoOpHitFinderPMT.HitAlgoPset.EndADCThreshold: 8
 SBNDDecoOpHitFinderPMT.HitAlgoPset.EndNSigmaThreshold: 0.2

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/CMakeLists.txt
@@ -1,5 +1,8 @@
 cet_build_plugin(DriftEstimatorPMTRatio art::tool SOURCE DriftEstimatorPMTRatio_tool.cc LIBRARIES sbndcode_OpDetReco_OpFlash_FlashFinder )
+
 cet_build_plugin(FlashGeoBarycenter art::tool SOURCE FlashGeoBarycenter_tool.cc LIBRARIES sbndcode_OpDetReco_OpFlash_FlashFinder )
+cet_build_plugin(FlashGeoThreshold art::tool SOURCE FlashGeoThreshold_tool.cc LIBRARIES sbndcode_OpDetReco_OpFlash_FlashFinder )
+
 cet_build_plugin(FlashT0FirstHit art::tool SOURCE FlashT0FirstHit_tool.cc LIBRARIES sbndcode_OpDetReco_OpFlash_FlashFinder )
 cet_build_plugin(FlashT0SelectedChannels art::tool SOURCE FlashT0SelectedChannels_tool.cc LIBRARIES sbndcode_OpDetReco_OpFlash_FlashFinder )
 

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
@@ -142,10 +142,10 @@ namespace lightana
 
   double DriftEstimatorPMTRatio::GetDriftPosition(std::vector<double> PE_v){
 
-    std::map<int, double> fBoxMap_PECoated;
-    std::map<int, double> fBoxMap_PEUncoated;
-    std::map<int, int> fBoxMap_NCoatedCh;
-    std::map<int, int> fBoxMap_NUncoatedCh;
+    std::map<int, double> BoxMap_PECoated;
+    std::map<int, double> BoxMap_PEUncoated;
+    std::map<int, int> BoxMap_NCoatedCh;
+    std::map<int, int> BoxMap_NUncoatedCh;
 
     for(size_t oc=0; oc<PE_v.size(); oc++){
       // skip 0 PE channels
@@ -161,28 +161,28 @@ namespace lightana
       // we store the pe in each box per PMT flavour
       // and the number of "triggered" PMTs
       if(pd_type=="pmt_coated") {
-        fBoxMap_PECoated[box_id]+=PE_v[oc];
-        fBoxMap_NCoatedCh[box_id]+=1;
+        BoxMap_PECoated[box_id]+=PE_v[oc];
+        BoxMap_NCoatedCh[box_id]+=1;
       }
       else if(pd_type=="pmt_uncoated") {
-        fBoxMap_PEUncoated[box_id]+=PE_v[oc];
-        fBoxMap_NUncoatedCh[box_id]+=1;
+        BoxMap_PEUncoated[box_id]+=PE_v[oc];
+        BoxMap_NUncoatedCh[box_id]+=1;
       }
     }
 
     // compute PMTRatio metric
-    double fPECoated=0, fPEUncoated=0;
+    double PECoated=0, PEUncoated=0;
     for(size_t boxID=0; boxID<fPDSBoxIDs.size(); boxID++){
       //we need the uncoated PMT in each window and at least one coated
-      if( fBoxMap_NUncoatedCh[boxID]==1 && fBoxMap_NCoatedCh[boxID]>=1){
-        double CoWeight = 1./fBoxMap_NCoatedCh[boxID];
-        fPECoated+=CoWeight * fBoxMap_PECoated[boxID];
-        fPEUncoated+=fBoxMap_PEUncoated[boxID];
+      if( BoxMap_NUncoatedCh[boxID]==1 && BoxMap_NCoatedCh[boxID]>=1){
+        double CoWeight = 1./BoxMap_NCoatedCh[boxID];
+        PECoated+=CoWeight * BoxMap_PECoated[boxID];
+        PEUncoated+=BoxMap_PEUncoated[boxID];
       }
     }
 
-    if(fPECoated!=0){
-      double pmtratio = fPEUncoated/fPECoated;
+    if(PECoated!=0){
+      double pmtratio = PEUncoated/PECoated;
 
       double drift_distance;
       if(pmtratio<=fPMTRatioCal[0])

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/DriftEstimatorPMTRatio_tool.cc
@@ -23,6 +23,7 @@
 
 #include <vector>
 #include <string>
+#include <map>
 
 #include "DriftEstimatorBase.hh"
 #include "sbndcode/OpDetSim/sbndPDMapAlg.hh"
@@ -95,6 +96,8 @@ namespace lightana
     // PDS mapping
     opdet::sbndPDMapAlg fPDSMap;
 
+    std::set<int> fPDSBoxIDs;
+
   };
 
   DriftEstimatorPMTRatio::DriftEstimatorPMTRatio(art::ToolConfigTable<Config> const& config)
@@ -131,20 +134,71 @@ namespace lightana
     fKinkDistance = 0.5*fDriftDistance*(1-fVGroupVUV/fVGroupVIS);
 
     fVGroupVUV_I = 1./fVGroupVUV;
+
+    for(size_t oc=0; oc<fPDSMap.size(); oc++){
+      fPDSBoxIDs.insert( fPDSMap.pdBox(oc) );
+    }
   }
 
   double DriftEstimatorPMTRatio::GetDriftPosition(std::vector<double> PE_v){
 
+    /*
     double coatedPE=0, uncoatedPE=0;
-
     for(size_t oc=0; oc<PE_v.size(); oc++){
       if( fPDSMap.pdType(oc)=="pmt_coated" ) coatedPE+=PE_v[oc];
       else if( fPDSMap.pdType(oc)=="pmt_uncoated" ) uncoatedPE+=PE_v[oc];
+    }*/
+
+    std::map<int, double> fBoxMap_PECoated;
+    std::map<int, double> fBoxMap_PEUncoated;
+    std::map<int, int> fBoxMap_NCoatedCh;
+    std::map<int, int> fBoxMap_NUncoatedCh;
+
+    for(size_t oc=0; oc<PE_v.size(); oc++){
+      // skip 0 PE channels
+      if(PE_v[oc]==0) continue;
+
+      std::string pd_type=fPDSMap.pdType(oc);
+      // exclude xarapucas by now
+      if(pd_type=="xarapuca_vuv" || pd_type=="xarapuca_vis") continue;
+
+      // get PDS box
+      int box_id = fPDSMap.pdBox(oc);
+
+      // we store the pe in each box per PMT flavour
+      // and the number of "triggered" PMTs
+      if(pd_type=="pmt_coated") {
+        //fPECoated+=FlashPE_v[oc];
+        fBoxMap_PECoated[box_id]+=PE_v[oc];
+        fBoxMap_NCoatedCh[box_id]+=1;
+      }
+      else if(pd_type=="pmt_uncoated") {
+        //fPEUncoated+=FlashPE_v[oc];
+        fBoxMap_PEUncoated[box_id]+=PE_v[oc];
+        fBoxMap_NUncoatedCh[box_id]+=1;
+      }
     }
 
-    double pmtratio=1.;
+    // compute PMTRatio metric
+    double fPECoated=0, fPEUncoated=0;
+    for(size_t boxID=0; boxID<fPDSBoxIDs.size(); boxID++){
+      //we need the uncoated PMT in each window and at least one coated
+      if( fBoxMap_NUncoatedCh[boxID]==1 && fBoxMap_NCoatedCh[boxID]>=1){
+        double CoWeight = 1./fBoxMap_NCoatedCh[boxID];
+        std::cout<<"Using box "<<boxID<<" W="<<CoWeight<<" "<<fBoxMap_PECoated[boxID]<<" "<<fBoxMap_PEUncoated[boxID]<<std::endl;
+        
+        fPECoated+=CoWeight * fBoxMap_PECoated[boxID];
+        fPEUncoated+=fBoxMap_PEUncoated[boxID];
+      }
+    }
+
+    /*double pmtratio=1.;
     if(coatedPE!=0)
-      pmtratio = 4*uncoatedPE/coatedPE;
+      pmtratio = 4*uncoatedPE/coatedPE;*/
+
+    double pmtratio=1.2;
+    if(fPECoated!=0)
+      pmtratio = fPEUncoated/fPECoated;
 
     double drift_distance;
     if(pmtratio<=fPMTRatioCal[0])
@@ -154,6 +208,7 @@ namespace lightana
     else
       drift_distance=Interpolate(pmtratio);
 
+    std::cout<<"Flash: "<<drift_distance<<" "<<pmtratio<<std::endl;
     return drift_distance;
    }
 

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBarycenter_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoBarycenter_tool.cc
@@ -45,6 +45,8 @@ namespace lightana{
 
     unsigned int fWeightExp;
 
+    static constexpr double fDefCenterValue = -999.;
+
   };
 
 
@@ -60,8 +62,8 @@ namespace lightana{
   {
 
     // Reset variables
-    Ycenter = Zcenter = 0.;
-    Ywidth  = Zwidth  = -999.;
+    Ycenter = Zcenter = fDefCenterValue;
+    Ywidth  = Zwidth  = fDefCenterValue;
     double totalPE = 0.;
     double sumy = 0., sumz = 0., sumy2 = 0., sumz2 = 0.;
     double weight =1.;

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoThreshold_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoThreshold_tool.cc
@@ -149,37 +149,20 @@ namespace lightana{
       fYPEAccumulator[(int) fPDxyz[1] ]+=pePerOpChannel[opch];
       fZPEAccumulator[(int) fPDxyz[2] ]+=pePerOpChannel[opch];
     }
-    
-    std::cout<<" YYY \n";
-    for(auto & y: fYPEAccumulator){
-      std::cout<<y.first<<":"<<y.second<<" ";
-    }
-    std::cout<<std::endl;
-
-    std::cout<<" ZZZ \n";
-    for(auto & z: fZPEAccumulator){
-      std::cout<<z.first<<":"<<z.second<<" ";
-    }
-    std::cout<<std::endl;
 
     // Normalize PE accumulators
     if(fNormalizeByPDType){
-      std::cout<<"Normalizing by PDType\n";
-
-      // Get normalization values for each PD type
+      
+      // Get normalization values for each PD type (Z)
       for(auto & z: fZPEAccumulator){
         if(z.second>fNormFactorsZ[ fPDTypeByZ[z.first] ]) 
           fNormFactorsZ[ fPDTypeByZ[z.first] ] = z.second;
       }
 
+      // Get normalization values for each PD type (Y)
       for(auto & y: fYPEAccumulator){
         if(y.second>fNormFactorsY[ fPDTypeByY[y.first] ]) 
           fNormFactorsY[ fPDTypeByY[y.first] ] = y.second;
-      }
-
-      std::cout<<" Norms are: \n";
-      for(auto & pd:fPDTypes){
-        std::cout<<"PDTypes: "<<pd<<" NormY: "<<fNormFactorsY[pd]<<" NormZ: "<<fNormFactorsZ[pd]<<std::endl;
       }
 
       for(auto & y: fYPEAccumulator)
@@ -190,7 +173,6 @@ namespace lightana{
 
     }
     else{
-      std::cout<<"Not normalizing by PDType\n";
 
       double normY = std::max_element(fYPEAccumulator.begin(), fYPEAccumulator.end(), 
                       [](const std::pair<int, double> &pe1, const std::pair<int, double> &pe2) 
@@ -199,25 +181,11 @@ namespace lightana{
       double normZ =  std::max_element(fZPEAccumulator.begin(), fZPEAccumulator.end(), 
                       [](const std::pair<int, double> &pe1, const std::pair<int, double> &pe2) 
                       {return pe1.second < pe2.second;})->second;
-      
-        
-      std::cout<<" Norms are: Y=" <<normY<<" Z="<<normZ<<"\n";
 
       for(auto & y: fYPEAccumulator) fYPEAccumulator[y.first] = y.second / normY; 
       for(auto & z: fZPEAccumulator) fZPEAccumulator[z.first] = z.second / normZ;
  
     }
-
-    std::cout<<" After norm...\n YYY \n";
-    for(auto & y: fYPEAccumulator){
-      std::cout<<y.first<<":"<<y.second<<" ";
-    }
-    std::cout<<std::endl;
-    std::cout<<" ZZZ \n";
-    for(auto & z: fZPEAccumulator){
-      std::cout<<z.first<<":"<<z.second<<" ";
-    }
-    std::cout<<std::endl;
 
     // Get YZ position of selected channels (above threshold)
     GetCenter(fYPEAccumulator, Ycenter, Ywidth);

--- a/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoThreshold_tool.cc
+++ b/sbndcode/OpDetReco/OpFlash/FlashTools/FlashGeoThreshold_tool.cc
@@ -1,0 +1,276 @@
+///////////////////////////////////////////////////////////////////////
+/// File: FlashGeoThreshold_tool.cc
+///
+/// Base class: FlashGeoBase.hh
+///
+/// It computes the PMTs Threshold
+/// weighted by the reconstructed number of PE
+///
+////////////////////////////////////////////////////////////////////////
+
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
+#include "art/Utilities/ToolConfigTable.h"
+
+#include "FlashGeoBase.hh"
+
+#include "sbndcode/OpDetSim/sbndPDMapAlg.hh"
+
+#include <string>
+#include <map>
+
+namespace lightana{
+
+  class FlashGeoThreshold : FlashGeoBase
+  {
+
+  public:
+
+    //Configuration parameters
+     struct Config {
+
+       fhicl::Atom<float> Threshold {
+         fhicl::Name("Threshold"),
+         fhicl::Comment("Use channels abnove this thershold")
+       };
+
+       fhicl::Sequence<std::string> PDTypes {
+         fhicl::Name("PDTypes"),
+         fhicl::Comment("Only use PD types specified in this list")
+       };
+
+       fhicl::Atom<bool> NormalizeByPDType {
+         fhicl::Name("NormalizeByPDType"),
+         fhicl::Comment("Normalize number of PE in each ZY position by PD type")
+       };
+
+       fhicl::Atom<unsigned int> WeightExp {
+         fhicl::Name("WeightExp"),
+         fhicl::Comment("Weight exponent for YZ barycenters")
+       };  
+
+     };
+
+
+    // Default constructor
+    explicit FlashGeoThreshold(art::ToolConfigTable<Config> const& config);
+
+    // Method to calculate the OpFlash t0
+    void GetFlashLocation(std::vector<double> pePerOpChannel,
+                            double& Ycenter, double& Zcenter,
+                            double& Ywidth, double& Zwidth) override;
+
+  private:
+
+    void ResetVars();
+    void GetCenter(std::map<int, double> PEAcc, double& center, double& width);
+
+    // Fhicl configuration parameters
+    std::vector<std::string> fPDTypes;
+    float fThreshold;
+    bool fNormalizeByPDType;
+    unsigned int fWeightExp;
+
+    // Store #PE at each YZ position
+    std::map<int, double> fYPEAccumulator;
+    std::map<int, double> fZPEAccumulator;
+
+    // Store PD type ar each YZ position
+    std::map<int, std::string> fPDTypeByY;
+    std::map<int, std::string> fPDTypeByZ;
+
+    // Store normalization factor for each PD type
+    std::map<std::string, double> fNormFactorsY;
+    std::map<std::string, double> fNormFactorsZ;
+
+    // PDS mapping
+    opdet::sbndPDMapAlg fPDSMap;
+    
+    // Array to store PD xyz position
+    double fPDxyz[3];
+
+    static constexpr double fDefCenterValue = -999.;
+
+  };
+
+
+  FlashGeoThreshold::FlashGeoThreshold(art::ToolConfigTable<Config> const& config)
+    : fPDTypes{ config().PDTypes() }
+    , fThreshold{ config().Threshold() }
+    , fNormalizeByPDType{ config().NormalizeByPDType() }
+    , fWeightExp{ config().WeightExp() }
+  {
+
+    // Initialize YZ map
+    for(size_t opch=0; opch<::lightana::NOpDets(); opch++){
+      
+      if( std::find(fPDTypes.begin(), fPDTypes.end(), fPDSMap.pdType(opch)) == fPDTypes.end() ) continue;
+      
+      ::lightana::OpDetCenterFromOpChannel(opch, fPDxyz);
+      
+      fYPEAccumulator[ (int) fPDxyz[1] ] = 0;
+      fZPEAccumulator[ (int) fPDxyz[2] ] = 0;
+      
+      if(fNormalizeByPDType){
+        fPDTypeByY[ (int) fPDxyz[1] ] = fPDSMap.pdType(opch);
+        fPDTypeByZ[ (int) fPDxyz[2] ] = fPDSMap.pdType(opch);
+      }
+
+    }
+
+    // Initialize normalixation factors by PD type
+    if(fNormalizeByPDType){
+      for(auto & pd:fPDTypes) {
+        fNormFactorsY[pd]=0.;
+        fNormFactorsZ[pd]=0.;
+      }
+    }
+  
+  }
+
+
+  void FlashGeoThreshold::GetFlashLocation(std::vector<double> pePerOpChannel,
+                                            double& Ycenter, double& Zcenter,
+                                            double& Ywidth, double& Zwidth)
+  {
+
+    // Reset variables
+    ResetVars();
+    Ycenter = Zcenter = fDefCenterValue;
+    Ywidth  = Zwidth  = fDefCenterValue;
+    
+    // Fill PE accumulators
+    for (unsigned int opch = 0; opch < pePerOpChannel.size(); opch++) {
+      if( std::find(fPDTypes.begin(), fPDTypes.end(), fPDSMap.pdType(opch)) == fPDTypes.end() ) continue;
+      // Get physical detector location for this opChannel
+      ::lightana::OpDetCenterFromOpChannel(opch, fPDxyz);
+      fYPEAccumulator[(int) fPDxyz[1] ]+=pePerOpChannel[opch];
+      fZPEAccumulator[(int) fPDxyz[2] ]+=pePerOpChannel[opch];
+    }
+    
+    std::cout<<" YYY \n";
+    for(auto & y: fYPEAccumulator){
+      std::cout<<y.first<<":"<<y.second<<" ";
+    }
+    std::cout<<std::endl;
+
+    std::cout<<" ZZZ \n";
+    for(auto & z: fZPEAccumulator){
+      std::cout<<z.first<<":"<<z.second<<" ";
+    }
+    std::cout<<std::endl;
+
+    // Normalize PE accumulators
+    if(fNormalizeByPDType){
+      std::cout<<"Normalizing by PDType\n";
+
+      // Get normalization values for each PD type
+      for(auto & z: fZPEAccumulator){
+        if(z.second>fNormFactorsZ[ fPDTypeByZ[z.first] ]) 
+          fNormFactorsZ[ fPDTypeByZ[z.first] ] = z.second;
+      }
+
+      for(auto & y: fYPEAccumulator){
+        if(y.second>fNormFactorsY[ fPDTypeByY[y.first] ]) 
+          fNormFactorsY[ fPDTypeByY[y.first] ] = y.second;
+      }
+
+      std::cout<<" Norms are: \n";
+      for(auto & pd:fPDTypes){
+        std::cout<<"PDTypes: "<<pd<<" NormY: "<<fNormFactorsY[pd]<<" NormZ: "<<fNormFactorsZ[pd]<<std::endl;
+      }
+
+      for(auto & y: fYPEAccumulator)
+        fYPEAccumulator[y.first] = y.second/ fNormFactorsY[ fPDTypeByY[y.first] ]; 
+      
+      for(auto & z: fZPEAccumulator)
+        fZPEAccumulator[z.first] = z.second/ fNormFactorsZ[ fPDTypeByZ[z.first] ]; 
+
+    }
+    else{
+      std::cout<<"Not normalizing by PDType\n";
+
+      double normY = std::max_element(fYPEAccumulator.begin(), fYPEAccumulator.end(), 
+                      [](const std::pair<int, double> &pe1, const std::pair<int, double> &pe2) 
+                      {return pe1.second < pe2.second;})->second;
+      
+      double normZ =  std::max_element(fZPEAccumulator.begin(), fZPEAccumulator.end(), 
+                      [](const std::pair<int, double> &pe1, const std::pair<int, double> &pe2) 
+                      {return pe1.second < pe2.second;})->second;
+      
+        
+      std::cout<<" Norms are: Y=" <<normY<<" Z="<<normZ<<"\n";
+
+      for(auto & y: fYPEAccumulator) fYPEAccumulator[y.first] = y.second / normY; 
+      for(auto & z: fZPEAccumulator) fZPEAccumulator[z.first] = z.second / normZ;
+ 
+    }
+
+    std::cout<<" After norm...\n YYY \n";
+    for(auto & y: fYPEAccumulator){
+      std::cout<<y.first<<":"<<y.second<<" ";
+    }
+    std::cout<<std::endl;
+    std::cout<<" ZZZ \n";
+    for(auto & z: fZPEAccumulator){
+      std::cout<<z.first<<":"<<z.second<<" ";
+    }
+    std::cout<<std::endl;
+
+    // Get YZ position of selected channels (above threshold)
+    GetCenter(fYPEAccumulator, Ycenter, Ywidth);
+    GetCenter(fZPEAccumulator, Zcenter, Zwidth);
+
+  }
+
+  void FlashGeoThreshold::ResetVars(){
+    // Reset PE accumulators
+    for(auto & y: fYPEAccumulator) fYPEAccumulator[y.first]=0;
+    for(auto & z: fZPEAccumulator) fZPEAccumulator[z.first]=0;
+    // Reset normalization
+    for(auto & pd:fPDTypes) {
+      fNormFactorsY[pd]=0.;
+      fNormFactorsZ[pd]=0.;
+    }
+  }
+
+  void FlashGeoThreshold::GetCenter(std::map<int, double> PEAcc, double& center, double& width){
+
+    // set variables
+    center = 0.;
+    double weight;
+    double weightNormCenter = 0.;
+    double weightNormWidth = 0.;
+    double sum=0;
+    double sum2=0;
+
+    for(auto & pe: PEAcc){
+
+      // Get weight for this channel
+      if(fWeightExp==1) weight = pe.second;
+      else if(fWeightExp==2) weight = pe.second*pe.second;
+      else weight = std::pow(pe.second, fWeightExp);
+      
+      // For OpFlash width consider all channels
+      weightNormWidth+=weight;
+      sum+=weight*pe.first;
+      sum2+=weight*pe.first*pe.first;
+
+      // For OpFlash center consider only channels above ceertain threshold
+      if(pe.second>fThreshold){  
+        center+=weight*pe.first;
+        weightNormCenter+=weight;
+      }
+
+    }
+
+    center = center/weightNormCenter;
+    width = std::sqrt(sum2*weightNormWidth - sum*sum)/weightNormWidth;
+
+  }
+
+}
+
+DEFINE_ART_CLASS_TOOL(lightana::FlashGeoThreshold)

--- a/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
+++ b/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
@@ -184,6 +184,8 @@ namespace opdet{
                            0, 0, 1, // this are just default values
                            drift_distance, -1, Ycenter, Ywidth, Zcenter, Zwidth);
         opflashes->emplace_back(std::move(flash));
+
+        std::cout<<" FLASH GEO: Yc="<<Ycenter<<" Zc="<<Zcenter<<" Yw"<<Ywidth<<" Zw"<<Zwidth<<std::endl;
       }
       else{
         recob::OpFlash flash(flasht0, lflash.time_err, trigger_time + flasht0,

--- a/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
+++ b/sbndcode/OpDetReco/OpFlash/SBNDFlashFinder_module.cc
@@ -185,7 +185,6 @@ namespace opdet{
                            drift_distance, -1, Ycenter, Ywidth, Zcenter, Zwidth);
         opflashes->emplace_back(std::move(flash));
 
-        std::cout<<" FLASH GEO: Yc="<<Ycenter<<" Zc="<<Zcenter<<" Yw"<<Ywidth<<" Zw"<<Zwidth<<std::endl;
       }
       else{
         recob::OpFlash flash(flasht0, lflash.time_err, trigger_time + flasht0,

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashfinder.fcl
@@ -15,7 +15,7 @@ SBNDSimpleFlash:
   OpFlashProducer : "opflash"
   PECalib         : @local::NoCalib
   OpHitInputTime  : "PeakTime"
-  FlashGeoConfig  : @local::FlashGeoBarycenter
+  FlashGeoConfig  : @local::FlashGeoThreshold
   UseT0Tool       : false
   FlashT0Config   : @local::FlashT0SelectedChannels
   ReadoutDelay    : 0. //in us

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
@@ -6,4 +6,13 @@ FlashGeoBarycenter:
   WeightExp: 2
 }
 
+FlashGeoThreshold:
+{
+  tool_type: "FlashGeoThreshold"
+  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  Threshold: 0.8
+  NormalizeByPDType: true
+  WeightExp: 2
+}
+
 END_PROLOG

--- a/sbndcode/OpDetSim/CMakeLists.txt
+++ b/sbndcode/OpDetSim/CMakeLists.txt
@@ -79,7 +79,6 @@ install_headers()
 install_fhicl()
 install_source()
 cet_enable_asserts()
-add_subdirectory(FlashFinder)
 add_subdirectory(PMTAlg)
 
 # install sbnd_pds_mapping.json with mapping of the photon detectors

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
@@ -10,8 +10,9 @@ namespace opdet {
   DigiPMTSBNDAlg::DigiPMTSBNDAlg(ConfigurationParameters_t const& config)
     : fParams(config)
     , fSampling(fParams.frequency)
-    , fQEDirect(fParams.QEDirect / fParams.larProp->ScintPreScale())
-    , fQERefl(fParams.QERefl / fParams.larProp->ScintPreScale())
+    , fPMTCoatedVUVEff(fParams.PMTCoatedVUVEff / fParams.larProp->ScintPreScale())
+    , fPMTCoatedVISEff(fParams.PMTCoatedVISEff / fParams.larProp->ScintPreScale())
+    , fPMTUncoatedEff(fParams.PMTUncoatedEff/ fParams.larProp->ScintPreScale())
       //  , fSinglePEmodel(fParams.SinglePEmodel)
     , fEngine(fParams.engine)
     , fFlatGen(*fEngine)
@@ -21,13 +22,15 @@ namespace opdet {
   {
 
     mf::LogInfo("DigiPMTSBNDAlg") << "PMT corrected efficiencies = "
-                                  << fQEDirect << " " << fQERefl;
+                                  << fPMTCoatedVUVEff << " " << fPMTCoatedVISEff << " " << fPMTUncoatedEff <<"\n";
 
-    if(fQERefl > 1.0001 || fQEDirect > 1.0001)
+    if(fPMTCoatedVUVEff > 1.0001 || fPMTCoatedVISEff > 1.0001 || fPMTUncoatedEff > 1.0001)
       mf::LogWarning("DigiPMTSBNDAlg")
-        << "Quantum efficiency set in fhicl file " << fParams.QERefl
-        << " or " << fParams.QEDirect << " seems to be too large!\n"
-        << "Final QE must be equal or smaller than the scintillation "
+        << "Detection efficiencies set in fhicl file seem to be too large!\n"
+        << "PMTCoatedVUVEff: " << fParams.PMTCoatedVUVEff << "\n"
+        << "PMTCoatedVISEff: " << fParams.PMTCoatedVISEff << "\n"
+        << "PMTUncoatedEff: " << fParams.PMTUncoatedEff << "\n"
+        << "Final efficiency must be equal or smaller than the scintillation "
         << "pre scale applied at simulation time.\n"
         << "Please check this number (ScintPreScale): "
         << fParams.larProp->ScintPreScale();
@@ -76,7 +79,7 @@ namespace opdet {
   DigiPMTSBNDAlg::~DigiPMTSBNDAlg(){}
 
 
-  void DigiPMTSBNDAlg::ConstructWaveform(
+  void DigiPMTSBNDAlg::ConstructWaveformUncoatedPMT(
     int ch,
     sim::SimPhotons const& simphotons,
     std::vector<short unsigned int>& waveform,
@@ -85,9 +88,10 @@ namespace opdet {
     unsigned n_sample)
   {
     std::vector<double> waves(n_sample, fParams.PMTBaseline);
-    CreatePDWaveform(simphotons, start_time, waves, ch, pdtype);
+    CreatePDWaveformUncoatedPMT(simphotons, start_time, waves, ch, pdtype);
     waveform = std::vector<short unsigned int> (waves.begin(), waves.end());
   }
+
 
   void DigiPMTSBNDAlg::ConstructWaveformCoatedPMT(
     int ch,
@@ -103,7 +107,7 @@ namespace opdet {
   }
 
 
-  void DigiPMTSBNDAlg::ConstructWaveformLite(
+  void DigiPMTSBNDAlg::ConstructWaveformLiteUncoatedPMT(
     int ch,
     sim::SimPhotonsLite const& litesimphotons,
     std::vector<short unsigned int>& waveform,
@@ -112,7 +116,7 @@ namespace opdet {
     unsigned n_sample)
   {
     std::vector<double> waves(n_sample, fParams.PMTBaseline);
-    CreatePDWaveformLite(litesimphotons, start_time, waves, ch, pdtype);
+    CreatePDWaveformLiteUncoatedPMT(litesimphotons, start_time, waves, ch, pdtype);
     waveform = std::vector<short unsigned int> (waves.begin(), waves.end());
   }
 
@@ -131,7 +135,7 @@ namespace opdet {
   }
 
 
-  void DigiPMTSBNDAlg::CreatePDWaveform(
+  void DigiPMTSBNDAlg::CreatePDWaveformUncoatedPMT(
     sim::SimPhotons const& simphotons,
     double t_min,
     std::vector<double>& wave,
@@ -143,7 +147,7 @@ namespace opdet {
     size_t timeBin;
     double ttpb=0;
     for(size_t i = 0; i < simphotons.size(); i++) { //simphotons is here reflected light. To be added for all PMTs
-      if(fFlatGen.fire(1.0) < fQERefl) {
+      if(fFlatGen.fire(1.0) < fPMTUncoatedEff) {
         if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS);
         ttpb = fTimeTPB->fire(); //for including TPB emission time
         tphoton = ttsTime + simphotons[i].Time - t_min + ttpb + fParams.CableTime;
@@ -177,7 +181,7 @@ namespace opdet {
     if(auto it{ DirectPhotonsMap.find(ch) }; it != std::end(DirectPhotonsMap) )
     {auxphotons = it->second;}
     for(size_t j = 0; j < auxphotons.size(); j++) { //auxphotons is direct light
-      if(fFlatGen.fire(1.0) < fQEDirect) {
+      if(fFlatGen.fire(1.0) < fPMTCoatedVUVEff) {
         if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS); //implementing transit time spread
         ttpb = fTimeTPB->fire(); //for including TPB emission time
         tphoton = ttsTime + auxphotons[j].Time - t_min + ttpb + fParams.CableTime;
@@ -190,7 +194,7 @@ namespace opdet {
     if(auto it{ ReflectedPhotonsMap.find(ch) }; it != std::end(ReflectedPhotonsMap) )
     {auxphotons = it->second;}
     for(size_t j = 0; j < auxphotons.size(); j++) { //auxphotons is now reflected light
-      if(fFlatGen.fire(1.0) < fQERefl) {
+      if(fFlatGen.fire(1.0) < fPMTCoatedVISEff) {
         if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS); //implementing transit time spread
         ttpb = fTimeTPB->fire(); //for including TPB emission time
         tphoton = ttsTime + auxphotons[j].Time - t_min + ttpb + fParams.CableTime;
@@ -207,7 +211,7 @@ namespace opdet {
   }
 
 
-  void DigiPMTSBNDAlg::CreatePDWaveformLite(
+  void DigiPMTSBNDAlg::CreatePDWaveformLiteUncoatedPMT(
     sim::SimPhotonsLite const& litesimphotons,
     double t_min,
     std::vector<double>& wave,
@@ -225,7 +229,7 @@ namespace opdet {
     for (auto const& reflectedPhotons : photonMap) {
       // TODO: check that this new approach of not using the last
       // (1-accepted_photons) doesn't introduce some bias. ~icaza
-      mean_photons = reflectedPhotons.second*fQERefl;
+      mean_photons = reflectedPhotons.second*fPMTUncoatedEff;
       accepted_photons = fPoissonQGen.fire(mean_photons);
       for(size_t i = 0; i < accepted_photons; i++) {
         if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS);
@@ -261,7 +265,7 @@ namespace opdet {
       for (auto& directPhotons : (it->second).DetectedPhotons) {
         // TODO: check that this new approach of not using the last
         // (1-accepted_photons) doesn't introduce some bias. ~icaza
-        mean_photons = directPhotons.second*fQEDirect;
+        mean_photons = directPhotons.second*fPMTCoatedVUVEff;
         accepted_photons = fPoissonQGen.fire(mean_photons);
         for(size_t i = 0; i < accepted_photons; i++) {
           if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS); //implementing transit time spread
@@ -279,7 +283,7 @@ namespace opdet {
       for (auto& reflectedPhotons : (it->second).DetectedPhotons) {
         // TODO: check that this new approach of not using the last
         // (1-accepted_photons) doesn't introduce some bias. ~icaza
-        mean_photons = reflectedPhotons.second*fQERefl;
+        mean_photons = reflectedPhotons.second*fPMTCoatedVISEff;
         accepted_photons = fPoissonQGen.fire(mean_photons);
         for(size_t i = 0; i < accepted_photons; i++) {
           if(fParams.TTS > 0.0) ttsTime = Transittimespread(fParams.TTS); //implementing transit time spread
@@ -465,8 +469,9 @@ namespace opdet {
     fBaseConfig.PMTChargeToADC           = config.pmtchargeToADC();
     fBaseConfig.PMTBaseline              = config.pmtbaseline();
     fBaseConfig.PMTSaturation            = config.pmtsaturation();
-    fBaseConfig.QEDirect                 = config.qEDirect();
-    fBaseConfig.QERefl                   = config.qERefl();
+    fBaseConfig.PMTCoatedVUVEff          = config.pmtcoatedVUVEff();
+    fBaseConfig.PMTCoatedVISEff          = config.pmtcoatedVISEff();
+    fBaseConfig.PMTUncoatedEff           = config.pmtuncoatedEff();
     fBaseConfig.PMTSinglePEmodel         = config.PMTsinglePEmodel();
     fBaseConfig.PMTRiseTime              = config.pmtriseTime();
     fBaseConfig.PMTFallTime              = config.pmtfallTime();

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
@@ -69,9 +69,25 @@ namespace opdet {
 
     if(fParams.MakeGainFluctuations){
       fPMTGainFluctuationsPtr = art::make_tool<opdet::PMTGainFluctuations>(fParams.GainFluctuationsParams);
+      std::cout<<" Constru: Simulating gain fluctuations"<<std::endl;
     }
+    if(fParams.SimulateNonLinearity){
+      fPMTNonLinearityPtr = art::make_tool<opdet::PMTNonLinearity>(fParams.NonLinearityParams);
+      std::cout<<" Constru: Simulating non linearity"<<std::endl;
+    }  
 
-    saturation = fParams.PMTBaseline + fParams.PMTSaturation * fParams.PMTChargeToADC * fParams.PMTMeanAmplitude;
+    // infer pulse polarity from SER peak sign
+    double minADC_SinglePE = *min_element(fSinglePEWave.begin(), fSinglePEWave.end());
+    double maxADC_SinglePE = *max_element(fSinglePEWave.begin(), fSinglePEWave.end());
+    fPositivePolarity = std::abs(maxADC_SinglePE) > std::abs(minADC_SinglePE); 
+    std::cout<<"Pulse polarity.... Positive="<<fPositivePolarity<<" Min: "<<minADC_SinglePE<<" maxSER: "<<maxADC_SinglePE<<std::endl;
+
+    // get ADC saturation value
+    // currently assumes all dynamic range for PE (no overshoot)
+    fADCSaturation = (fPositivePolarity ? fParams.PMTBaseline + fParams.PMTADCDynamicRange : fParams.PMTBaseline - fParams.PMTADCDynamicRange);
+    std::cout<<" ADCSatValue: "<<fADCSaturation<<std::endl;
+
+
     file->Close();
   } // end constructor
 
@@ -224,6 +240,9 @@ namespace opdet {
     double tphoton;
     size_t timeBin;
     double ttpb=0;
+
+    std::vector<unsigned int> nPE(wave.size(), 0);
+
     // reflected light to be added to all PMTs
     std::map<int, int> const& photonMap = litesimphotons.DetectedPhotons;
     for (auto const& reflectedPhotons : photonMap) {
@@ -237,10 +256,22 @@ namespace opdet {
         tphoton = ttsTime + reflectedPhotons.first - t_min + ttpb + fParams.CableTime;
         if(tphoton < 0.) continue; // discard if it didn't made it to the acquisition
         timeBin = std::floor(tphoton*fSampling);
-        if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+        //if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+        if(timeBin < wave.size()) nPE[timeBin]++;
       }
     }
 
+    for(size_t k=0; k<nPE.size(); k++){
+      if(nPE[k] > 0) {
+        if(fParams.SimulateNonLinearity){
+          AddSPE(k, wave, fPMTNonLinearityPtr->NObservedPE(k, nPE) );
+        }
+        else{
+          AddSPE(k, wave, nPE[k]);
+        }
+      }
+    }
+    
     if(fParams.PMTBaselineRMS > 0.0) AddLineNoise(wave);
     if(fParams.PMTDarkNoiseRate > 0.0) AddDarkNoise(wave);
     CreateSaturation(wave);
@@ -254,12 +285,17 @@ namespace opdet {
     std::unordered_map<int, sim::SimPhotonsLite>& DirectPhotonsMap,
     std::unordered_map<int, sim::SimPhotonsLite>& ReflectedPhotonsMap)
   {
+
+    //DEBUG: std::cout<<"DEBUGGING OpDetSim  "<<fParams.PMTNonLinearityTF1<<std::endl;
     double mean_photons;
     size_t accepted_photons;
     double ttsTime = 0;
     double tphoton;
     size_t timeBin;
     double ttpb;
+
+    std::vector<unsigned int> nPE(wave.size(), 0);
+
     // direct light
     if ( auto it{ DirectPhotonsMap.find(ch) }; it != std::end(DirectPhotonsMap) ){
       for (auto& directPhotons : (it->second).DetectedPhotons) {
@@ -273,7 +309,8 @@ namespace opdet {
           tphoton = ttsTime + directPhotons.first - t_min + ttpb + fParams.CableTime;
           if(tphoton < 0.) continue; // discard if it didn't made it to the acquisition
           timeBin = std::floor(tphoton*fSampling);
-          if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+          //if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+          if(timeBin < wave.size()) nPE[timeBin]++;
         }
       }
     }
@@ -291,10 +328,25 @@ namespace opdet {
           tphoton = ttsTime + reflectedPhotons.first - t_min + ttpb + fParams.CableTime;
           if(tphoton < 0.) continue; // discard if it didn't made it to the acquisition
           timeBin = std::floor(tphoton*fSampling);
-          if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+          //if(timeBin < wave.size()) {AddSPE(timeBin, wave);}
+          if(timeBin < wave.size()) nPE[timeBin]++;
         }
       }
     }
+    int NPre=0; int NPost=0;
+    for(size_t k=0; k<nPE.size(); k++){
+      if(nPE[k] > 0) {
+        if(fParams.SimulateNonLinearity){
+          AddSPE(k, wave, fPMTNonLinearityPtr->NObservedPE(k, nPE) );
+          NPre=NPre+nPE[k]; NPost+=fPMTNonLinearityPtr->NObservedPE(k, nPE);
+        }
+        else{
+          AddSPE(k, wave, nPE[k]);
+        }
+      }
+    }
+
+    std::cout<<" NPre: "<<NPre<<" NPost: "<<NPost<<std::endl;
 
     //Adding noise and saturation
     if(fParams.PMTBaselineRMS > 0.0) AddLineNoise(wave);
@@ -328,29 +380,40 @@ namespace opdet {
   }
 
 
-  void DigiPMTSBNDAlg::AddSPE(size_t time_bin, std::vector<double>& wave)
-  {
+  void DigiPMTSBNDAlg::AddSPE(size_t time_bin, std::vector<double>& wave, double npe)
+  {    
     size_t max = time_bin + pulsesize < wave.size() ? time_bin + pulsesize : wave.size();
     auto min_it = std::next(wave.begin(), time_bin);
     auto max_it = std::next(wave.begin(), max);
-    if(fParams.MakeGainFluctuations){
-      double npe=fPMTGainFluctuationsPtr->GainFluctuation(1,fEngine);
-      std::transform(min_it, max_it,
+    double npe_anode = npe;
+    if(fParams.MakeGainFluctuations)
+      npe_anode=fPMTGainFluctuationsPtr->GainFluctuation(npe, fEngine);
+
+    //std::cout<<npe<<" "<<npe_anode<<std::endl;
+    /* std::transform(min_it, max_it,
                      fSinglePEWave.begin(), min_it,
-                     [npe](auto a, auto b) { return a+npe*b; });
+                     [npe_an](auto a, auto b) { return a+npe_an*b; });
     }
     else{
       std::transform(min_it, max_it,
                    fSinglePEWave.begin(), min_it,
                    std::plus<double>( ));
-    }
+    }*/
+
+    std::transform(min_it, max_it,
+                     fSinglePEWave.begin(), min_it,
+                     [npe_anode](auto a, auto b) { return a+npe_anode*b; });
   }
 
 
   void DigiPMTSBNDAlg::CreateSaturation(std::vector<double>& wave)
   {
-    std::replace_if(wave.begin(), wave.end(),
-                    [&](auto w){return w < saturation;}, saturation);
+    if(fPositivePolarity)
+      std::replace_if(wave.begin(), wave.end(),
+                      [&](auto w){return w > fADCSaturation;}, fADCSaturation);
+    else
+      std::replace_if(wave.begin(), wave.end(),
+                        [&](auto w){return w < fADCSaturation;}, fADCSaturation);
   }
 
 
@@ -468,7 +531,7 @@ namespace opdet {
     // settings
     fBaseConfig.PMTChargeToADC           = config.pmtchargeToADC();
     fBaseConfig.PMTBaseline              = config.pmtbaseline();
-    fBaseConfig.PMTSaturation            = config.pmtsaturation();
+    fBaseConfig.PMTADCDynamicRange       = config.pmtADCDynamicRange();
     fBaseConfig.PMTCoatedVUVEff          = config.pmtcoatedVUVEff();
     fBaseConfig.PMTCoatedVISEff          = config.pmtcoatedVISEff();
     fBaseConfig.PMTUncoatedEff           = config.pmtuncoatedEff();
@@ -482,8 +545,8 @@ namespace opdet {
     fBaseConfig.TTS                      = config.tts();
     fBaseConfig.CableTime                = config.cableTime();
     fBaseConfig.PMTDataFile              = config.pmtDataFile();
-    fBaseConfig.MakeGainFluctuations     = config.makeGainFluctuations();
-    config.gainFluctuationsParams.get_if_present(fBaseConfig.GainFluctuationsParams);
+    fBaseConfig.MakeGainFluctuations = config.gainFluctuationsParams.get_if_present(fBaseConfig.GainFluctuationsParams);
+    fBaseConfig.SimulateNonLinearity = config.nonLinearityParams.get_if_present(fBaseConfig.NonLinearityParams);
   }
 
   std::unique_ptr<DigiPMTSBNDAlg>

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -59,8 +59,9 @@ namespace opdet {
       double PMTBaselineRMS; //Pedestal RMS in ADC counts
       double PMTDarkNoiseRate; //in Hz
       double PMTSaturation; //in number of p.e.
-      double QEDirect; //PMT quantum efficiency for direct (VUV) light
-      double QERefl; //PMT quantum efficiency for reflected (TPB converted) light
+      double PMTCoatedVUVEff; //PMT (coated) efficiency for direct (VUV) light
+      double PMTCoatedVISEff; //PMT (coated) efficiency for reflected (VIS) light
+      double PMTUncoatedEff; //PMT (uncoated) efficiency
       std::string PMTDataFile; //File containing timing emission structure for TPB, and single PE profile from data
       bool PMTSinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
       bool MakeGainFluctuations; //Fluctuate PMT gain
@@ -76,7 +77,7 @@ namespace opdet {
     //Default destructor
     ~DigiPMTSBNDAlg();
 
-    void ConstructWaveform(
+    void ConstructWaveformUncoatedPMT(
       int ch,
       sim::SimPhotons const& simphotons,
       std::vector<short unsigned int>& waveform,
@@ -92,7 +93,7 @@ namespace opdet {
       double start_time,
       unsigned n_sample);
 
-    void ConstructWaveformLite(
+    void ConstructWaveformLiteUncoatedPMT(
       int ch,
       sim::SimPhotonsLite const& litesimphotons,
       std::vector<short unsigned int>& waveform,
@@ -118,8 +119,9 @@ namespace opdet {
     ConfigurationParameters_t fParams;
     // Declare member data here.
     double fSampling;       //wave sampling frequency (GHz)
-    double fQEDirect;
-    double fQERefl;
+    double fPMTCoatedVUVEff;
+    double fPMTCoatedVISEff;
+    double fPMTUncoatedEff;
     //int fSinglePEmodel;
     double sigma1;
     double sigma2;
@@ -146,7 +148,7 @@ namespace opdet {
     int pulsesize; //size of 1PE waveform
     std::unordered_map< raw::Channel_t, std::vector<double> > fFullWaveforms;
 
-    void CreatePDWaveform(
+    void CreatePDWaveformUncoatedPMT(
       sim::SimPhotons const& SimPhotons,
       double t_min,
       std::vector<double>& wave,
@@ -158,7 +160,7 @@ namespace opdet {
       std::vector<double>& wave,
       std::unordered_map<int, sim::SimPhotons>& DirectPhotonsMap,
       std::unordered_map<int, sim::SimPhotons>& ReflectedPhotonsMap);
-    void CreatePDWaveformLite(
+    void CreatePDWaveformLiteUncoatedPMT(
       sim::SimPhotonsLite const& litesimphotons,
       double t_min,
       std::vector<double>& wave,
@@ -247,14 +249,19 @@ namespace opdet {
         Comment("Saturation in number of p.e.")
       };
 
-      fhicl::Atom<double> qEDirect {
-        Name("QEDirect"),
-        Comment("PMT quantum efficiency for direct (VUV) light")
+      fhicl::Atom<double> pmtcoatedVUVEff {
+        Name("PMTCoatedVUVEff"),
+        Comment("PMT (coated) detection efficiency for direct (VUV) light")
       };
 
-      fhicl::Atom<double> qERefl {
-        Name("QERefl"),
-        Comment("PMT quantum efficiency for reflected (TPB emitted)light")
+      fhicl::Atom<double> pmtcoatedVISEff {
+        Name("PMTCoatedVISEff"),
+        Comment("PMT (coated) detection efficiency for reflected (VIS) light")
+      };
+
+      fhicl::Atom<double> pmtuncoatedEff {
+        Name("PMTUncoatedEff"),
+        Comment("PMT (uncoated) detection efficiency")
       };
 
       fhicl::Atom<bool> PMTsinglePEmodel {

--- a/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
+++ b/sbndcode/OpDetSim/PMTAlg/CMakeLists.txt
@@ -1,10 +1,18 @@
-set(
-   TOOL_LIBRARIES
-         nurandom::RandomUtils_NuRandomService_service
-         CLHEP::CLHEP
+cet_build_plugin(PMTGainFluctuations1Dynode art::tool 
+      SOURCE
+            PMTGainFluctuations1Dynode_tool.cc 
+      LIBRARIES 
+            nurandom::RandomUtils_NuRandomService_service
 )
 
-cet_build_plugin(PMTGainFluctuations1Dynode art::tool SOURCE PMTGainFluctuations1Dynode_tool.cc LIBRARIES ${TOOL_LIBRARIES})
+
+cet_build_plugin(PMTNonLinearityTF1 art::tool 
+      SOURCE
+            PMTNonLinearityTF1_tool.cc 
+      LIBRARIES
+            ROOT::Hist
+)
+
 
 install_headers()
 install_fhicl()

--- a/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTGainFluctuations1Dynode_tool.cc
@@ -8,7 +8,6 @@
 ////////////////////////////////////////////////////////////////////////
 
 #include "fhiclcpp/ParameterSet.h"
-#include "messagefacility/MessageLogger/MessageLogger.h"
 #include "art/Utilities/ToolMacros.h"
 #include "art/Utilities/make_tool.h"
 #include "art/Utilities/ToolConfigTable.h"

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearity.hh
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearity.hh
@@ -1,0 +1,26 @@
+///////////////////////////////////////////////////////////////////////
+///
+/// Interface class for PMTNonLinearity tool
+///
+////////////////////////////////////////////////////////////////////////
+
+#ifndef SBND_PMTNonLinearity_H
+#define SBND_PMTNonLinearity_H
+
+
+
+namespace opdet {
+  class PMTNonLinearity;
+}
+
+//Base class
+class opdet::PMTNonLinearity {
+public:
+  //Constructor
+  virtual ~PMTNonLinearity() noexcept = default;
+
+  //Returns rescaled number of PE
+  virtual double NObservedPE(size_t bin, std::vector<unsigned int> & pe_vector) = 0;
+};
+
+#endif

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -64,8 +64,6 @@ private:
   std::vector<double> fAttenuationFormParams;
   unsigned int fAttenuationPreTime;
   std::vector<unsigned int> fNonLinearRange;
-  unsigned int fPEStartSat;
-  unsigned int fPEMaxSat;
 
   //TF1 for non linearity function
   TF1 *fNonLinearTF1;

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -9,7 +9,6 @@
 
 #include "fhiclcpp/ParameterSet.h"
 #include "art/Utilities/ToolMacros.h"
-#include "art/Utilities/make_tool.h"
 #include "art/Utilities/ToolConfigTable.h"
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -99,12 +99,13 @@ opdet::PMTNonLinearityTF1::PMTNonLinearityTF1(art::ToolConfigTable<Config> const
   for(size_t pe=fNonLinearRange[0]; pe<fNonLinearRange[1]; pe++){
     fPEAttenuation_V[pe] = fNonLinearTF1->Eval(pe)/pe;
   }
-  fPESaturationValue = fPEAttenuation_V[fNonLinearRange[1]-1];
+  fPESaturationValue = fNonLinearTF1->Eval(fNonLinearRange[1]);
 
   std::cout<<" fAttFunc:  ";
   for(size_t pe=0; pe<fNonLinearRange[1]; pe++){
     std::cout<<pe<<":"<<pe*fPEAttenuation_V[pe]<<":"<<fPEAttenuation_V[pe]<<"  ";
   }
+  std::cout<<" PESatValue: "<<fPESaturationValue<<std::endl;
 
 }
 

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -1,0 +1,139 @@
+////////////////////////////////////////////////////////////////////////
+// Specific class tool for PMTGainFluctuations
+// File: PMTGainFluctuations1Dynode_tool.hh
+// Base class:        PMTGainFluctuations.hh
+// Algorithm based on function
+// 'multiplicationStageGain(unsigned int i /* = 1 */) const'
+// in icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+////////////////////////////////////////////////////////////////////////
+
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Utilities/ToolMacros.h"
+#include "art/Utilities/make_tool.h"
+#include "art/Utilities/ToolConfigTable.h"
+#include "fhiclcpp/types/Atom.h"
+#include "fhiclcpp/types/Sequence.h"
+
+#include <vector>
+#include <numeric>
+#include <string>
+#include "TF1.h"
+
+#include "sbndcode/OpDetSim/PMTAlg/PMTNonLinearity.hh"
+
+
+namespace opdet {
+  class PMTNonLinearityTF1;
+}
+
+
+class opdet::PMTNonLinearityTF1 : opdet::PMTNonLinearity {
+public:
+
+  //Configuration parameters
+  struct Config {
+    using Name = fhicl::Name;
+    using Comment = fhicl::Comment;
+
+    fhicl::Atom<std::string> attenuationForm {
+      Name("AttenuationForm"),
+      Comment("Non linearity functional form")
+    };
+
+    fhicl::Sequence<double> attenuationFormParams {
+      Name("AttenuationFormParams"),
+      Comment("Parameters for non linearity functional form")
+    };
+
+    fhicl::Atom<unsigned int> attenuationPreTime {
+      Name("AttenuationPreTime"),
+      Comment("Pre bins to conisder")
+    };
+
+    fhicl::Sequence<unsigned int> nonLinearRange {
+      Name("NonLinearRange"),
+      Comment("Non linear range. Assume linear response/completely saturated response out of this range")
+    };
+
+  };
+
+  explicit PMTNonLinearityTF1(art::ToolConfigTable<Config> const& config);
+
+  //Returns rescaled #pe after non linearity
+  double NObservedPE(size_t bin, std::vector<unsigned int> & pe_vector) override;
+
+private:
+  //Configuration parameters
+  std::string fAttenuationForm;
+  std::vector<double> fAttenuationFormParams;
+  unsigned int fAttenuationPreTime;
+  std::vector<unsigned int> fNonLinearRange;
+  unsigned int fPEStartSat;
+  unsigned int fPEMaxSat;
+
+  //TF1 for non linearity function
+  TF1 *fNonLinearTF1;
+
+  // Vector to store non linearity attenuation values
+  std::vector<double> fPEAttenuation_V;
+  int fPESaturationValue;
+};
+
+
+opdet::PMTNonLinearityTF1::PMTNonLinearityTF1(art::ToolConfigTable<Config> const& config)
+  : fAttenuationForm { config().attenuationForm() }
+  , fAttenuationFormParams { config().attenuationFormParams() }
+  , fAttenuationPreTime { config().attenuationPreTime() }
+  , fNonLinearRange { config().nonLinearRange() }
+{
+  fNonLinearTF1 = new TF1("NonLinearTF1", fAttenuationForm.c_str());
+  std::cout<<" Non Linearity Parameteres: \n";
+  std::cout<<fAttenuationForm<<"  PreTime"<<fAttenuationPreTime<<" PESat: "<<fNonLinearRange[1]<<"\n";
+  for(size_t k=0; k<fAttenuationFormParams.size(); k++){
+    fNonLinearTF1->SetParameter(k, fAttenuationFormParams[k]);
+    std::cout<<" Par "<<k<<" "<<fAttenuationFormParams[k]<<std::endl;
+  }
+
+  // Initialize attenuation vector
+  fPEAttenuation_V.resize(fNonLinearRange[1], 1);
+  for(size_t pe=fNonLinearRange[0]; pe<fNonLinearRange[1]; pe++){
+    fPEAttenuation_V[pe] = fNonLinearTF1->Eval(pe)/pe;
+  }
+  fPESaturationValue = fPEAttenuation_V[fNonLinearRange[1]-1];
+
+  std::cout<<" fAttFunc:  ";
+  for(size_t pe=0; pe<fNonLinearRange[1]; pe++){
+    std::cout<<pe<<":"<<pe*fPEAttenuation_V[pe]<<":"<<fPEAttenuation_V[pe]<<"  ";
+  }
+
+}
+
+double opdet::PMTNonLinearityTF1::NObservedPE(size_t bin, std::vector<unsigned int> & pe_vector){
+  
+  /*std::vector<unsigned int>::iterator it1 = pe_vector.begin();
+  std::vector<unsigned int>::iterator it2 = std::next(pe_vector.begin(), -1);
+  std::cout<<" ITER: "<<std::distance(pe_vector.begin(), it1)<<" "<<std::distance(pe_vector.begin(), it2)<<std::endl;
+  */
+
+  // get first bin
+  size_t start_bin = bin-fAttenuationPreTime;
+  
+  if(fAttenuationPreTime<0) start_bin=0;
+  unsigned int npe_acc = std::accumulate(pe_vector.begin()+start_bin,pe_vector.begin()+bin+1, 0);
+  
+  /*std::cout<<" In bin: "<<bin<<std::endl;
+  for(size_t k=start_bin; k<=bin; k++){
+    std::cout<<"  "<<k<<" "<<pe_vector[k];
+  }
+  std::cout<< "    Acc"<<npe_acc<<"  Rescales: "<<pe_vector[bin]*fPEAttenuation_V[npe_acc]<<std::endl;*/
+
+  //std::cout<< "   Bin="<<bin<<" Acc"<<npe_acc<<"  Rescales: "<<pe_vector[bin]*fPEAttenuation_V[npe_acc]<<std::endl;
+  
+  if(pe_vector[bin]>100) std::cout<<"  High En: "<<pe_vector[bin]<<" Acc="<<npe_acc<<" "<<pe_vector[bin]*fPEAttenuation_V[npe_acc]<<std::endl;
+
+  if(npe_acc<fNonLinearRange[1]) return pe_vector[bin]*fPEAttenuation_V[npe_acc];
+  else return fPESaturationValue;
+}
+
+
+DEFINE_ART_CLASS_TOOL(opdet::PMTNonLinearityTF1)

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -107,8 +107,6 @@ double opdet::PMTNonLinearityTF1::NObservedPE(size_t bin, std::vector<unsigned i
   
   if(fAttenuationPreTime<0) start_bin=0;
   unsigned int npe_acc = std::accumulate(pe_vector.begin()+start_bin,pe_vector.begin()+bin+1, 0);
-  
-  if(pe_vector[bin]>100) std::cout<<"  High En: "<<pe_vector[bin]<<" Acc="<<npe_acc<<" "<<pe_vector[bin]*fPEAttenuation_V[npe_acc]<<std::endl;
 
   if(npe_acc<fNonLinearRange[1]) return pe_vector[bin]*fPEAttenuation_V[npe_acc];
   else return fPESaturationValue;

--- a/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
+++ b/sbndcode/OpDetSim/PMTAlg/PMTNonLinearityTF1_tool.cc
@@ -1,10 +1,7 @@
 ////////////////////////////////////////////////////////////////////////
-// Specific class tool for PMTGainFluctuations
-// File: PMTGainFluctuations1Dynode_tool.hh
-// Base class:        PMTGainFluctuations.hh
-// Algorithm based on function
-// 'multiplicationStageGain(unsigned int i /* = 1 */) const'
-// in icaruscode/PMT/Algorithms/PMTsimulationAlg.cxx
+// Specific class tool for PMTNonLinearity
+// File: PMTNonLinearityTF1_tool.hh
+// Base class:        PMTNonLinearity.hh
 ////////////////////////////////////////////////////////////////////////
 
 #include "fhiclcpp/ParameterSet.h"

--- a/sbndcode/OpDetSim/PMTAlg/pmtnonlinearity_config.fcl
+++ b/sbndcode/OpDetSim/PMTAlg/pmtnonlinearity_config.fcl
@@ -1,0 +1,15 @@
+BEGIN_PROLOG
+
+PMTNonLinearityTF1:
+{
+  tool_type: "PMTNonLinearityTF1"
+
+  #AttenuationForm:    "sqrt( (sqrt(1+8*(x/[0])**[1])-1)/( 4*(x/[0])**[1] ) )"
+  #AttenuationFormParams: [78.15, 1.96]
+  AttenuationForm:    "x/sqrt(1+(x/[0])**[1])"
+  AttenuationFormParams: [269, 1.84]
+  AttenuationPreTime: 1 
+  NonLinearRange: [75, 701]
+}
+
+END_PROLOG

--- a/sbndcode/OpDetSim/PMTAlg/pmtnonlinearity_config.fcl
+++ b/sbndcode/OpDetSim/PMTAlg/pmtnonlinearity_config.fcl
@@ -8,8 +8,8 @@ PMTNonLinearityTF1:
   #AttenuationFormParams: [78.15, 1.96]
   AttenuationForm:    "x/sqrt(1+(x/[0])**[1])"
   AttenuationFormParams: [269, 1.84]
-  AttenuationPreTime: 1 
-  NonLinearRange: [75, 701]
+  AttenuationPreTime: 4 #ns
+  NonLinearRange: [100, 701]
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -1,41 +1,46 @@
 #include "detsimmodules.fcl"
 #include "pmtgainfluctuations_config.fcl"
+#include "pmtnonlinearity_config.fcl"
 
 BEGIN_PROLOG
 
 sbnd_digipmt_alg:
 {
+  # Parameters for ideal SER simulation
   PMTRiseTime:           3.8        #ns
   PMTFallTime:           13.7       #ns
   PMTMeanAmplitude:      0.9        #in pC
-  PMTBaselineRMS:        1.0        #in ADC
-  PMTDarkNoiseRate:      1000.0     #in Hz
   TransitTime:           55.1       #ns
+  PMTChargeToADC:        -25.97     #charge to adc factor
+
+  # Parameters for test bench SER simulation
+  PMTSinglePEmodel:        true     #false for ideal PMT response, true for test bench measured response
+  PMTDataFile:             "OpDetSim/digi_pmt_sbnd_v2int0.root"  # located in sbnd_data
+  
+  # Time delays
   TTS:                   2.4        #Transit Time Spread in ns
   CableTime:             135        #time delay of the 30 m long readout cable in ns
-  PMTChargeToADC:        -25.97   #charge to adc factor
-  PMTSaturation:         300        #in number of p.e. to see saturation effects in the signal
+
+  # Digitizer simulation
+  PMTADCDynamicRange:    16384      #in ADC values
   PMTBaseline:           8000.0     #in ADC
-  PMTCoatedVUVEff:       0.12      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff:       0.13      #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff:        0.19      #PMT uncoated detection efficiency
-  PMTSinglePEmodel:        true   # false for ideal PMT response, true for test bench measured response
-  PMTDataFile:             "OpDetSim/digi_pmt_sbnd_v2int0.root"  # located in sbnd_data
-  MakeGainFluctuations: true
+  PMTBaselineRMS:        1.0        #in ADC
+  
+  # Dark counts
+  PMTDarkNoiseRate:      1000.0     #in Hz
+  
+  # Detection efficiencies
+  PMTCoatedVUVEff:       0.12       #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff:       0.13       #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff:        0.19       #PMT uncoated detection efficiency
+
+  # Simulate gain fluctuations
+  # (comment-out to skip gain fluctuations simulation)
   GainFluctuationsParams: @local::FirstDynodeGainFluctuations
-
-
-  ##This is the readout window size for each "trigger" on the electronics
-  # ReadoutWindowSize:         2000    #ticks (if 2ns each --> 4us)
-  # PreTrigFraction:           0.25    # fraction of readout window size that should come before the "trigger" on the electronics
-  ##NOTE this is assumed to be positive-going and ABOVE BASELINE! Pulse polarity is corrected before determining trigger.
-  # ThresholdADC:              10      #Threshold for self-triggered readout (ADC counts)
-  # PulsePolarity:             -1      #Pulse polarity (1 = positive, -1 = negative)
-  # TriggerOffsetPMT:          -1150   #Time (us) relative to trigger that readout begins
-  # ReadoutEnablePeriod:       3450    #Time (us) for which pmt readout is enabled
-  # CreateBeamGateTriggers:    true    #Option to create unbiased readout around beam spill
-  # BeamGateTriggerRepPeriod:  2.0     #Repetition Period (us) for BeamGateTriggers
-  # BeamGateTriggerNReps:      10      #Number of beamgate trigger reps to produce
+  
+  # Simulate PMT non linear response
+  # (comment-out to skip non linearities simulation)
+  NonLinearityParams: @local::PMTNonLinearityTF1
 
 }
 

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -16,6 +16,15 @@ sbnd_digipmt_alg:
   PMTChargeToADC:        -25.97   #charge to adc factor
   PMTSaturation:         300        #in number of p.e. to see saturation effects in the signal
   PMTBaseline:           8000.0     #in ADC
+  PMTCoatedVUVEff:       0.12      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff:       0.13      #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff:        0.19      #PMT uncoated detection efficiency
+  PMTSinglePEmodel:        true   # false for ideal PMT response, true for test bench measured response
+  PMTDataFile:             "OpDetSim/digi_pmt_sbnd_v2int0.root"  # located in sbnd_data
+  MakeGainFluctuations: true
+  GainFluctuationsParams: @local::FirstDynodeGainFluctuations
+
+
   ##This is the readout window size for each "trigger" on the electronics
   # ReadoutWindowSize:         2000    #ticks (if 2ns each --> 4us)
   # PreTrigFraction:           0.25    # fraction of readout window size that should come before the "trigger" on the electronics
@@ -28,13 +37,6 @@ sbnd_digipmt_alg:
   # BeamGateTriggerRepPeriod:  2.0     #Repetition Period (us) for BeamGateTriggers
   # BeamGateTriggerNReps:      10      #Number of beamgate trigger reps to produce
 
-  QEDirect:                  0.03    #PMT quantum efficiency for direct (VUV) light
-  QERefl:                    0.03    #PMT quantum efficiency for reflected (TPB converted) light
-  PMTSinglePEmodel:        true   # false for ideal PMT response, true for test bench measured response
-  PMTDataFile:             "OpDetSim/digi_pmt_sbnd_v2int0.root"  # located in sbnd_data
-
-  MakeGainFluctuations: true
-  GainFluctuationsParams: @local::FirstDynodeGainFluctuations
 }
 
 END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -23,9 +23,9 @@ sbnd_digipmt_alg:
   CableTime:             135        #time delay of the 30 m long readout cable in ns
 
   # Digitizer simulation
-  PMTADCDynamicRange:    16384      #in ADC values
-  PMTBaseline:           8000.0     #in ADC
-  PMTBaselineRMS:        1.0        #in ADC
+  PMTADCDynamicRange:    15564      #in ADC values
+  PMTBaseline:           15564      #in ADC
+  PMTBaselineRMS:        2.6        #in ADC
   
   # Dark counts
   PMTDarkNoiseRate:      1000.0     #in Hz

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -23,8 +23,8 @@ sbnd_digipmt_alg:
   CableTime:             135        #time delay of the 30 m long readout cable in ns
 
   # Digitizer simulation
-  PMTADCDynamicRange:    15564      #in ADC values
-  PMTBaseline:           15564      #in ADC
+  PMTADCDynamicRange:    14745      #in ADC values
+  PMTBaseline:           14745      #in ADC
   PMTBaselineRMS:        2.6        #in ADC
   
   # Dark counts

--- a/sbndcode/OpDetSim/opDetDigitizerWorker.cc
+++ b/sbndcode/OpDetSim/opDetDigitizerWorker.cc
@@ -205,7 +205,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
           coatedpmts_todigitize.insert(ch);
         }
         else if( (Reflected) && (pdtype == "pmt_uncoated") ) { //Uncoated PMT channels
-          pmtDigitizer->ConstructWaveformLite(ch,
+          pmtDigitizer->ConstructWaveformLiteUncoatedPMT(ch,
                                               litesimphotons,
                                               waveform,
                                               pdtype,
@@ -323,7 +323,7 @@ void opdet::opDetDigitizerWorker::MakeWaveforms(opdet::DigiPMTSBNDAlg *pmtDigiti
         }
         // uncoated PMTs
         else if(Reflected && pdtype == "pmt_uncoated") {
-          pmtDigitizer->ConstructWaveform(ch,
+          pmtDigitizer->ConstructWaveformUncoatedPMT(ch,
                                           simphotons,
                                           waveform,
                                           pdtype,

--- a/sbndcode/OpDetSim/optriggeralg_sbnd.fcl
+++ b/sbndcode/OpDetSim/optriggeralg_sbnd.fcl
@@ -4,7 +4,7 @@ sbnd_optrigger_alg:
 {
   PulsePolarityPMT: -1
   PulsePolarityArapuca: 1
-  TriggerThresholdADCPMT: 9
+  TriggerThresholdADCPMT: 20
   TriggerThresholdADCArapuca: 17
   BeamTriggerEnable: true
   BeamTriggerTime: 0.

--- a/sbndcode/OpDetSim/sbndPDMapAlg.hh
+++ b/sbndcode/OpDetSim/sbndPDMapAlg.hh
@@ -60,6 +60,8 @@ namespace opdet {
     bool isPDType(size_t ch, std::string pdname) const override;
     bool isElectronics(size_t ch, std::string pdname) const;
     std::string pdType(size_t ch) const override;
+    int pdBox(size_t ch) const;
+    int pdTPC(size_t ch) const;
     std::string electronicsType(size_t ch) const;
     std::vector<int> getChannelsOfType(std::string pdname) const;
     std::vector<int> getChannelsOfType(std::string pdname,std::string elname) const;//overload

--- a/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
+++ b/sbndcode/OpDetSim/sbndPDMapAlg_tool.cc
@@ -44,6 +44,17 @@ namespace opdet {
     return PDmap.at(ch)["electronics"]; 
   }
 
+  int sbndPDMapAlg::pdBox(size_t ch) const
+  {
+    return PDmap.at(ch)["pds_box"];
+  }
+
+
+  int sbndPDMapAlg::pdTPC(size_t ch) const
+  {
+    return PDmap.at(ch)["tpc"];
+  }
+
   std::vector<int> sbndPDMapAlg::getChannelsOfType(std::string pdname) const
   {
     std::vector<int> out_ch_v;


### PR DESCRIPTION
This PR includes various updates to the PDS simulation & reconstruction chain. A summary list is provided below. More details and validation plots can be found in [docdb-30445](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=30445).

- G4 stage: the ScintillationPreScale parameter is updated to 19%. This is done in order to match the new higher PMT detection efficiency.
- DetSim stage:
    - Updated PMT detection efficiencies: the PMT simulation now includes 3 detection efficiencies: two for the coated PMTs (VUV and VIS) and one for the uncoated PMTs.
    - Updated pedestal simulation: the baseline RMS has been updated from 1 to 2.6 ADC (according to the studies performed in [docdb-30879](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=30879)). The pedestal is now set to 15564 ADC. It assumes 95% signal-5% overshoot for the 14 bits CAEN V1730 digitizers.
    - Updates to the PMT saturation: we now simulate two saturation effects:
        - Saturation due to the digitizer dynamic range: truncates every waveform below 0 ADCs.
        - Includes PMT non linear effects by effectively re-scaling the #PE in each time bin.
- Reco1 stage:
    - Adds new method to estimate the OpFlash ZY barycenter
    - Updates how the PMTRatio metric (used to infer the OpFlash drift position) is calculated
    - Switch to a gauss filter for the PMT deconvolution
