### PR TITLE
InterPlane Drift Effect

### DIFF
--- a/sbndcode/Utilities/detectorproperties_sbnd.fcl
+++ b/sbndcode/Utilities/detectorproperties_sbnd.fcl
@@ -16,5 +16,11 @@ sbnd_detproperties.InheritNumberTimeSamples: false
 sbnd_detproperties.NumberTimeSamples: 3400
 sbnd_detproperties.ReadOutWindowSize: 3400 
 
+# WireCell corrects for the interplane drift in its signal processing. This is
+# not something traditional 1D approaches do. Setting this flag to false
+# ensures that we don't 'double correct' at the start of pandora. This
+# should be set to true when using 1D signal processing.
+# Henry Lay - Nov 2023
+sbnd_detproperties.IncludeInterPlanePitchInXTickOffsets: false
 
 END_PROLOG


### PR DESCRIPTION
Turns off the detector properties service adding a correction for the drift time _between_ the readout planes. This is because WireCell 2D simulation applies this to the `recob::Wire`s whereas the old 1D simulation did not.

Pandora then uses this service to set the times for its input hits used for the pattern recognition. Hence for samples from the 2D simulation the correction would be `applied twice`.

Details are in [docDB #33916](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=33916).

This fix will affect _all_ fcls, i.e. anyone using 1D simulation would need to turn it back on. As far as I'm aware there are no plans to do this in the next production though. IMHO the best solution would be to define two tables in this fcl, one for 1D and one for 2D and then any dedicated 1D fcls could inherit the 1D table, however, that workflow distinction doesn't currently exist so that should be left as part of a wider fcl cleanup. If reviewers disagree we can iterate on this.