### PR TITLE
Modify SBNDOpHitFinder to allow for a channel-dependent threshold

### DIFF
--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -170,7 +170,7 @@ namespace opdet {
     // Initialize the hit finder algorithm
     // If we need to apply and individual threshold for each channel, set the algorithm threhsold to the lowest value
     auto hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
-    if(fUseIndividualHitThreshold) hit_alg_pset.put<double>("ADCThreshold", *min_element(fADCThresholdVector.begin(), fADCThresholdVector.end()));
+    if(fUseIndividualHitThreshold) hit_alg_pset.put_or_replace<double>("ADCThreshold", *min_element(fADCThresholdVector.begin(), fADCThresholdVector.end()));
     std::string threshAlgName = hit_alg_pset.get<std::string>("Name");
     if (threshAlgName == "Threshold")
       fThreshAlg = thresholdAlgorithm<pmtana::AlgoThreshold>(hit_alg_pset, rise_alg_pset);

--- a/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
+++ b/sbndcode/OpDetReco/OpHit/SBNDOpHitFinder_module.cc
@@ -91,7 +91,8 @@ namespace opdet {
     std::vector<std::string> _pd_to_use; ///< PDS to use (ex: "pmt", "barepmt")
     std::string fElectronics; ///< PDS readouts to use (ex: "CAEN", "Daphne")
     std::vector<int> _opch_to_use; ///< List of of opch (will be infered from _pd_to_use)
-
+    std::vector<double> fADCThresholdVector;
+    bool fUseIndividualHitThreshold;
     pmtana::PulseRecoManager  fPulseRecoMgr;
     pmtana::PMTPulseRecoBase* fThreshAlg;
     pmtana::PMTPedestalBase*  fPedAlg;
@@ -131,6 +132,9 @@ namespace opdet {
     fElectronics = pset.get< std::string >("Electronics");
     _opch_to_use = this->PDNamesToList(_pd_to_use);
 
+
+    fADCThresholdVector = pset.get< std::vector<double>>("ADCThresholdVector", {0});
+    fUseIndividualHitThreshold = pset.get< bool>("UseIndividualHitThreshold", false);
     fDaphne_Freq  = pset.get< float >("DaphneFreq");
     fHitThreshold = pset.get< float >("HitThreshold");
     bool useCalibrator = pset.get< bool > ("UseCalibrator", false);
@@ -164,7 +168,9 @@ namespace opdet {
     auto const rise_alg_pset = pset.get_if_present<fhicl::ParameterSet>("RiseTimeCalculator");
 
     // Initialize the hit finder algorithm
-    auto const hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
+    // If we need to apply and individual threshold for each channel, set the algorithm threhsold to the lowest value
+    auto hit_alg_pset = pset.get<fhicl::ParameterSet>("HitAlgoPset");
+    if(fUseIndividualHitThreshold) hit_alg_pset.put<double>("ADCThreshold", *min_element(fADCThresholdVector.begin(), fADCThresholdVector.end()));
     std::string threshAlgName = hit_alg_pset.get<std::string>("Name");
     if (threshAlgName == "Threshold")
       fThreshAlg = thresholdAlgorithm<pmtana::AlgoThreshold>(hit_alg_pset, rise_alg_pset);
@@ -318,6 +324,12 @@ namespace opdet {
     // Now correct the time. Unfortunately, there are no setter methods for OpHits,
     // so we have to make a new OpHit vector.
     for (auto h : *HitPtr) {
+      
+      // Apply individual threshold 
+      int channelNumber = h.OpChannel();
+      int PeakAmplitude = h.Amplitude();
+      if(fUseIndividualHitThreshold && (PeakAmplitude < fADCThresholdVector[channelNumber]) ) continue;
+
       (*HitPtrFinal).emplace_back(h.OpChannel(),
                                   h.PeakTime() + clockData.TriggerTime(),
                                   h.PeakTimeAbs(),

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -253,7 +253,7 @@ wpdir   product_dir     wire-cell-cfg
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-sbncode		v09_93_01_02       -
+sbncode		v09_93_01_01       -
 cetmodules	v3_24_01	-	only_for_build
 sbnd_data	v01_25_00	-	optional
 sbndutil	v09_93_01_01	-	optional

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -253,7 +253,7 @@ wpdir   product_dir     wire-cell-cfg
 #
 ####################################
 product		version		qual	flags		<table_format=2>
-sbncode		v09_93_01_01       -
+sbncode		v09_93_01_02       -
 cetmodules	v3_24_01	-	only_for_build
 sbnd_data	v01_25_00	-	optional
 sbndutil	v09_93_01_01	-	optional


### PR DESCRIPTION
## Description 

This PR modifies SBNDOpHitFinder to allow for a channel dependent ADCThreshold. This changes is made to mee the needs presented at [docdb-39495](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39495) . This is a **temporary** fix that runs the peak finding algorithm with the lowest ADCThreshold of the list and then only saves the OpHits that pass the ADCThreshold for each channel. Ideally, the peak finder algorithm should be run for each channel with and independent threshold, which is not possible with the current implementation of the algorithm in larana. [This PR]((https://github.com/LArSoft/larana/pull/36)) in larana implements the required changes to larana, but will require migrating sbndcode to larsoft v10. 

As soon as the larana PR is merged and sbndcode migrated to larsoft v10 this modification can be reverted and updated to match the definitive implementation.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
[docdb-39495](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39495)