### PR TITLE
Keep raw::OpDetWaveforms after reco stages for data

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
@@ -22,3 +22,5 @@ physics.reco1: [sptpc2d, gaushit, cluster3d, crtstrips]
 physics.ana: [superadata]
 physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:gauss"
 physics.end_paths: ["stream1",ana]
+
+outputs.out1.outputCommands: [@sequence::sbnd_rootoutput.outputCommands, @sequence::sbnd_reco1_drops_keep_rawopdetwf]

--- a/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
@@ -21,7 +21,6 @@ physics.producers:
 physics.reco1: [sptpc2d, gaushit, numberofhitsfilter, cluster3d, crtstrips]
 physics.ana: [superadata]
 physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:gauss"
-physics.end_paths: ["stream1",ana]
 
 outputs.out1.SelectEvents: [ "reco1" ]
 outputs.out1.outputCommands: [@sequence::sbnd_rootoutput.outputCommands, @sequence::sbnd_reco1_drops_keep_rawopdetwf]

--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -25,3 +25,5 @@ physics.analyzers.caloskim.G4producer: ""
 physics.analyzers.caloskim.SimChannelproducer: ""
 physics.caloskimana_tpconly: [ caloskim ]
 physics.end_paths: [stream1, caloskimana_tpconly]
+
+outputs.out1.outputCommands: [@sequence::sbnd_rootoutput.outputCommands, @sequence::sbnd_reco1_drops_keep_rawopdetwf]


### PR DESCRIPTION
## Description 
Keep `raw::OpDetWaveforms` after reco1 and reco2 stage for data processing. 

Using `fhicl-dump` on the old vs. new `reco1_data.fcl`/`reco2_data.fcl` and `diff` gives: 
```
<          "drop raw::OpDetWaveforms_*_*_*",
```
confirming the only change is _not_ dropping `raw::OpDetWaveforms`. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [N/A] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [N/A] Does this affect the standard workflow? 

### Link(s) to docdb describing changes (optional)
No particular slides, but this PR follows discussion had after presentation at [docdb38577](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=38577).