### PR TITLE
Updating Clock to the New Porch Size

### DIFF
--- a/sbndcode/Utilities/detectorclocks_sbnd.fcl
+++ b/sbndcode/Utilities/detectorclocks_sbnd.fcl
@@ -13,7 +13,7 @@ sbnd_detectorclocks: @local::standard_detectorclocks
 
 sbnd_detectorclocks.TrigModuleName:     "triggersim"
 sbnd_detectorclocks.InheritClockConfig: true
-sbnd_detectorclocks.TriggerOffsetTPC:   -0.2e3  # Time [us] for TPC readout start w.r.t. trigger time
+sbnd_detectorclocks.TriggerOffsetTPC:   -0.205e3  # Time [us] for TPC readout start w.r.t. trigger time
 sbnd_detectorclocks.FramePeriod:        1.3e3   # Frame period [us]
 sbnd_detectorclocks.ClockSpeedTPC:      2.      # TPC clock speed in MHz
 sbnd_detectorclocks.ClockSpeedOptical:  500.    # Optical clock speed in MHz

--- a/sbndcode/WireCell/cfg/pgrapher/common/params.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/common/params.jsonnet
@@ -156,6 +156,11 @@ local wc = import "wirecell.jsonnet";
     // Parameters related to simulation, not given elsewhere.
     sim : {
 
+        // The "absolute" time (ie, relative to trigger time?) that the lower edge
+        // of final readout tick #0 should correspond to.  This is a
+        // "fixed" notion.
+        tick0_time: 0,
+
         // The number of impact bins per wire region gives the
         // granularity of the simulation convolution in the transverse
         // dimension.  Typically should match what the granularity at

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
@@ -120,6 +120,11 @@ base {
         // For running in LArSoft, the simulation must be in fixed time mode. 
         fixed: true,
 
+        // The "absolute" time (ie, relative to trigger time?) that the lower edge
+        // of final readout tick #0 should correspond to.
+        // this is the default value unless overridden with extVar in main
+        tick0_time: -200 * wc.us,
+
         // Open the ductor's gate a bit early.
         local response_time_offset = $.det.response_plane / $.lar.drift_speed,
         local response_nticks = wc.roundToInt(response_time_offset / $.daq.tick),

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
@@ -123,7 +123,7 @@ base {
         // The "absolute" time (ie, relative to trigger time?) that the lower edge
         // of final readout tick #0 should correspond to.
         // this is the default value unless overridden with extVar in main
-        tick0_time: -200 * wc.us,
+        tick0_time: -205 * wc.us,
 
         // Open the ductor's gate a bit early.
         local response_time_offset = $.det.response_plane / $.lar.drift_speed,

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet
@@ -120,11 +120,6 @@ base {
         // For running in LArSoft, the simulation must be in fixed time mode. 
         fixed: true,
 
-        // The "absolute" time (ie, relative to trigger time?) that the lower edge
-        // of final readout tick #0 should correspond to.  This is a
-        // "fixed" notion.
-        local tick0_time = -205*wc.us, // updated in January 2025, front porch in data = 410 ticks
-
         // Open the ductor's gate a bit early.
         local response_time_offset = $.det.response_plane / $.lar.drift_speed,
         local response_nticks = wc.roundToInt(response_time_offset / $.daq.tick),
@@ -132,7 +127,7 @@ base {
         ductor : {
             nticks: $.daq.nticks + response_nticks,
             readout_time: self.nticks * $.daq.tick,
-            start_time: tick0_time - response_time_offset,
+            start_time: $.sim.tick0_time - response_time_offset,
         },
 
         // To counter the enlarged duration of the ductor, a Reframer

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/simparams.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/simparams.jsonnet
@@ -76,13 +76,6 @@ base {
     continuous: false,
     fluctuate: false,
 
-    // The "absolute" time (ie, relative to trigger time?) that the lower edge
-    // of final readout tick #0 should correspond to.  This is a
-    // "fixed" notion.
-    // note: should be overriden by extVar in main jsonnet to maintain consistency
-    // with the larsoft clock service
-    local tick0_time = -200*wc.us, 
-
     //ductor : super.ductor {
     //    start_time: $.daq.start_time - $.elec.fields.drift_dt + $.trigger.time,
     //},

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/simparams.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/simparams.jsonnet
@@ -76,6 +76,13 @@ base {
     continuous: false,
     fluctuate: false,
 
+    // The "absolute" time (ie, relative to trigger time?) that the lower edge
+    // of final readout tick #0 should correspond to.  This is a
+    // "fixed" notion.
+    // note: should be overriden by extVar in main jsonnet to maintain consistency
+    // with the larsoft clock service
+    local tick0_time = -200*wc.us, 
+
     //ductor : super.ductor {
     //    start_time: $.daq.start_time - $.elec.fields.drift_dt + $.trigger.time,
     //},

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -28,6 +28,10 @@ local params = base {
     // Electron drift speed, assumes a certain applied E-field
     drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
   },
+  sim: super.sim {
+    // front porch size [us]
+    tick0_time: std.extVar('tick0_time') * wc.us,
+  }
 };
 
 local tools = tools_maker(params);

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -1,3 +1,4 @@
+#include "detectorclocks_sbnd.fcl"
 BEGIN_PROLOG
 
 sbnd_wcls: { 
@@ -68,6 +69,8 @@ sbnd_wcls_simsp.wcls_main.structs:  {
                                      lifetime: 100.0
                                      ## Electron drift speed, assumes 0.5 kV/cm and 88.4 K. Units: mm/us
                                      driftSpeed: 1.563
+                                     ## simulated front porch size [us]
+                                     tick0_time: @local::sbnd_detectorclocks.TriggerOffsetTPC
                                     }
 
 # ------------------------------------------------------------------------------------ #


### PR DESCRIPTION
## Description 
The front porch in our drift simulation was changed to be -205 us to match data here:
https://github.com/SBNSoftware/sbndcode/blob/6ca9a98ec859cf51bd568f08b0d7b8bb17a3920f/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/params.jsonnet#L126

I have updated our detector clock service to have a matching time. This being out of sync was leading to our "truth matching" in the CAF files to fail. 

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [X] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? *Yes*

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
Before we really notice this we'll need LArWireCell#55 which gives us SimChannels

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
