### PR TITLE
TPC Decoder: change to use fragment ID to get the FEM crate number

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -46,7 +46,7 @@ tpcAnalysis::TPCDecodeAna daq::SBNDTPCDecoder::Fragment2TPCDecodeAna(art::Event 
   const sbndaq::NevisTPCHeader *raw_header = fragment.header();
   tpcAnalysis::TPCDecodeAna ret;
 
-  ret.crate = raw_header->getFEMID();
+  ret.crate = (frag.fragmentID() >> 8) & 0xF;  
   ret.slot = raw_header->getSlot();
   ret.event_number = raw_header->getEventNum();
   // ret.frame_number = raw_header->getFrameNum();
@@ -158,10 +158,12 @@ void daq::SBNDTPCDecoder::process_fragment(art::Event &event, const artdaq::Frag
     header_collection->push_back(header_data);
   }
 
+  unsigned int FEMCrate = (frag.fragmentID() >> 8) & 0xF;
+  unsigned int FEMSlot = fragment.header()->getSlot()-_config.min_slot_no + 1;
+  
   for (auto waveform: waveform_map) {
-    auto chanInfo = channelMap->GetChanInfoFromFEMElements(
-							   fragment.header()->getFEMID(), // FEM crate
-							   fragment.header()->getSlot()-_config.min_slot_no + 1, // FEM slot
+    auto chanInfo = channelMap->GetChanInfoFromFEMElements(FEMCrate,
+							   FEMSlot,
 							   waveform.first); // nevis_channel_id    
     if (!chanInfo.valid) continue;
 

--- a/sbndcode/Decoders/TPC/runtpcdecoder.fcl
+++ b/sbndcode/Decoders/TPC/runtpcdecoder.fcl
@@ -24,7 +24,7 @@ source: {}
 outputs: {
   rootout: {
     module_type: "RootOutput"
-    fileName: "digits.root"
+    fileName: "%ifb_tpcdecode.root"
   }
 }
 


### PR DESCRIPTION
Bill Badgett told me last week the FEM crate number is encoded in the artdaq::Fragment ID.  It has been tested with runs 10356 and 10357.  Michelle had found and debugged a crate ID issue with one of the DAQ fcl files, and now all 11 crates have unique IDs that match those in Nupur's map.
![evd twq-proj 10356 60tpc1](https://github.com/SBNSoftware/sbndcode/assets/11527579/eca17c95-bf72-4d4f-98d8-bfcccc7d96f1)
![evd twq-proj 10356 60tpc0](https://github.com/SBNSoftware/sbndcode/assets/11527579/05125365-08af-4c88-9aa2-8b33fa336ca1)
