### PR TITLE
Add possible HLTs for CRT time referencing

### DIFF
--- a/sbndcode/CRT/CRTReco/crtrecoproducers_sbnd.fcl
+++ b/sbndcode/CRT/CRTReco/crtrecoproducers_sbnd.fcl
@@ -29,7 +29,7 @@ crtstriphitproducer_data_sbnd.RawTSCorrection:           367000
 crtstriphitproducer_data_sbnd.MaxAllowedRefTimeDiff:     3000000
 crtstriphitproducer_data_sbnd.SPECTDCModuleLabel:        "tdcdecoder"
 crtstriphitproducer_data_sbnd.PTBModuleLabel:            "ptbdecoder"
-crtstriphitproducer_data_sbnd.AllowedPTBHLTs:            [ 1, 2, 3, 4, 5 ]
+crtstriphitproducer_data_sbnd.AllowedPTBHLTs:            [ 1, 2, 3, 4, 5, 14, 15 ]
 
 crtclusterproducer_sbnd:
 {


### PR DESCRIPTION
## Description 
Following discussion with Tereza & Lynn these trigger types should also be added as legitimate event triggers.

They correspond to NS & EW crossing muon triggers (originally we thought we had covered this with 5).
Relevant documentation is here: https://cdcvs.fnal.gov/redmine/projects/sbnd/wiki/Trigger_Type_Definitions

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
