### PR TITLE
Don't drop SimEnergyDeposit in standard G4 fhicl

### DIFF
--- a/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_g4_sbnd.fcl
@@ -127,7 +127,7 @@ outputs:
                     # Drop the SimEnergyDeposits made by LArG4
                     , "drop sim::SimEnergyDeposits_largeant_*_*"
                     # Drop the IonAndScint w/ SCE offsets applied
-                    , "drop *_ionandscint_*_*"
+                    , "drop *_ionandscint__*"
                     # Drop LArG4 AuxDetHits, now replaced by AuxDetSimChannels
                     , "drop sim::AuxDetHits_*_*_*"
                     ]


### PR DESCRIPTION
Our current standard G4 fhicl drops ALL the SimEnergyDeposit data products. With this pull request, I propose to keep the SimEnergyDeposit (prior to SCE) in the output. The decision to either exclude or include this data product has been previously discussed in:
- https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=25656&filename=sbn_prod_mar31_2022.pdf&version=1
- https://sbn-docdb.fnal.gov/cgi-bin/sso/RetrieveFile?docid=23838&filename=sbn_ai_meeting_211102.pdf&version=1

I understand that these objects are excluded by default to reduce the size of the artroot file, particularly for large MC productions. However, the SimEnergyDeposit can be valuable for developers. In my specific use case, it contains light-related information that is not present in the sim::IDEs from the sim::SimChannels.

We already have dedicated fhicls ("_lite") that drop all the "unnecessary" data products and lighten the file size, which are indeed the ones we are using in MC campaigns. From my perspective, users running the standard G4 fhicl out of the box would expect the SimEnergyDeposits to be stored in the output file, hence my proposed changes.

I'm open to further discuss this change. Alternatively, we could introduce a second set of fhicls that act as a counterpart to the "lite" version and include the SimEnergyDeposit. However, I believe this would further complicate our fhicl workflow.

Just pinging some people that have worked on this in the past to hear what they think.
@hgreenlee @absolution1 @marcodeltutto @henrylay97 @jzennamo 
