### PR TITLE
Use QGSP_BERT_HP physics list

### DIFF
--- a/sbndcode/LArG4/larg4_services_sbnd.fcl
+++ b/sbndcode/LArG4/larg4_services_sbnd.fcl
@@ -8,7 +8,7 @@ BEGIN_PROLOG
 #
 sbnd_physics_list_fastoptical:
 {
-  PhysicsListName: "SBN_QGSP_BERT_NNC"
+  PhysicsListName: "QGSP_BERT_HP"
   DumpList: true
   enableNeutronLimit: false
   NeutronTimeLimit: 0.0


### PR DESCRIPTION
With this PR we switch to using the `QGSP_BERT_HP` Geant4 physics list.

Comparison of performances is below (10 events generated with `prodoverlay_corsika_cosmics_proton_genie_nu_spill_tpc_sbnd.fcl` followed by `g4_sce.fcl`).

Original (`SBN_QGSP_BERT_NNC`):
```
TrigReport ---------- Event summary -------------
TrigReport Events total = 10 passed = 10 failed = 0

TrigReport ---------- Modules in End-path ----------
TrigReport        Run    Success      Error Name
TrigReport         10         10          0 out1

TimeReport ---------- Time summary [sec] -------
TimeReport CPU = 309.721987 Real = 320.409894

MemReport  ---------- Memory summary [base-10 MB] ------
MemReport  VmPeak = 4060.32 VmHWM = 3174.96
```

New (`QGSP_BERT_HP`):
```
TrigReport ---------- Event summary -------------
TrigReport Events total = 10 passed = 10 failed = 0

TrigReport ---------- Modules in End-path ----------
TrigReport        Run    Success      Error Name
TrigReport         10         10          0 out1

TimeReport ---------- Time summary [sec] -------
TimeReport CPU = 356.488440 Real = 396.237816

MemReport  ---------- Memory summary [base-10 MB] ------
MemReport  VmPeak = 4733.35 VmHWM = 3852.27
```