### PR TITLE
Removing Gallery From CI

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -985,17 +985,17 @@ testlist=nucosmics_seq_test_sbndcode
 #  [4.1] Compilation tests
 # ------------------------------------------------------------------------------
 #
-
-[test compilation_test_sbndcode]
-
-cpu_usage_range=0:250
-mem_usage_range=10000:800000
-script=${SBNDCODE_DIR}/test/compileGalleryAnalysis.sh
-parse_art_output=False
-
-
-[suite gallery_test_sbndcode]
-testlist=compilation_test_sbndcode
+#
+#[test compilation_test_sbndcode]
+#
+#cpu_usage_range=0:250
+#mem_usage_range=10000:800000
+#script=${SBNDCODE_DIR}/test/compileGalleryAnalysis.sh
+#parse_art_output=False
+#
+#
+#[suite gallery_test_sbndcode]
+#testlist=compilation_test_sbndcode
 
 
 

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -986,16 +986,16 @@ testlist=nucosmics_seq_test_sbndcode
 # ------------------------------------------------------------------------------
 #
 #
-#[test compilation_test_sbndcode]
-#
-#cpu_usage_range=0:250
-#mem_usage_range=10000:800000
-#script=${SBNDCODE_DIR}/test/compileGalleryAnalysis.sh
-#parse_art_output=False
-#
-#
-#[suite gallery_test_sbndcode]
-#testlist=compilation_test_sbndcode
+[test compilation_test_sbndcode]
+
+cpu_usage_range=0:250
+mem_usage_range=10000:800000
+script=${SBNDCODE_DIR}/test/compileGalleryAnalysis.sh
+parse_art_output=False
+
+
+[suite gallery_test_sbndcode]
+testlist=compilation_test_sbndcode
 
 
 
@@ -1045,7 +1045,8 @@ parse_art_output=False
 # Includes single particle and data-like.
 # 
 [suite develop_test_sbndcode]
-testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
+#testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
+testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode fcl_checks_sbndcode
 
 
 ### 
@@ -1073,7 +1074,8 @@ testlist=generate_reference_single_test_sbndcode generate_reference_nucosmics_te
 # This suite is intended mainly to "test the tests", and may include redundant tests.
 #
 [suite all_tests_sbndcode]
-testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode single_seq_test_sbndcode nucosmics_seq_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
+#testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode single_seq_test_sbndcode nucosmics_seq_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
+testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode single_seq_test_sbndcode nucosmics_seq_test_sbndcode fcl_checks_sbndcode
 
 
 #############################################################

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -985,7 +985,6 @@ testlist=nucosmics_seq_test_sbndcode
 #  [4.1] Compilation tests
 # ------------------------------------------------------------------------------
 #
-#
 [test compilation_test_sbndcode]
 
 cpu_usage_range=0:250

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -1044,6 +1044,7 @@ parse_art_output=False
 # Includes single particle and data-like.
 # 
 [suite develop_test_sbndcode]
+# Remove gallery checks until geometry refactoring is complete
 #testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
 testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode fcl_checks_sbndcode
 

--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -1074,6 +1074,7 @@ testlist=generate_reference_single_test_sbndcode generate_reference_nucosmics_te
 # This suite is intended mainly to "test the tests", and may include redundant tests.
 #
 [suite all_tests_sbndcode]
+# Remove gallery checks until geometry refactoring is complete
 #testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode single_seq_test_sbndcode nucosmics_seq_test_sbndcode gallery_test_sbndcode fcl_checks_sbndcode
 testlist=single_quick_test_sbndcode nucosmics_quick_test_sbndcode single_seq_test_sbndcode nucosmics_seq_test_sbndcode fcl_checks_sbndcode
 


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

With the refactoring of LArSoft's geometry the handling in gallery C++ and python code has been broken. This is causing the CI tests to fail. This PR disables that test until we can fix it by refactoring the code in the long term. 

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
