### PR TITLE
Reco2 fcl reorganisation, bug fix

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -18,7 +18,7 @@ physics.producers:
     crttracks:      @local::crttrackproducer_data_sbnd
 }
 
-physics.reco2_sce: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, caloskimCalorimetry,
+physics.reco2: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, caloskimCalorimetry,
   crtclustering, crtspacepoints, crttracks ]
 
 physics.analyzers.caloskim.G4producer: ""


### PR DESCRIPTION
## Description 
Omitted removal of '_sce' from the reco2 data fcl in the fcl reorganisation.

## Checklist
- [x ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x ] Does this affect the standard workflow? 


