### PR TITLE
Bug fix for running hitdumper without crt strip hits present

### DIFF
--- a/sbndcode/Commissioning/HitDumper_module.cc
+++ b/sbndcode/Commissioning/HitDumper_module.cc
@@ -581,9 +581,11 @@ void Hitdumper::analyze(const art::Event& evt)
     art::fill_ptr_vector(crtStripHitVector, crtStripHitHandle);
     _n_crt_strip_hits = crtStripHitVector.size();
   }
-  else
+  else {
     std::cout << "Failed to get sbnd::crt::CRTStripHit data product ("<<fCRTStripHitModuleLabel<<")." << std::endl;
-
+    _n_crt_strip_hits = 0;
+  }
+  
   if (_n_crt_strip_hits > _max_crt_strip_hits) _n_crt_strip_hits = _max_crt_strip_hits;
 
   ResetCRTStripHitVars();


### PR DESCRIPTION
Bug fix for running hit-dumper module with CRT strip hits present:   _n_crt_strip_hits is not initialised, then set to _max_crt_strip_hits in if statement at L589 resulting in seg-fault in subsequent loop 