### PR TITLE
G4 fcl using Ellipsoidal Modified Box Recombination Model for 2024A Calibration Production

### DIFF
--- a/sbndcode/JobConfigurations/standard/g4/recomb_variations/g4_sce_dirt_filter_lite_recomb_ellips.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/recomb_variations/g4_sce_dirt_filter_lite_recomb_ellips.fcl
@@ -1,0 +1,6 @@
+#include "g4_sce_dirt_filter_lite.fcl"
+
+process_name: G4Var
+
+services.LArG4Parameters.UseModBoxRecomb: false
+services.LArG4Parameters.UseEllipsModBoxRecomb: true


### PR DESCRIPTION
Add G4 fcl using the ellipsoidal modified box recombination model for the upcoming 2024A production. This fcl will be used to create samples for recombination studies. Below fhicl-dump outputs shows the `UseEllipsModBoxRecomb` and `UseModBoxRecomb` parameters changed compared to the nominal fcl.

```
-bash-4.2$ fhicl-dump g4_sce_dirt_filter_lite_recomb_ellips.fcl | grep Box
      EllipsModBoxA: 9.06e-1
      EllipsModBoxB: 2.03e-1
      EllipsModBoxR: 1.25
      ModBoxA: 9.3e-1
      ModBoxB: 2.12e-1
      UseEllipsModBoxRecomb: true
      UseModBoxRecomb: false
-bash-4.2$ fhicl-dump g4_sce_dirt_filter_lite.fcl | grep Box
      EllipsModBoxA: 9.06e-1
      EllipsModBoxB: 2.03e-1
      EllipsModBoxR: 1.25
      ModBoxA: 9.3e-1
      ModBoxB: 2.12e-1
      UseEllipsModBoxRecomb: false
      UseModBoxRecomb: true
```