### PR TITLE
Update wcls-sim-drift-depoflux-nf-sp.jsonnet

### DIFF
--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -124,7 +124,6 @@ local wcls_depoflux_writer = g.pnode({
 
     reference_time: -1700 * wc.us,
 
-    energy: 1, # equivalent to use_energy = true
     simchan_label: 'simpleSC',
     sed_label: if (savetid == 'true') then 'ionandscint' else '',
     sparse: false,


### PR DESCRIPTION
This config does something weird to the energy deposits, making the total energy deposited much greater than the total energy of the particle. Removing this produces much more reasonable values, i.e. values always less than the total energy.