### PR TITLE
Trigger Metrics Object Patch

### DIFF
--- a/sbndcode/Commissioning/CMakeLists.txt
+++ b/sbndcode/Commissioning/CMakeLists.txt
@@ -20,6 +20,7 @@ set(
         sbndcode_CRTUtils
         sbnobj::Common_CRT
         sbnobj::SBND_CRT
+        sbndaq_artdaq_core::sbndaq-artdaq-core_Obj_SBND
         nusimdata::SimulationBase
         art::Framework_Core
         art::Framework_Principal


### PR DESCRIPTION
Missed adding one entry to a CMakesList... without this addition, local build of `sbndcode` would fail without having `sbndaq-artdaq-core`. 

Main PR is #430. 