### PR TITLE
CRT data fcl updates

### DIFF
--- a/sbndcode/CRT/CRTReco/crtrecoproducers_sbnd.fcl
+++ b/sbndcode/CRT/CRTReco/crtrecoproducers_sbnd.fcl
@@ -74,6 +74,6 @@ crttrackproducer_sbnd:
 crttrackproducer_data_sbnd: @local::crttrackproducer_sbnd
 crttrackproducer_data_sbnd.CRTGeoAlg:     @local::crtgeoalg_data_sbnd
 crttrackproducer_data_sbnd.UseTs0:        true
-crttrackproducer_data_sbnd.MaskedTaggers: [ 0 ]
+crttrackproducer_data_sbnd.MaskedTaggers: [ ]
 
 END_PROLOG

--- a/sbndcode/CRT/CRTReco/run_crtreco_data.fcl
+++ b/sbndcode/CRT/CRTReco/run_crtreco_data.fcl
@@ -12,4 +12,5 @@ physics.producers.crtspacepoints: @local::crtspacepointproducer_data_sbnd
 physics.producers.crttracks:      @local::crttrackproducer_data_sbnd
 
 outputs.out1.outputCommands: [ "keep *_*_*_*",
-                               "drop *_daq_*_*" ]
+                               "drop *_daq_*_*",
+                               "keep *_daq_RawEventHeader_*" ]


### PR DESCRIPTION
## Description 
Two minor changes to fcls relating to CRT data reconstruction.

1. Allow tracks to be made using the bottom CRT
      - This was turned off during some commissioning studies early on to reduce the reconstruction rate while we understood things further up our priority list. This can now be undone.
2. Don't drop the `RawEventHeader` objects in the CRT-only reco workflow.
      - We were dropping all the fragments from the event. We would like to retain this particular fragment as it allows us to undo timing referencing if we want to. Note, this _does not_ affect the standard data reconstruction workflow (`reco1_data.fcl` and `reco2_data.fcl`) where currently all fragments are being retained. This only impacts the CRT only workflow used internally by the CRT group.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
None

### Link(s) to docdb describing changes (optional)
None
