### PR TITLE
Keep cluster3d after reco1

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_drops.fcl
+++ b/sbndcode/JobConfigurations/base/reco_drops.fcl
@@ -20,8 +20,8 @@ BEGIN_PROLOG
 reco_drops: [ @sequence::detsim_drops,
               "drop raw::RawDigits_*_*_*",
               "drop raw::OpDetWaveforms_*_*_*",
-              "drop *_cluster3d_*_*", #drop all mlreco output
               "drop *_sedlite_*_*" #drop all mlreco output
+              #"drop *_cluster3d_*_*", #drop cluster3d output
               #"drop *_simplemerge_*_*" #drop all mlreco output
                ]
 


### PR DESCRIPTION
## Description 
Cluster3d is very light, and can be kept since it may be useful to study.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees` ,
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant issue link(s) (optional)
Is there existing issue that this PR addresses?

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
