### PR TITLE
Update beam flux from config J to K

### DIFF
--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -191,7 +191,7 @@ sbnd_flux_bnb_nu_Jv1_test1: {
 
 
 #
-# Booster Neutrino Beam, neutrino mode, configuration J (v1)
+# Booster Neutrino Beam, neutrino mode, configuration K (v1)
 #
 sbnd_flux_bnb_nu_Kv1: {
   FluxType:       "simple_flux"
@@ -201,7 +201,7 @@ sbnd_flux_bnb_nu_Kv1: {
 }
 
 sbnd_flux_bnb_nu_Kv1_test1: {
-  @table::sbnd_flux_bnb_nu_Jv1
+  @table::sbnd_flux_bnb_nu_Kv1
   FluxFiles: [ "gsimple_april07_baseline_0732_redecay_wkaonwgh.root" ]
 }
 

--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -190,12 +190,28 @@ sbnd_flux_bnb_nu_Jv1_test1: {
 }
 
 
+#
+# Booster Neutrino Beam, neutrino mode, configuration J (v1)
+#
+sbnd_flux_bnb_nu_Kv1: {
+  FluxType:       "simple_flux"
+  FluxCopyMethod: "DIRECT"
+  FluxSearchPaths: "/cvmfs/sbnd.osgstorage.org/pnfs/fnal.gov/usr/sbnd/persistent/stash/fluxFiles/bnb/BooNEtoGSimple/configK-v1/july2023/neutrinoMode"
+  FluxFiles: [ "gsimple_april07_baseline_*_redecay_wkaonwgh.root" ]
+}
+
+sbnd_flux_bnb_nu_Kv1_test1: {
+  @table::sbnd_flux_bnb_nu_Jv1
+  FluxFiles: [ "gsimple_april07_baseline_0732_redecay_wkaonwgh.root" ]
+}
+
+
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 #
 # Booster Neutrino Beam, neutrino mode, "default" configuration
 #
-sbnd_flux_bnb_nu: @local::sbnd_flux_bnb_nu_Jv1
-sbnd_flux_bnb_nu_test1: @local::sbnd_flux_bnb_nu_Jv1_test1
+sbnd_flux_bnb_nu: @local::sbnd_flux_bnb_nu_Kv1
+sbnd_flux_bnb_nu_test1: @local::sbnd_flux_bnb_nu_Kv1_test1
 
 #
 # Booster Neutrino Beam, interaction from dirt


### PR DESCRIPTION
Update from flux config J-v1 to config K-v1 
What’s new: 
New flux production on gpvm
Kaon weight is applied with a stand alone code and does not have MiniBooNE dependency 

Validation can be found on docdc: [32091](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32091)
