### PR TITLE
Quick fix to the hitfinder module to work with the Raw XARAPUCA waveforms

### DIFF
--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -45,11 +45,19 @@ sbnd_ophit_finder_pmt.HitAlgoPset.ADCThreshold: 7
 sbnd_ophit_finder_arapuca: @local::sbnd_ophit_finder
 sbnd_ophit_finder_arapuca.PD: ["xarapuca_vis", "xarapuca_vuv"]
 sbnd_ophit_finder_arapuca.Electronics: "Daphne"
-sbnd_ophit_finder_arapuca.SPEArea: 8541. # It's 66.33 ADC = 132.66 ADCxns x 0.5ns^-1
+sbnd_ophit_finder_arapuca.SPEArea: 217.928. # rodrigoa: Sum of bins at 8ADC, 62.5 MHz/16ns and dipolar/realistic SER
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMax:  1520
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMin:  1480
 sbnd_ophit_finder_arapuca.PedAlgoPset.Threshold:    5
 sbnd_ophit_finder_arapuca.PedAlgoPset.MaxSigma:     5
-sbnd_ophit_finder_arapuca.HitAlgoPset.ADCThreshold: 20
+sbnd_ophit_finder_arapuca.PedAlgoPset.Name:"Edges"
+sbnd_ophit_finder_arapuca.PedAlgoPset.NumSampleFront:50
+sbnd_ophit_finder_arapuca.PedAlgoPset.NumSampleTail: 50
+sbnd_ophit_finder_arapuca.PedAlgoPset.Method:2
+sbnd_ophit_finder_arapuca.HitAlgoPset.ADCThreshold: 4  # rodrigoa: 4 ADC is 1/2 of the 8 ADC threshold
+sbnd_ophit_finder_arapuca.HitAlgoPset.NumPostSample: 0 # rodrigoa: prevent sum the negative part (overshooting)
+sbnd_ophit_finder_arapuca.HitAlgoPset.NumPreSample: 5
+sbnd_ophit_finder_arapuca.HitAlgoPset.TailADCThreshold: 2
+sbnd_ophit_finder_arapuca.HitAlgoPset.TailNSigmaThreshold: 2
 
 END_PROLOG

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -45,7 +45,7 @@ sbnd_ophit_finder_pmt.HitAlgoPset.ADCThreshold: 7
 sbnd_ophit_finder_arapuca: @local::sbnd_ophit_finder
 sbnd_ophit_finder_arapuca.PD: ["xarapuca_vis", "xarapuca_vuv"]
 sbnd_ophit_finder_arapuca.Electronics: "Daphne"
-sbnd_ophit_finder_arapuca.SPEArea: 217.928. # rodrigoa: Sum of bins at 8ADC, 62.5 MHz/16ns and dipolar/realistic SER
+sbnd_ophit_finder_arapuca.SPEArea: 136.47 # rodrigoa: Sum of bins at 8ADC, 62.5 MHz/16ns and dipolar/realistic SER
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMax:  1520
 sbnd_ophit_finder_arapuca.PedAlgoPset.PedRangeMin:  1480
 sbnd_ophit_finder_arapuca.PedAlgoPset.Threshold:    5
@@ -59,5 +59,6 @@ sbnd_ophit_finder_arapuca.HitAlgoPset.NumPostSample: 0 # rodrigoa: prevent sum t
 sbnd_ophit_finder_arapuca.HitAlgoPset.NumPreSample: 5
 sbnd_ophit_finder_arapuca.HitAlgoPset.TailADCThreshold: 2
 sbnd_ophit_finder_arapuca.HitAlgoPset.TailNSigmaThreshold: 2
+sbnd_ophit_finder_arapuca.HitAlgoPset.PositivePolarity: true
 
 END_PROLOG


### PR DESCRIPTION
Fixed:
-Polarity was set to negative as PMTs
-Thresholds where too high (current SER peak is 8 ADC)
-Computed the Area of the current SER (no idea what was implemented before, 3 years since the last change)

Changed:
-Slightly tuned the algorithm params.