### PR TITLE
Solve compiling errors in SBNDPDSAnalyzer with c14

### DIFF
--- a/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc
+++ b/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc
@@ -259,7 +259,6 @@ void opdet::SBNDPDSAnalyzer::analyze(art::Event const& e)
   art::ServiceHandle<cheat::ParticleInventoryService> pi_serv;
   art::ServiceHandle<cheat::BackTrackerService> bt_serv;
   art::ServiceHandle<detinfo::DetectorClocksService> timeservice;
-  auto const clockData(timeservice->DataFor(e));
 
   // --- Saving MCTruths
   if(fSaveMCTruth){
@@ -998,7 +997,6 @@ void opdet::SBNDPDSAnalyzer::FillAverageDepositedEnergyVariables(std::vector<std
   }
 
   if(ndeps_tpc0!=0){
-    dE_tpc0=dE_tpc0;
     dEpromx_tpc0=dEpromx_tpc0/dE_tpc0;
     dEpromy_tpc0=dEpromy_tpc0/dE_tpc0;
     dEpromz_tpc0=dEpromz_tpc0/dE_tpc0;
@@ -1009,7 +1007,6 @@ void opdet::SBNDPDSAnalyzer::FillAverageDepositedEnergyVariables(std::vector<std
     dEspreadx[0]=spreadx_tpc0;dEspready[0]=spready_tpc0;dEspreadz[0]=spreadz_tpc0;
   }
   if(ndeps_tpc1!=0){
-    dE_tpc1=dE_tpc1;
     dEpromx_tpc1=dEpromx_tpc1/dE_tpc1;
     dEpromy_tpc1=dEpromy_tpc1/dE_tpc1;
     dEpromz_tpc1=dEpromz_tpc1/dE_tpc1;

--- a/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.hh
+++ b/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.hh
@@ -177,8 +177,7 @@ private:
   std::vector <double> _nuvZ;
   std::vector <double> _nuvE;
   
-  // Saving MCParticles
-  int _nMCParticles;                        
+  // Saving MCParticles                       
   std::vector < std::vector <double> > _mc_stepX;
   std::vector < std::vector <double> > _mc_stepY;
   std::vector < std::vector <double> > _mc_stepZ;


### PR DESCRIPTION
I saw `c14` is throwing these compiling error after merging #467. This PR aims to address this.
```

5129: /scratch/workspace/sbnd_ci/label_exp/swarm/label_exp2/swarm/SBND/srcs/sbndcode/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc:262:14: error: unused variable 'clockData' [-Werror,-Wunused-variable]
5130:   auto const clockData(timeservice->DataFor(e));
5131:              ^
5132: /scratch/workspace/sbnd_ci/label_exp/swarm/label_exp2/swarm/SBND/srcs/sbndcode/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc:1001:12: error: explicitly assigning value of variable of type 'double' to itself [-Werror,-Wself-assign]
5133:     dE_tpc0=dE_tpc0;
5134:     ~~~~~~~^~~~~~~~
5135: /scratch/workspace/sbnd_ci/label_exp/swarm/label_exp2/swarm/SBND/srcs/sbndcode/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc:1012:12: error: explicitly assigning value of variable of type 'double' to itself [-Werror,-Wself-assign]
5136:     dE_tpc1=dE_tpc1;
5137:     ~~~~~~~^~~~~~~~
5138: In file included from /scratch/workspace/sbnd_ci/label_exp/swarm/label_exp2/swarm/SBND/srcs/sbndcode/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.cc:1:
5139: /scratch/workspace/sbnd_ci/label_exp/swarm/label_exp2/swarm/SBND/srcs/sbndcode/sbndcode/OpDetAnalyzer/PDSAnalyzer/SBNDPDSAnalyzer_module.hh:181:7: error: private field '_nMCParticles' is not used [-Werror,-Wunused-private-field]
5140:   int _nMCParticles;                        
5141:       ^
```