### PR TITLE
bulletproof the call to removeProduct -- deal with case if handle is not valid

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -138,7 +138,7 @@ void daq::SBNDTPCDecoder::produce(art::Event & event)
   // by downstream processes if need be, but we are
   // done with them here
 
-  daq_handle.removeProduct();
+  if ( daq_handle.isValid() ) daq_handle.removeProduct();
 }
 
 


### PR DESCRIPTION
Just a little bulletproofing for the call to removeProduct().  I saw in the shift operations Slack channel some mention about an invalid handle from the TPC decoder running in the DQM.  I looked through the source to see if there was a test on isValid() before doing anything, and to gracefully handle cases in which the data are missing.  It was all okay except the call to removeProduct() was not guarded.  It may be that the call will still not throw an exception even if the handle is not valid, but I figured I'd put in a test anyway.

This is a standalone PR.  I tested it by redecoding the same file I redecoded for PR499 and reproduced the event displays, not re-uploaded here.