### PR TITLE
increase precision of timestamp calculation to 64 bits -- was 32 bits

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -49,7 +49,7 @@ tpcAnalysis::TPCDecodeAna daq::SBNDTPCDecoder::Fragment2TPCDecodeAna(art::Event 
   ret.crate = (frag.fragmentID() >> 8) & 0xF;  
   ret.slot = raw_header->getSlot();
   ret.event_number = raw_header->getEventNum();
-  // ret.frame_number = raw_header->getFrameNum();
+  //std::cout << "TPC decoder frame, sample: " << raw_header->getFrameNum() << " " << raw_header->get2mhzSample() << std::endl;
   ret.checksum = raw_header->getChecksum();
   
   ret.adc_word_count = raw_header->getADCWordCount();
@@ -57,8 +57,8 @@ tpcAnalysis::TPCDecodeAna daq::SBNDTPCDecoder::Fragment2TPCDecodeAna(art::Event 
   
   // formula for getting unix timestamp from nevis frame number:
   // timestamp = frame_number * (timesize + 1) + trigger_sample
-  ret.timestamp = (raw_header->getFrameNum() * (_config.timesize + 1) + raw_header->get2mhzSample()) * _config.frame_to_dt;
-
+  ret.timestamp = (raw_header->getFrameNum() * ( (ULong64_t) _config.timesize + 1) + raw_header->get2mhzSample()) * ( (double)  _config.frame_to_dt);
+  //std::cout << "timestamp: " << ret.timestamp << std::endl;
   ret.index = raw_header->getSlot() - _config.min_slot_no;
 
   return ret;

--- a/sbndcode/Decoders/TPC/TPCDecodeAna.h
+++ b/sbndcode/Decoders/TPC/TPCDecodeAna.h
@@ -18,7 +18,7 @@ class TPCDecodeAna {
   uint8_t slot; //!< Index of "slot" of readout board 
   uint32_t event_number; //!< Event number for this header 
   uint32_t checksum; //!< checksum associated with header
-  uint32_t timestamp; //!< timestamp for this header
+  ULong64_t timestamp; //!< timestamp for this header
   uint32_t adc_word_count; //!< word count of ADC counts associated with this header
 
   unsigned index; //!< Globally usable index for this header information. 

--- a/sbndcode/Decoders/TPC/classes_def.xml
+++ b/sbndcode/Decoders/TPC/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="tpcAnalysis::TPCDecodeAna" ClassVersion="10">
+  <class name="tpcAnalysis::TPCDecodeAna" ClassVersion="11">
+   <version ClassVersion="11" checksum="3638395479"/>
    <version ClassVersion="10" checksum="3825172703"/>
   </class>
   <class name="std::vector<tpcAnalysis::TPCDecodeAna>"/>


### PR DESCRIPTION
The TPC Analysis data product that the raw decoder makes had a 32-bit timestamp which is inadequate.  I had copied it from here:

https://github.com/SBNSoftware/sbndqm/blob/bbdb305238b32b4d3d215bba47ea1bf44ba97b6c/sbndqm/Decode/TPC/HeaderData.hh#L21

I changed the data type to ULong64_t from uint32_t in the data product, and upgraded the formula computing it so that it doesn't roll over at 2E9 or so.  The classes_def.xml file automatically updated, and ROOT's automatic schema evolution should take care of reading in old files as only the size of one element of the data product changed.  I checked reading in an old and a new analysis data product in the same ROOT session in the same TTree, and ROOT figured it out.  Below are results of a test of redecoding a file and looking at the timestamp vs. the entry number in the file.

![run12804_rollover](https://github.com/SBNSoftware/sbndcode/assets/11527579/79b21a6f-213a-4855-aeb9-97220b14eb03)
![norollover](https://github.com/SBNSoftware/sbndcode/assets/11527579/91cd6895-0c83-452e-ac0a-b9ba00353e60)

