### PR TITLE
Adding new SCE map for the 2d drift simulation

### DIFF
--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_3drift_windows_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_3drift_windows_sce_2d_drift_sim.fcl
@@ -1,0 +1,4 @@
+#include "standard_detsim_sbnd.fcl"
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_3drift_windows_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_3drift_windows_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: detsim_3drift_windows_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of detsim_3drift_windows_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "detsim_drops.fcl"
+#include "detsim_3drift_windows_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ "keep *_*_*_*",
+                               @sequence::detsim_drops ]

--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim.fcl
@@ -1,0 +1,2 @@
+#include "standard_detsim_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: detsim_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of detsim_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "detsim_drops.fcl"
+#include "detsim_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ "keep *_*_*_*",
+                               @sequence::detsim_drops ]

--- a/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim_lite_wc.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/2d_drift_sim/detsim_sce_2d_drift_sim_lite_wc.fcl
@@ -1,0 +1,8 @@
+# File:    detsim_sce_2d_drift_sim_lite_wc.fcl 
+# Purpose: Simulates readout response to induced and collected charge
+#          ****DROPS 1D TPC SIM, includes optical+crt simulation ONLY  ****
+#
+
+#include "detsim_sce_2d_drift_sim_lite.fcl"
+
+physics.simulate: [rns, crtsim, opdaq] # removes the "daq" producer

--- a/sbndcode/JobConfigurations/standard/detsim/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/detsim/CMakeLists.txt
@@ -5,4 +5,4 @@ install_source(EXTRAS  ${fcl_files} )
 
 add_subdirectory(diffusion_variations)
 add_subdirectory(legacy)
-
+add_subdirectory(2d_drift_sim)

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim.fcl
@@ -1,0 +1,4 @@
+#include "standard_g4_sbnd.fcl"
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_3drift_windows_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of g4_3drift_windows_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_3drift_windows_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter.fcl
@@ -1,0 +1,4 @@
+#include "g4_simphotontime_filter.fcl"
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter_lite.fcl
+#
+# Purpose: Lite version of g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_3drift_windows_sce_2d_drift_sim_simphotontime_filter.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_eastwestcrt_filter_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_eastwestcrt_filter_sce_2d_drift_sim.fcl
@@ -1,0 +1,3 @@
+#include "g4_mu_eastwestcrt_filter.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_eastwestcrt_filter_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_eastwestcrt_filter_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_mu_eastwestcrt_filter_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of g4_mu_eastwestcrt_filter_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_mu_eastwestcrt_filter_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_frontbackcrt_filter_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_frontbackcrt_filter_sce_2d_drift_sim.fcl
@@ -1,0 +1,4 @@
+#include "g4_mu_frontbackcrt_filter.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"
+

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_frontbackcrt_filter_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_mu_frontbackcrt_filter_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_mu_frontbackcrt_filter_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of g4_mu_frontbackcrt_filter_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_mu_frontbackcrt_filter_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim.fcl
@@ -1,0 +1,2 @@
+#include "standard_g4_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter.fcl
@@ -1,0 +1,4 @@
+#include "g4_simphotontime_filter.fcl"
+
+#include "3drift_services_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_3drift_windows_simphotontime_filter.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco.fcl
@@ -1,0 +1,4 @@
+#include "standard_g4_sbnd.fcl"
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"
+
+services.ParticleListAction.keepGenTrajectories: ["generator", "corsika"]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_SaveCosmicMCReco_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_SaveCosmicMCReco.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_SaveCosmicMCReco.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup.fcl
@@ -1,0 +1,3 @@
+#include "g4_sce_2d_drift_sim_SaveCosmicMCReco.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_SaveCosmicMCReco_no_shower_rollup.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter.fcl
@@ -1,0 +1,4 @@
+# Runs standard g4 fcl without largeant designed for use with gen stage fcls that run a largeant dirt filter with sce_2d_drift_sim
+#include "g4_dirt_filter.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_dirt_filter_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_dirt_filter.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_dirt_filter.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_lite_wc.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_lite_wc.fcl
@@ -1,0 +1,28 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_dirt_filter_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_dirt_filter.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_dirt_filter.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops,
+			       "keep *_ionandscint_*_*",
+                               "drop *_ionandscint_priorSCE_*"
+                             ]
+
+
+
+
+
+

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup.fcl
@@ -1,0 +1,3 @@
+#include "g4_sce_2d_drift_sim_dirt_filter.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_dirt_filter_no_shower_rollup.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup.fcl
@@ -1,0 +1,9 @@
+# File:    g4_sce_2d_drift_sim_no_shower_rollup.fcl
+# Purpose: Same as g4_sce_2d_drift_sim.fcl, but saves all EM shower daughter particles.
+#
+# This runs the new, refactored, LArG4 simulation.
+
+
+#include "g4_sce_2d_drift_sim.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_no_shower_rollup_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_no_shower_rollup.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_no_shower_rollup.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco.fcl
@@ -1,0 +1,16 @@
+# File:    g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco.fcl
+# Purpose: Same as g4_sce_2d_drift_sim_no_shower_rollup.fcl, but removes mcreco from the simulate process
+#
+# This runs the new, refactored, LArG4 simulation.
+
+
+#include "g4_sce_2d_drift_sim_no_shower_rollup.fcl"
+
+physics.simulate: [ rns
+                    , loader
+                    , largeant
+                    , ionandscint
+                    , pdfastsim
+                    , simdrift
+                    , genericcrt
+                  ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_no_shower_rollup_no_mcreco.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter.fcl
@@ -1,0 +1,3 @@
+#include "g4_simphotontime_filter.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_simphotontime_filter_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_simphotontime_filter.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_simphotontime_filter.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup.fcl
@@ -1,0 +1,3 @@
+#include "g4_sce_2d_drift_sim_simphotontime_filter.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco.fcl
@@ -1,0 +1,29 @@
+#include "g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup.fcl"
+
+# Add all these new modules to the simulate path                                                                                                                                 
+physics.simulate: [ rns
+                  ### Complete intime drift simulation and generic CRT                                                                                                           
+                  , simdriftintime
+                  , genericcrtintime
+                  ### Do full Geant4 simulation for the outtimes                                                                                                                 
+                  , loader
+                  , larg4outtime
+                  , ionandscintouttime
+                  , pdfastsimouttime
+                  , simdriftouttime
+                  , genericcrtouttime
+                  ### Simulate the light outside the AV                                                                                                                          
+                  # , ionandscintoutintime                                                                                                                                       
+                  # , pdfastsimoutintime                                                                                                                                         
+                  # , ionandscintoutouttime                                                                                                                                      
+                  # , pdfastsimoutouttime                                                                                                                                        
+                  ### Merge the intime and outtime paths                                                                                                                         
+                  , largeant
+                  , ionandscint
+                  , simdrift
+                  , pdfastsim
+                  # , pdfastsimout                                                                                                                                               
+                  , genericcrt
+                  ### Don't truth-level reconstruction                                                                                                                              
+                  #, mcreco
+                  ]

--- a/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco_lite.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/2d_drift_sim/g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco_lite.fcl
@@ -1,0 +1,19 @@
+#-------------------------------------------------------------------
+#
+# Name: g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco_lite.fcl
+#
+# Purpose: Lite version of g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco.fcl
+#
+# Created: 01-Apr-2022  H. Greenlee
+#
+# Automatically generated.
+#
+#-------------------------------------------------------------------
+
+#include "g4_drops.fcl"
+#include "g4_sce_2d_drift_sim_simphotontime_filter_no_shower_rollup_no_mcreco.fcl"
+
+# Drop truth data products.
+
+outputs.out1.outputCommands: [ @sequence::outputs.out1.outputCommands,
+                               @sequence::g4_drops ]

--- a/sbndcode/JobConfigurations/standard/g4/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/standard/g4/CMakeLists.txt
@@ -5,3 +5,4 @@ install_source(EXTRAS  ${fcl_files} )
 
 add_subdirectory(recomb_variations)
 add_subdirectory(legacy)
+add_subdirectory(2d_drift_sim)

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce_2d_drift_sim.fcl
@@ -1,0 +1,3 @@
+#include "prodcorsika_proton_intime_filter.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce_2d_drift_sim_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/corsika/prodcorsika_proton_intime_filter_sce_2d_drift_sim_no_shower_rollup.fcl
@@ -1,0 +1,3 @@
+#include "prodcorsika_proton_intime_filter_sce_2d_drift_sim.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim.fcl
@@ -1,0 +1,3 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_sbnd.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim_keep_corsika_trajectories.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim_keep_corsika_trajectories.fcl
@@ -1,0 +1,3 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim.fcl"
+
+services.ParticleListAction.keepGenTrajectories: [ "generator", "corsika" ]

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim_no_shower_rollup.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim_no_shower_rollup.fcl
@@ -1,0 +1,3 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_sce_2d_drift_sim.fcl"
+
+services.ParticleListAction.keepEMShowerDaughters: true

--- a/sbndcode/LArSoftConfigurations/enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl
+++ b/sbndcode/LArSoftConfigurations/enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl
@@ -1,0 +1,11 @@
+# Author: Gray Putnam <grayputnam@uchicago.edu>
+# Include this file at the bottom of any fhicl file where space-charge is intended
+# to be turned "ON"
+# It will modify all services parameters necessary.
+
+services.SpaceCharge.EnableCalSpatialSCE: false
+services.SpaceCharge.EnableSimSpatialSCE: true
+services.SpaceCharge.EnableSimEfieldSCE: true
+services.SpaceCharge.EnableCalEfieldSCE: false
+
+services.SpaceCharge.InputFilename: "SCEoffsets/SCEoffsets_SBND_E500_voxelTH3_2DSigSimHack.root"


### PR DESCRIPTION
The 2D drift simulation uses the wrong convention for the SCE offsets in the right hand TPC.

This PR adds a new set of fcls which uses as "hacked" map to correct this issue in the 2D drift simulation. 

The reconstruction and the 1D drift simulation should use the "standard" SCE maps. 

...I am sorry for having to make this PR....

It also requires an update to `sbnd_data`:

`/exp/sbnd/app/users/jaz8600/SpaceChargeFix/srcs/sbnd_data`