### PR TITLE
Fix off-by-one bug in channel map call in TPC decoder

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoderDefaults.fcl
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoderDefaults.fcl
@@ -1,0 +1,14 @@
+BEGIN_PROLOG
+
+SBNDTPCDecoderDefaults: {
+      module_type: SBNDTPCDecoder
+      produce_header: true
+      baseline_calc: true
+      timesize: 2559          // for computing timestamps
+      frame_to_dt: 0.5        // produce timestamps in units of microseconds
+      min_slot_no: 3          // channel mapping -- 16 slots don't start at 1 but this number
+      channel_per_slot: 64
+    }
+
+END_PROLOG
+

--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -153,7 +153,7 @@ void daq::SBNDTPCDecoder::process_fragment(art::Event &event, const artdaq::Frag
     auto chanInfo = channelMap->GetChanInfoFromFEMElements(
 							   fragment.header()->getFEMID(), // FEM crate
 							   fragment.header()->getSlot()-_config.min_slot_no + 1, // FEM slot
-							   waveform.first + 1); // nevis_channel_id    
+							   waveform.first); // nevis_channel_id    
     if (!chanInfo.valid) continue;
 
     std::vector<int16_t> raw_digits_waveform;

--- a/sbndcode/Decoders/TPC/runtpcdecoder.fcl
+++ b/sbndcode/Decoders/TPC/runtpcdecoder.fcl
@@ -1,4 +1,5 @@
 #include "TPCChannelMapService.fcl"
+#include "SBNDTPCDecoderDefaults.fcl"
 
 services.TPCChannelMapService: @local::SBNDTPCChannelMapServiceDefaults
 
@@ -7,15 +8,7 @@ physics:
   // now also have something produce the digits and headers
   producers:
   {
-    daq: {
-      module_type: SBNDTPCDecoder
-      produce_header: true
-      baseline_calc: true
-      timesize: 2559          // for computing timestamps
-      frame_to_dt: 0.5        // produce timestamps in units of microseconds
-      min_slot_no: 3          // channel mapping -- 16 slots don't start at 1 but this number
-      channel_per_slot: 64
-    }
+    daq: @local::SBNDTPCDecoderDefaults
   }
 
   analyzers: {}


### PR DESCRIPTION
Apologies for noisy PR's -- I see the channel ID in the Nevis map starts at 0 and not 1, so this is the bugfix.  I also made a separate fcl file with a PROLOG in it for decoder configs that can be #included by other fcls more easily.