### PR TITLE
SimChannel Module Label

### DIFF
--- a/sbndcode/AnalysisTree/analysistreemodule_sbnd.fcl
+++ b/sbndcode/AnalysisTree/analysistreemodule_sbnd.fcl
@@ -10,7 +10,7 @@ sbnd_analysistree:
  DigitModuleLabel:         "daq"
  HitsModuleLabel:          "gaushit"
  LArGeantModuleLabel:      "largeant"
- TPCSimChannelModuleLabel: "simdrift"
+ TPCSimChannelModuleLabel: "simtpc2d:simpleSC"
  CalDataModuleLabel:       "caldata"
  GenieGenModuleLabel:      "generator"
  CryGenModuleLabel:        "generator"

--- a/sbndcode/JobConfigurations/README
+++ b/sbndcode/JobConfigurations/README
@@ -1,4 +1,17 @@
-23rd September 2020
-'standard' contains the fcl files for processing g4, detsim, reco and anatree through the usual workflow
-'base' various groups of fcls which should all produce output.  It includes runnable fcls that the 'standard' fcls inherit from.  It also contains developer-level fcls (such as optical library production)
-If you're unsure which fcls you need, you most likely want the fcls in the 'standard' directory
+The intended operation of the fcl workflows is that the `standard-*` fcls run the standard workflow. This isn't currently true and should be acknowledged here. Diversions due to space charge effect workflows and the implentation of the 2D drift simulation & signal processing (WireCell) have resulted in an explosion in the number of fcls and a confusing naming system.
+
+At the time of writing, the core workflow (for BNB + Dirt + Cosmics) is the following:
+- prodoverlay_corsika_cosmics_proton_genie_rockbox_sce.fcl
+- g4_sce_dirt_filter_lite_wc.fcl
+- wirecell_sim_sp_sbnd.fcl
+- detsim_sce_lite_wc.fcl
+- reco1_sce_lite_wc2d.fcl
+- reco2_sce.fcl
+
+This may well change over the coming months, and this README should be updated to reflect this.
+
+* ALERT * 
+Due to changes implemented in sbndcode PRs #408 and #409 the 1D simulation fcls will not work out of the box, they will need editing by experts!
+Hopefully this is a relatively temporary state of affairs!
+
+Henry Lay - 15th Feb 2024

--- a/sbndcode/JobConfigurations/base/evd_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/evd_sbnd.fcl
@@ -42,4 +42,4 @@ physics:
 
 
 services.RawDrawingOptions.MinimumSignal:              10.
-services.SimulationDrawingOptions.SimChannelLabel:     "simdrift"
+services.SimulationDrawingOptions.SimChannelLabel:     "simtpc2d:simpleSC"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -2,6 +2,7 @@
 
 #include "services_sbnd.fcl"
 #include "geometry_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
 
 #include "larproperties.fcl"
 #include "backtrackerservice.fcl"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -52,8 +52,8 @@ services:
   DetectorClocksService:     @local::sbnd_services.DetectorClocksService
   DetectorPropertiesService: @local::sbnd_detproperties
   ChannelStatusService:      @local::sbnd_channelstatus
-  ParticleInventoryService:  @local::standard_particleinventoryservice
-  BackTrackerService:        @local::standard_backtrackerservice
+  ParticleInventoryService:  @local::sbnd_particleinventoryservice
+  BackTrackerService:        @local::sbnd_backtrackerservice
   SpaceCharge:               @local::sbnd_spacecharge
   NuRandomService: {
     policy: perEvent
@@ -139,4 +139,3 @@ physics.producers.fluxweight.weight_functions: @local::physics.producers.fluxwei
 # input art file.
 physics.producers.cafmaker.SystWeightLabels: []
 
-services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -73,5 +73,4 @@ physics.runprod: [ pandoraTrackMCS, pandoraTrackRange,
 # Enable the Space-Charge service
 #include "enable_spacecharge_services_sbnd.fcl"
 
-services.BackTrackerService.BackTracker.SimChannelModuleLabel: "simdrift"
-physics.producers.cafmaker.SimChannelLabel: "simdrift"
+physics.producers.cafmaker.SimChannelLabel: "simtpc2d:simpleSC"

--- a/sbndcode/LArG4/mcreco_sbnd.fcl
+++ b/sbndcode/LArG4/mcreco_sbnd.fcl
@@ -4,6 +4,6 @@ BEGIN_PROLOG
 
 sbnd_mcreco: @local::standard_mcreco
 sbnd_mcreco.MCParticleLabel: "largeant"
-sbnd_mcreco.SimChannelLabel: "simdrift"
+sbnd_mcreco.SimChannelLabel: "simtpc2d:simpleSC"
 
 END_PROLOG

--- a/sbndcode/LArSoftConfigurations/simulationservices_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/simulationservices_sbnd.fcl
@@ -59,7 +59,7 @@ sbnd_larvoxelcalculator:   @local::standard_larvoxelcalculator # from simulation
 sbnd_backtrackerservice:          @local::standard_backtrackerservice        # from backtrackerservice.fcl
 
 sbnd_backtrackerservice.BackTracker.G4ModuleLabel: "largeant"
-sbnd_backtrackerservice.BackTracker.SimChannelModuleLabel: "simdrift"
+sbnd_backtrackerservice.BackTracker.SimChannelModuleLabel: "simtpc2d:simpleSC"
 sbnd_backtrackerservice.BackTracker.MinimumHitEnergyFraction: 1e-1
 sbnd_backtrackerservice.BackTracker.OverrideRealData: true
 

--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -7,7 +7,7 @@ sbnd_basicpandora:
 {
     module_type:                                                    "StandardPandora"
     GeantModuleLabel:                                               "largeant"
-    SimChannelModuleLabel:                                          "simdrift"
+    SimChannelModuleLabel:                                          "simtpc2d:simpleSC"
     HitFinderModuleLabel:                                           "gaushit"
     EnableMCParticles:                                              false
     EnableProduction:                                               true


### PR DESCRIPTION
This changes the module label used by the back tracker for SimChannels from `simdrift` (1D simulation) to `simtpc2d:simpleSC` (WireCell 2D simulation).

Details are in [docDB #33131](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=33131).

Like with the interplane drift effect this invalidates the use of these fcls on 1D simulation files but I think given the lack of parallel workflows this is the best approach.

I change the base use of this in the definition of the backtracker service _plus_ other module label locations that are currently pointed at `simdrift`. @lynnt20 feel free to weigh in with a WireCell perspective.