### PR TITLE
Update T0 default to be in configuration fcl

### DIFF
--- a/sbndcode/JobConfigurations/base/prodsingle_sbnd.fcl
+++ b/sbndcode/JobConfigurations/base/prodsingle_sbnd.fcl
@@ -26,13 +26,6 @@
 
 #include "singles_sbnd.fcl"
 
-#include "larg4_sbnd.fcl"
-#include "ionandscint_sbnd.fcl"
-#include "PDFastSim_sbnd.fcl"
-#include "simdrift_sbnd.fcl"
-
-#include "detsimmodules_sbnd.fcl"
-
 #include "rootoutput_sbnd.fcl"
 
 
@@ -74,37 +67,11 @@ physics:
 
     # Generation
     generator: @local::sbnd_singlep
-
-    # A dummy module that forces the G4 physics list to be loaded
-    loader: { module_type: "PhysListLoader" }
-
-    # The geant4 step
-    largeant: @local::sbnd_larg4
-
-    # Creation of ionization electrons and scintillation photons, inside the active volume
-    ionandscint: @local::sbnd_ionandscint
-
-    # Light propogation inside the active volume
-    pdfastsim: @local::sbnd_pdfastsim_par
-
-    # Electron propogation
-    simdrift: @local::sbnd_simdrift
-
-    # Detector simulation
-    daq: @local::sbnd_simwire
   }
 
   #define the producer and filter modules for this path, order matters,
-  # simulate:  [ rns, generator, largeant, daq]
-  # simulate:  [ rns, generator ]
   simulate: [ rns
           , generator
-          , loader
-          , largeant
-          , ionandscint
-          , pdfastsim
-          , simdrift
-          , daq
         ]
 
   #define the output stream, there could be more than one if using filters
@@ -121,16 +88,8 @@ outputs:
 {
   out1:
   {
-              @table::sbnd_rootoutput # inherit shared settings
+    @table::sbnd_rootoutput # inherit shared settings
     fileName: "prodsingle_sbnd_%p-%tc.root" # default file name, can override from command line with -o or --output
-    outputCommands: [ "keep *_*_*_*"
-                    , "drop *_ionandscint__*" # Drop the IonAndScint w/ SCE offsets applied
-                    ]
   }
 }
 
-#
-# at the end of the configuration, we can override single parameters to reflect our needs:
-#
-physics.producers.generator.T0: [ 0 ]
-physics.producers.generator.Theta0XZ: [ 10 ]

--- a/sbndcode/LArSoftConfigurations/gen/singles_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/singles_sbnd.fcl
@@ -4,8 +4,11 @@ BEGIN_PROLOG
 
 sbnd_singlep: @local::standard_singlep
 
+# By default pad ot a vector if it is size 1
+physics.producers.generator.PadOutVectors: true
+
 # Particle generated at this time will appear in main drift window at trigger T0.
-physics.producers.generator.T0:     [  1.7e3  ] # us
+physics.producers.generator.T0:     [0] # us
 
 physics.producers.generator.P0:     [ -1.0 ]  # GeV/c
 physics.producers.generator.SigmaP: [ 0.0 ]  # GeV/c


### PR DESCRIPTION
## Description 
Updates T0 for particle gun generator to be defined in the configuration file, `singles_sbnd.fcl`. This will set the default time of each generated particle to 0. Also pad out vectors by default, so not every vector needs to be the same length. Also removed extra simulation stages not relevant to generating single particles.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [na] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [na] Does this affect the standard workflow? 

