### PR TITLE
Drop Wire Cell badchannel and badmask From CI for now

### DIFF
--- a/test/ci/sbnd_ci_single_detsim_quick_test_sbndcode.fcl
+++ b/test/ci/sbnd_ci_single_detsim_quick_test_sbndcode.fcl
@@ -2,3 +2,11 @@
 
 services.NuRandomService.policy: "perEvent"
 
+
+#Adding these drops because the WireCell Toolkit simulation
+# is not deterministic, but they would like to keep these 
+# in main production to further develop.
+outputs.out1.outputCommands: [ "keep *_*_*_*"
+                               ,"*_simtpc2d_badmasks_*"
+                               ,"*_simtpc2d_badchannels_*"
+                           ]


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

This PR adds some drop commands to the CI so that it does not check the output of the WireCell internal data-products that are unused by the standard workflows. 

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? *No*

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
This is stand alone.

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
Nope