### PR TITLE
call removeProduct for raw fragments to conserve memory

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -100,8 +100,11 @@ daq::SBNDTPCDecoder::Config::Config(fhicl::ParameterSet const & param) {
 
 void daq::SBNDTPCDecoder::produce(art::Event & event)
 {
-  auto const& daq_handle = event.getValidHandle<artdaq::Fragments>(_tag);
-
+  auto daq_handle = event.getHandle<artdaq::Fragments>(_tag);
+  if ( !daq_handle.isValid() ) {
+    throw cet::exception("SBNDTPCDecoder_module ") << " invalid fragment handle";
+  }
+  
   RDPmkr rdpm(event);
   TSPmkr tspm(event);
 
@@ -122,6 +125,12 @@ void daq::SBNDTPCDecoder::produce(art::Event & event)
   if (_config.produce_header) {
     event.put(std::move(header_collection));
   }
+
+  // remove TPC fragments from the art event cache.  They can be re-read from the file
+  // by downstream processes if need be, but we are
+  // done with them here
+
+  daq_handle.removeProduct();
 }
 
 


### PR DESCRIPTION
The raw fragments, once decoded, do not need to linger in the art event.  art provides removeProduct for this purpose, but it only works for products that have been read from a file rather than produced in the job, as they can be re-read from the file if need be.

I had to change the daq_handle from a validHandle to just a Handle because removing the product makes the handle invalid, so removeProduct() is not even a method of validHandle.

The memory savings are not obvious in a job that just runs the decoder, as there is nothing else to use the memory until the next event.  But in a job that produces other things, it should reduce the memory footprint by the size of the raw TPC fragments.