### PR TITLE
Compute asicchan from FEMBCh and fill the field in ChanInfo

### DIFF
--- a/sbndcode/ChannelMaps/TPC/TPCChannelMapService_service.cc
+++ b/sbndcode/ChannelMaps/TPC/TPCChannelMapService_service.cc
@@ -75,6 +75,7 @@ SBND::TPCChannelMapService::TPCChannelMapService(fhicl::ParameterSet const& pset
       if (planestr == "Y") c.plane = 2;
       if (c.plane == 10) c.valid = false;
       c.WIBQFSP = atoi(qfspstr.substr(3,1).c_str());
+      c.asicchan = c.FEMBCh % 16;
 
       fChanInfoFromFEMInfo[c.FEMCrate][c.FEM][c.FEMCh] = c;
       fChanInfoFromOfflChan[c.offlchan] = c;


### PR DESCRIPTION
I had put in a field called "asicchan" in the ChanInfo struct but forgot to fill it.   It can be computed from FEMBCh.  asic is just FEMBCh / 16.  No one has complained yet, but it's best not to leave the field uninitialized.