### PR TITLE
Scrub stage metadata

### DIFF
--- a/sbndcode/JobConfigurations/standard/scrubs/scrub_g4_wcls_detsim_reco1.fcl
+++ b/sbndcode/JobConfigurations/standard/scrubs/scrub_g4_wcls_detsim_reco1.fcl
@@ -5,6 +5,7 @@
 # Author Henry Lay (h.lay@lancaster.ac.uk)
 
 #include "rootoutput_sbnd.fcl"
+#include "sam_sbnd.fcl"
 
 process_name: Scrub
 

--- a/sbndcode/JobConfigurations/standard/scrubs/scrub_wcls_detsim_reco1.fcl
+++ b/sbndcode/JobConfigurations/standard/scrubs/scrub_wcls_detsim_reco1.fcl
@@ -5,6 +5,7 @@
 # Author Henry Lay (h.lay@lancaster.ac.uk)
 
 #include "rootoutput_sbnd.fcl"
+#include "sam_sbnd.fcl"
 
 process_name: Scrub
 


### PR DESCRIPTION
## Description 
Quick fix to allow SAM metadata generation for scrub files. The scrub files are used when generating detector variation samples, and having metadata for these stages allows us to track parentage and simplify processing.

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer as additional reviewer.
- [ ] Does this affect the standard workflow? 
