### PR TITLE
Trj digitalnoisechannelstatus may3 2024

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -49,7 +49,7 @@ tpcAnalysis::TPCDecodeAna daq::SBNDTPCDecoder::Fragment2TPCDecodeAna(art::Event 
   ret.crate = (frag.fragmentID() >> 8) & 0xF;  
   ret.slot = raw_header->getSlot();
   ret.event_number = raw_header->getEventNum();
-  // ret.frame_number = raw_header->getFrameNum();
+  //std::cout << "TPC decoder frame, sample: " << raw_header->getFrameNum() << " " << raw_header->get2mhzSample() << std::endl;
   ret.checksum = raw_header->getChecksum();
   
   ret.adc_word_count = raw_header->getADCWordCount();
@@ -57,8 +57,8 @@ tpcAnalysis::TPCDecodeAna daq::SBNDTPCDecoder::Fragment2TPCDecodeAna(art::Event 
   
   // formula for getting unix timestamp from nevis frame number:
   // timestamp = frame_number * (timesize + 1) + trigger_sample
-  ret.timestamp = (raw_header->getFrameNum() * (_config.timesize + 1) + raw_header->get2mhzSample()) * _config.frame_to_dt;
-
+  ret.timestamp = (raw_header->getFrameNum() * ( (ULong64_t) _config.timesize + 1) + raw_header->get2mhzSample()) * ( (double)  _config.frame_to_dt);
+  //std::cout << "timestamp: " << ret.timestamp << std::endl;
   ret.index = raw_header->getSlot() - _config.min_slot_no;
 
   return ret;

--- a/sbndcode/Decoders/TPC/TPCDecodeAna.h
+++ b/sbndcode/Decoders/TPC/TPCDecodeAna.h
@@ -18,7 +18,7 @@ class TPCDecodeAna {
   uint8_t slot; //!< Index of "slot" of readout board 
   uint32_t event_number; //!< Event number for this header 
   uint32_t checksum; //!< checksum associated with header
-  uint32_t timestamp; //!< timestamp for this header
+  ULong64_t timestamp; //!< timestamp for this header
   uint32_t adc_word_count; //!< word count of ADC counts associated with this header
 
   unsigned index; //!< Globally usable index for this header information. 

--- a/sbndcode/Decoders/TPC/classes_def.xml
+++ b/sbndcode/Decoders/TPC/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="tpcAnalysis::TPCDecodeAna" ClassVersion="10">
+  <class name="tpcAnalysis::TPCDecodeAna" ClassVersion="11">
+   <version ClassVersion="11" checksum="3638395479"/>
    <version ClassVersion="10" checksum="3825172703"/>
   </class>
   <class name="std::vector<tpcAnalysis::TPCDecodeAna>"/>

--- a/sbndcode/Utilities/CMakeLists.txt
+++ b/sbndcode/Utilities/CMakeLists.txt
@@ -27,6 +27,10 @@ cet_build_plugin( SignalShapingServiceSBND  art::service SOURCE SignalShapingSer
                ${sbnd_util_lib_list}
         )
 
+cet_build_plugin( DigitalNoiseChannelStatus art::service SOURCE DigitalNoiseChannelStatus_service.cc LIBRARIES
+	${sbnd_util_lib_list}
+	)
+      
 cet_build_plugin ( SBNDGeoHelper art::module
                      larcorealg::Geometry
                      larcore::Geometry_Geometry_service

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus.h
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus.h
@@ -47,6 +47,11 @@ private:
   std::string fRawDigitLabel;
   std::string fRecobWireLabel;
 
+  int fNAwayFromPedestalRawDigit;
+  int fDistFromPedestalRawDigit;
+  int fNAwayFromPedestalRecobWire;
+  float fDistFromPedestalRecobWire;
+  
 };
 
 DECLARE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus, LEGACY)

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus.h
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus.h
@@ -50,6 +50,5 @@ private:
 };
 
 DECLARE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus, LEGACY)
-DEFINE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus)
 
 #endif

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus.h
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus.h
@@ -35,7 +35,9 @@ public:
   const std::unordered_set<raw::ChannelID_t> & GetSetOfBadChannels() const;
 
   size_t NBadChannels() const;
-  
+
+  void pub_PrepEvent(const art::Event& evt, art::ScheduleContext);
+
 private:
 
   std::unordered_set<raw::ChannelID_t> fDNChannels;   // set of channels with digital noise on them on this event
@@ -44,8 +46,6 @@ private:
   int fNBADCutRawDigit;
   std::string fRawDigitLabel;
   std::string fRecobWireLabel;
-
-  void priv_PrepEvent(const art::Event& evt, art::ScheduleContext);
 
 };
 

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus.h
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus.h
@@ -1,0 +1,55 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       DigitalNoiseChannelStatus
+// Plugin Type: service (Unknown Unknown)
+// File:        DigitalNoiseChannelStatus_service.cc
+//
+// Generated at Thu May  2 17:24:05 2024 by Thomas Junk using cetskelgen
+// from cetlib version 3.18.02.
+////////////////////////////////////////////////////////////////////////
+
+#ifndef DigitalNoiseChannelStatusService_H
+#define DigitalNoiseChannelStatusService_H
+
+#include "art/Framework/Services/Registry/ActivityRegistry.h"
+#include "art/Framework/Services/Registry/ServiceMacros.h"
+#include "fhiclcpp/ParameterSet.h"
+
+#include "lardataobj/RawData/RawDigit.h"
+#include "lardataobj/RecoBase/Wire.h"
+
+#include <unordered_set>
+
+namespace sbnd {
+  class DigitalNoiseChannelStatus;
+}
+
+
+class sbnd::DigitalNoiseChannelStatus {
+public:
+  explicit DigitalNoiseChannelStatus(fhicl::ParameterSet const& p, art::ActivityRegistry& areg);
+  // The compiler-generated destructor is fine for non-base
+  // classes without bare pointers or other resource use.
+
+  bool IsBad(raw::ChannelID_t chan) const;
+
+  const std::unordered_set<raw::ChannelID_t> & GetSetOfBadChannels() const;
+
+  size_t NBadChannels() const;
+  
+private:
+
+  std::unordered_set<raw::ChannelID_t> fDNChannels;   // set of channels with digital noise on them on this event
+  float fRMSCutWire;
+  float fRMSCutRawDigit;
+  int fNBADCutRawDigit;
+  std::string fRawDigitLabel;
+  std::string fRecobWireLabel;
+
+  void priv_PrepEvent(const art::Event& evt, art::ScheduleContext);
+
+};
+
+DECLARE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus, LEGACY)
+DEFINE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus)
+
+#endif

--- a/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
@@ -1,0 +1,12 @@
+BEGIN_PROLOG
+
+DigitalNoiseChannelStatusDefaults : 
+{
+  RawDigitLabel: "daq"
+  RecobWireLabel: "caldata"
+  RMSCutRawDigit: 100
+  RMSCutWire: 100
+  NBADCutRawDigit: 5
+}
+
+END_PROLOG

--- a/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
@@ -7,10 +7,10 @@ DigitalNoiseChannelStatusDefaults :
   RMSCutRawDigit: 100
   RMSCutWire: 100
   NBADCutRawDigit: 5
-  NAwayFromPedestalRawDigit: 100
-  DistFromPedestalRawDigit: 100
-  NAwayFromPedestalRecobWire: 100
-  DistFromPedestalRecobWire: 100
+  NAwayFromPedestalRawDigit: 200
+  DistFromPedestalRawDigit: 1000
+  NAwayFromPedestalRecobWire: 200
+  DistFromPedestalRecobWire: 1000
 }
 
 END_PROLOG

--- a/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatusDefaults.fcl
@@ -7,6 +7,10 @@ DigitalNoiseChannelStatusDefaults :
   RMSCutRawDigit: 100
   RMSCutWire: 100
   NBADCutRawDigit: 5
+  NAwayFromPedestalRawDigit: 100
+  DistFromPedestalRawDigit: 100
+  NAwayFromPedestalRecobWire: 100
+  DistFromPedestalRecobWire: 100
 }
 
 END_PROLOG

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
@@ -82,3 +82,7 @@ void sbnd::DigitalNoiseChannelStatus::priv_PrepEvent(const art::Event& evt, art:
   //    std::cout << "noisy chan: " << c << std::endl;
   //  }
 }
+
+DEFINE_ART_SERVICE(sbnd::DigitalNoiseChannelStatus)
+
+

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
@@ -1,0 +1,84 @@
+
+#include "DigitalNoiseChannelStatus.h"
+#include "TMath.h"
+#include "lardataobj/RawData/raw.h"
+#include "art/Framework/Principal/Event.h"
+
+sbnd::DigitalNoiseChannelStatus::DigitalNoiseChannelStatus(fhicl::ParameterSet const& p, art::ActivityRegistry& areg)
+// :
+// Initialize member data here.
+{
+  fRMSCutWire = p.get<float>("RMSCutWire",100.0);
+  fRMSCutRawDigit = p.get<float>("RMSCutRawDigit",100.0);
+  fNBADCutRawDigit = p.get<float>("NBADCutRawDigit",5);
+  fRawDigitLabel = p.get<std::string>("RawDigitLabel","daq");
+  fRecobWireLabel = p.get<std::string>("RecobWireLabel","caldata");
+
+  areg.sPreProcessEvent.watch(this, &sbnd::DigitalNoiseChannelStatus::priv_PrepEvent);
+}
+
+bool sbnd::DigitalNoiseChannelStatus::IsBad(raw::ChannelID_t chan) const
+{
+  return (fDNChannels.find(chan) != fDNChannels.end());
+}
+
+const std::unordered_set<raw::ChannelID_t> & sbnd::DigitalNoiseChannelStatus::GetSetOfBadChannels() const
+{
+  return fDNChannels;
+}
+
+size_t sbnd::DigitalNoiseChannelStatus::NBadChannels() const
+{
+  return fDNChannels.size();
+}
+
+// prepare channel status data for the event
+
+// put cuts on RMS, number of 0xBAD samples, and whether the differences between a sample and
+// the first are all even (catches all the powers of two).
+
+void sbnd::DigitalNoiseChannelStatus::priv_PrepEvent(const art::Event& evt, art::ScheduleContext)
+{
+  fDNChannels.clear();
+  if (fRawDigitLabel != "")
+    {
+      auto const& rawdigits = evt.getProduct<std::vector<raw::RawDigit>>(fRawDigitLabel);
+      for (const auto& rd : rawdigits)
+	{
+	  bool chanbad = false;
+	  chanbad |= (rd.GetSigma() > fRMSCutRawDigit);
+	  int nhexbad = 0;
+	  std::vector<short> rawadc;
+	  rawadc.resize(rd.Samples());
+	  raw::Uncompress(rd.ADCs(), rawadc, rd.GetPedestal(), rd.Compression());
+	  bool alleven = true;
+	  const short adc0 = rawadc.at(0);
+	  for (size_t i=0; i< rd.Samples(); ++i)
+	    {
+	      const short adc = rawadc.at(i);
+	      if (adc == 0xBAD) ++nhexbad;
+	      alleven &= ( ((adc - adc0) % 2) == 0 ); 
+	    }
+	  chanbad |= (nhexbad > fNBADCutRawDigit);
+	  chanbad |= alleven;
+	  if (chanbad) fDNChannels.emplace(rd.Channel());
+	}
+    }
+  else if (fRecobWireLabel != "")
+    {
+      art::InputTag rwtag(fRecobWireLabel);
+      auto const& rbwires = evt.getProduct<std::vector<recob::Wire>>(fRecobWireLabel);
+      for (const auto& rw : rbwires)
+	{
+	  bool chanbad = false;
+	  auto rms = TMath::RMS(rw.NSignal(),rw.Signal().data());
+	  chanbad |= (rms > fRMSCutWire);
+	  if (chanbad) fDNChannels.emplace(rw.Channel());
+	}
+    }
+  //std::cout << "sbnd::DigitalNoiseStatus_service: NBadChannels: " << fDNChannels.size() << std::endl;
+  //for (const auto& c : fDNChannels)
+  //  {
+  //    std::cout << "noisy chan: " << c << std::endl;
+  //  }
+}

--- a/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
+++ b/sbndcode/Utilities/DigitalNoiseChannelStatus_service.cc
@@ -14,7 +14,7 @@ sbnd::DigitalNoiseChannelStatus::DigitalNoiseChannelStatus(fhicl::ParameterSet c
   fRawDigitLabel = p.get<std::string>("RawDigitLabel","daq");
   fRecobWireLabel = p.get<std::string>("RecobWireLabel","caldata");
 
-  areg.sPreProcessEvent.watch(this, &sbnd::DigitalNoiseChannelStatus::priv_PrepEvent);
+  areg.sPreProcessEvent.watch(this, &sbnd::DigitalNoiseChannelStatus::pub_PrepEvent);
 }
 
 bool sbnd::DigitalNoiseChannelStatus::IsBad(raw::ChannelID_t chan) const
@@ -37,7 +37,7 @@ size_t sbnd::DigitalNoiseChannelStatus::NBadChannels() const
 // put cuts on RMS, number of 0xBAD samples, and whether the differences between a sample and
 // the first are all even (catches all the powers of two).
 
-void sbnd::DigitalNoiseChannelStatus::priv_PrepEvent(const art::Event& evt, art::ScheduleContext)
+void sbnd::DigitalNoiseChannelStatus::pub_PrepEvent(const art::Event& evt, art::ScheduleContext)
 {
   fDNChannels.clear();
   if (fRawDigitLabel != "")


### PR DESCRIPTION
This is a service that checks raw::RawDigit and/or recob::Wire to identify channels that have digital noise on them.  The selection is on the RMS with a fcl-steerable parameter (separate for raw digits and recob::Wire), or if the differences between raw digit values is always divisible by 2, which covers cases where we've seen that bits are shifted and differences are powers of two.  Looks like I re-used a branch for my old timestamp PR that should have been merged already.