### PR TITLE
Update the bunch spacing in GENIE and MeVPrtl using number measured by MicroBooNE

### DIFF
--- a/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
@@ -21,7 +21,7 @@ kaon2hnl: {
   # https://beamdocs.fnal.gov/AD/DocDB/0050/005000/001/bunchLength_1st_draft.pdf
   # Bunch spacing taken from
   # https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
   GlobalTimeOffset: 0
   Verbose: false
 }

--- a/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
@@ -17,8 +17,11 @@ kaon2hnl: {
   BeamOrigin: @local::sbnd_bnb_beam_origin
 
   // timing config
-  SpillTimeConfig: "evgb::EvtTimeFNALBeam  booster,  dtbucket=19., sigma=1.308"
-  //SpilTimeConfig: "" #"evgb::EvtTimeFlat 10000 0" // 10us duration, no offset  
+  # Bunch sigma taken from 
+  # https://beamdocs.fnal.gov/AD/DocDB/0050/005000/001/bunchLength_1st_draft.pdf
+  # Bunch spacing taken from
+  # https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
   GlobalTimeOffset: 0
   Verbose: false
 }

--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -274,13 +274,13 @@ sbnd_flux_numi_dirt: {
 # https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
 
 sbnd_fluxbucket_bnb: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
 }
 
 # Booster Neutrino Beam, rotated bucket
 #
 sbnd_fluxbucket_bnb_rotated: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
 }
 
 ################################################################################

--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -270,14 +270,17 @@ sbnd_flux_numi_dirt: {
 #
 # Bunch sigma taken from 
 # https://beamdocs.fnal.gov/AD/DocDB/0050/005000/001/bunchLength_1st_draft.pdf
+# Bunch spacing taken from
+# https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
+
 sbnd_fluxbucket_bnb: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=19., sigma=1.308"
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
 }
 
 # Booster Neutrino Beam, rotated bucket
 #
 sbnd_fluxbucket_bnb_rotated: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=19., sigma=1.308"
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936., sigma=1.308"
 }
 
 ################################################################################


### PR DESCRIPTION
The bunch spacing is simulated with a place holder value of 19 ns.
Update to use MicroBooNE number of 18.936 ns.
This is also consistent with SBND measured using the CRT panels in 2017-2018 with bunch spacing = 18.935 ns. 
![image](https://github.com/SBNSoftware/sbndcode/assets/74775793/3fc94a36-ce8a-4605-a170-894db49118af)
