### PR TITLE
Adding fcls for Production

### DIFF
--- a/sbndcode/JobConfigurations/base/detsim_drops.fcl
+++ b/sbndcode/JobConfigurations/base/detsim_drops.fcl
@@ -17,9 +17,12 @@
 
 BEGIN_PROLOG
 
-detsim_drops: [ @sequence::g4_drops,
-                "drop sim::SimPhotonsLites_*_*_*",
-                "drop sim::SimPhotons_*_*_*" ]
+detsim_drops: [ @sequence::g4_drops
+                , "drop sim::SimPhotonsLites_*_*_*"
+                , "drop sim::SimPhotons_*_*_*" 
+                , "drop sim::SimEnergyDeposits_ionandscintout__*"
+                , "drop sim::SimEnergyDeposits_ionandscint_*_*"
+                , "drop sim::SimEnergyDeposits_largeant_*_*"]
 
 END_PROLOG
 

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_fullosc_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_fullosc_sce.fcl
@@ -1,0 +1,5 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_sbnd.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"
+
+physics.producers.generator.MixerConfig:     "map 12:14 -12:-14 14:12 -14:-12"

--- a/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_intrnue_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/overlay/prodoverlay_corsika_cosmics_proton_genie_rockbox_intrnue_sbnd_sce.fcl
@@ -1,0 +1,3 @@
+#include "prodoverlay_corsika_cosmics_proton_genie_rockbox_intrnue_sbnd.fcl"
+
+#include "enable_spacecharge_services_sbnd_2D_DriftSimOnly.fcl"

--- a/sbndcode/JobConfigurations/standard/reco/config/drops_reco1.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/drops_reco1.fcl
@@ -5,7 +5,7 @@
 BEGIN_PROLOG
 
 sbnd_reco1_ml_drops: [
-#    "drop *_cluster3d_*_*" #drop all mlreco output
+    "drop *_cluster3d_*_*" #drop all mlreco output
   , "drop *_sedlite_*_*" #drop all mlreco output
   , "drop *_simplemerge_*_*" #drop all mlreco output
 ]


### PR DESCRIPTION
## Description 
This adds the functionality to run full osc and intrinsic nue samples with the space-charge hack. 

It also includes `drop` commands *into our standard workflow* to reduce our `reco1` file-size from 130 MB/event to 20 MB/event. 

I tested these through the [full workflows](https://docs.google.com/document/d/11Hdo6z2nMWi5fefFN_-TbtyaOFcm7rPL5cDKQ6HoTaA/edit?usp=sharing) and things worked. 

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? *yes!*

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
Nope. 

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
