### PR TITLE
Add saving picosecond value in decoded TDC

### DIFF
--- a/sbndcode/Decoders/SPECTDC/SPECTDCDecoder_module.cc
+++ b/sbndcode/Decoders/SPECTDC/SPECTDCDecoder_module.cc
@@ -100,7 +100,7 @@ sbnd::timing::DAQTimestamp SPECTDCDecoder::FragToDAQTimestamp(const artdaq::Frag
   const sbndaq::TDCTimestampFragment tdcFrag = sbndaq::TDCTimestampFragment(frag);
   const sbndaq::TDCTimestamp         *tdcTS  = tdcFrag.getTDCTimestamp();
 
-  return sbnd::timing::DAQTimestamp(tdcTS->vals.channel, tdcTS->timestamp_ns(), 0, tdcTS->vals.name);
+  return sbnd::timing::DAQTimestamp(tdcTS->vals.channel, tdcTS->timestamp_ns(), 0, tdcTS->vals.name, tdcTS->picoseconds());
 }
 
 DEFINE_ART_MODULE(SPECTDCDecoder)


### PR DESCRIPTION
## Description 
The fix introduces a new variable `timestampPs` in the decoded TDC object `sbnd::timing::DAQTimestamp` located in sbnobj repo.

It also enables the TDC decoder to save the new variable in the decoding process.

If analyser want to access the new variable `timestampPs` in an older version of  sbnd::timing::DAQTimestamp, it is defaulted to be 0 to prevent breaking in backward compatability.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
[sbnobj PR#121](https://github.com/SBNSoftware/sbnobj/pull/121)

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
