### PR TITLE
Updated electronics for "Daphne" flavored XARAPUCAs 

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/opdeconvolution_alg.fcl
@@ -32,8 +32,8 @@ OpDeconvolutionAlg:
   UseParamFilter: false
   #Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))"
   FilterParams: [0.1, 20]
-  Electronics: "CAEN" # 2 Optical readouts in sbnd: "CAEN" for PMT and Apsaia XArapucas (500MHz/2 ns), "Daphne" for XArapucas with 80MHz/12.5 ns
-  DaphneFreq:  80 # in MHz
+  Electronics: "CAEN" # 2 Optical readouts in sbnd: "CAEN" for PMT and Apsaia XArapucas (500MHz/2 ns), "Daphne" for XArapucas with 62.5MHz/16 ns
+  DaphneFreq:  62.5 # in MHz
 }
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -344,7 +344,7 @@ namespace opdet {
       // std::cout<<"@rodrigoa debug: Electronics="<<fElectronics<<std::endl;
 
       if (fElectronics=="Daphne"){
-        //take only daphne xarapuca channels (80 Mhz) for now ~rodrigoa
+        //take only daphne xarapuca channels (62.5 Mhz) for now ~rodrigoa
         ch_v = _pds_map.getChannelsOfType(name, "daphne");
       }else{
         ch_v = _pds_map.getChannelsOfType(name);

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -11,7 +11,7 @@ sbnd_ophit_finder:
   ChannelMasks:   []                  # Will ignore channels in this list
   PD:             ["pmt_coated", "pmt_uncoated"]  # Will only use PDS in this list
   Electronics:    "CAEN" #Will only use PDS with CAEN/Daphne readouts (500/80MHz sampling frec)
-  DaphneFreq:     80    # Frequency of Daphne(XArapucas) readouts (in MHz)
+  DaphneFreq:     62.5  # Frequency of Daphne(XArapucas) readouts (in MHz)
   HitThreshold:   0.2   # PE
   AreaToPE:       true  # Use area to calculate number of PEs
   SPEArea:        66.33 # If AreaToPE is true, this number is

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -10,7 +10,7 @@ sbnd_ophit_finder:
   InputLabels:    [""]
   ChannelMasks:   []                  # Will ignore channels in this list
   PD:             ["pmt_coated", "pmt_uncoated"]  # Will only use PDS in this list
-  Electronics:    "CAEN" #Will only use PDS with CAEN/Daphne readouts (500/80MHz sampling frec)
+  Electronics:    "CAEN" #Will only use PDS with CAEN/Daphne readouts (500/62.5MHz sampling frec)
   DaphneFreq:     62.5  # Frequency of Daphne(XArapucas) readouts (in MHz)
   HitThreshold:   0.2   # PE
   AreaToPE:       true  # Use area to calculate number of PEs

--- a/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_arapuca_sbnd.fcl
@@ -27,7 +27,7 @@ sbnd_digiarapuca_alg:
   DecayTXArapucaVIS:         8.5     # decay time of EJ280 in ns
   ArapucaDataFile:           "OpDetSim/digi_arapuca_sbnd.root" # located in sbnd_data
   ArapucaSinglePEmodel:      true    # false for ideal response true for response from XTDBoard cold tests
-  DaphneFrequency:           80.0    #in MHz. Frequency of the Daphne Readouts
+  DaphneFrequency:           62.5    #in MHz. Frequency of the Daphne Readouts
   MakeAmpFluctuations:       true
   AmpFluctuation:            0.099   #STD of the first PE Gaussian
   HDOpticalWaveformParamsXARAPUCA: @local::IncludeHDOpticalWaveforms_XARAPUCA

--- a/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
+++ b/sbndcode/OpDetSim/opDetSBNDTriggerAlg.cc
@@ -4,7 +4,7 @@
 namespace {
   double optical_period(detinfo::DetectorClocksData const& clockData,bool is_daphne)
   {
-    if (is_daphne) return clockData.OpticalClock().TickPeriod()*500/80; //500MHz Apsaia, 80MHz Daphne. TODO load frequency values from fcl ~rodrigoa
+    if (is_daphne) return clockData.OpticalClock().TickPeriod()*500/62.5; //500MHz Apsaia, 62.5MHz Daphne. TODO load frequency values from fcl ~rodrigoa
     return clockData.OpticalClock().TickPeriod();
   }
 

--- a/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
+++ b/sbndcode/OpDetSim/ophitfinder_sbnd.fcl
@@ -16,7 +16,7 @@ sbnd_hit_finder:
   PulsePolarityPMT:     -1         # use -1 for inverse polarity
   PulsePolarityArapuca:  1         # use -1 for inverse polarity
   UseDenoising:          true      # denoising algorithm to use with arapucas
-  DaphneFrequency:       80.0      # in MHz. Frequency of the Daphne Readouts
+  DaphneFrequency:       62.5      # in MHz. Frequency of the Daphne Readouts
 
 }
 

--- a/sbndcode/OpDetSim/wvfana_sbnd.fcl
+++ b/sbndcode/OpDetSim/wvfana_sbnd.fcl
@@ -10,7 +10,7 @@ wvf_ana_sbnd:
   ClusterModuleLabel: "linecluster"
   OpDetsToPlot: ["pmt_coated", "pmt_uncoated",
                  "xarapuca_vuv", "xarapuca_vis"]
-  DaphneFrequency: 80.0  #in MHz. Frequency of the Daphne Readouts
+  DaphneFrequency: 62.5  #in MHz. Frequency of the Daphne Readouts
 
 }
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -255,7 +255,7 @@ wpdir   product_dir     wire-cell-cfg
 product		version		qual	flags		<table_format=2>
 sbncode		v09_75_02	-
 cetmodules	v3_20_00	-	only_for_build
-sbnd_data	v01_20_00	-	optional
+sbnd_data	v01_21_00	-	optional
 sbndutil	v09_75_02	-	optional
 end_product_list
 ####################################


### PR DESCRIPTION
Updates to detsim and reco1 stages to take into account the new sampling frequency of the latest choice for this subsystem readout, the CAEN v1740 model: [https://www.caen.it/products/v1740/](https://www.caen.it/products/v1740/).

The SER has also been resampled to the latest 16ns binning, from the previous expected from Daphne electronics 80MHz/12.5ns.

