### PR TITLE
Add fcls to run OpT0Finder on data

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -1,5 +1,6 @@
 #include "crt_channel_map_service.fcl"
 #include "crt_calib_service.fcl"
+#include "opt0finder_sbnd_data.fcl"
 #include "standard_reco2_sbnd.fcl"
 
 services:
@@ -16,10 +17,12 @@ physics.producers:
     crtclustering:  @local::crtclusterproducer_data_sbnd
     crtspacepoints: @local::crtspacepointproducer_data_sbnd
     crttracks:      @local::crttrackproducer_data_sbnd
+    opt0finder:     @local::sbnd_opt0_finder_data
 }
 
 physics.reco2: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, caloskimCalorimetry,
-  crtclustering, crtspacepoints, crttracks]
+  crtclustering, crtspacepoints, crttracks,
+  opt0finder]
 #  crtclustering, crtspacepoints, crttracks, cvn ]
 
 physics.analyzers.caloskim.G4producer: ""

--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -21,9 +21,7 @@ physics.producers:
 }
 
 physics.reco2: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, caloskimCalorimetry,
-  crtclustering, crtspacepoints, crttracks,
-  opt0finder]
-#  crtclustering, crtspacepoints, crttracks, cvn ]
+  crtclustering, crtspacepoints, crttracks, opt0finder]
 
 physics.analyzers.caloskim.G4producer: ""
 physics.analyzers.caloskim.SimChannelproducer: ""

--- a/sbndcode/OpT0Finder/job/opt0finder_sbnd.fcl
+++ b/sbndcode/OpT0Finder/job/opt0finder_sbnd.fcl
@@ -70,17 +70,6 @@ sbnd_opt0_finder_one_to_many.FlashMatchConfig.QLLMatch.ChiErrorWidth:      0.1  
 sbnd_opt0_finder_one_to_many.FlashMatchConfig.QLLMatch.UseMinuit:          false   # do not perform minimiziation!!; Minuit not needed for one-to-many matching
 sbnd_opt0_finder_one_to_many.FlashMatchConfig.QLLMatch.SaturatedThreshold: 2.5e3   # fix for saturated PMTs, determines when to evaluate non-linearities 
 
-# ... for TPC 0
-sbnd_opt0_finder_one_to_many_tpc0: @local::sbnd_opt0_finder_one_to_many
-sbnd_opt0_finder_one_to_many_tpc0.TPC: 0
-sbnd_opt0_finder_one_to_many_tpc0.OpFlashProducer: ["opflashtpc0","opflashtpc0xarapuca"]
-
-# ... for TPC 1
-sbnd_opt0_finder_one_to_many_tpc1: @local::sbnd_opt0_finder_one_to_many
-sbnd_opt0_finder_one_to_many_tpc1.TPC: 1
-sbnd_opt0_finder_one_to_many_tpc1.OpFlashProducer: ["opflashtpc1","opflashtpc1xarapuca"]
-
-
 # WARNING: many-to-many matching is untested, performance unknown! 
 #
 # Configuration to run the flash matching in many flashes to many slices configuration

--- a/sbndcode/OpT0Finder/job/opt0finder_sbnd_data.fcl
+++ b/sbndcode/OpT0Finder/job/opt0finder_sbnd_data.fcl
@@ -5,14 +5,18 @@ BEGIN_PROLOG
 sbnd_opt0_finder_data: @local::sbnd_opt0_finder_one_to_many
 
 sbnd_opt0_finder_data.CaloProducer:     "pandoraCaloData"
-sbnd_opt0_finder_data.SelectNeutrino:   false # for data, unsure about trusting pandora to select neutrinos
+sbnd_opt0_finder_data.SelectNeutrino:   true 
 sbnd_opt0_finder_data.CalAreaConstants: [ 0.0204 , 0.0210, 0.0193 ]
-sbnd_opt0_finder_data.OpChannelsToSkip: [39, 66, 67, 69, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302, # OFF/uncalibrated PMTs
-                                        134,135,150,151,152,153,154,155,156,157,158,159,160,161,176,177] # APSIA channels
+sbnd_opt0_finder_data.OpChannelsToSkip: [39, 66, 67, 69, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302]
+# since the flash time is w.r.t the TDC ETRIG, this may move with light arrival; need to extend the flash window
 sbnd_opt0_finder_data.FlashVetoTimeStart: -1
 sbnd_opt0_finder_data.FlashVetoTimeEnd:    5
 
-# set to arbitrary high value to ignore saturation correction until we know it better
+sbnd_opt0_finder_data.FlashMatchConfig.QLLMatch.ChiErrorWidth: 0.25 # increase the error width from 0.1
+sbnd_opt0_finder_data.FlashMatchConfig.PhotonLibHypothesis.GlobalQE:     0.25 # effectively a global scaling factor
+sbnd_opt0_finder_data.FlashMatchConfig.PhotonLibHypothesis.GlobalQERefl: 0.25 # effectively a global scaling factor
+
+# set to arbitrary high value to ignore non-linearity correction until we know it better
 sbnd_opt0_finder_data.FlashMatchConfig.QLLMatch.SaturatedThreshold: 1e9  
 
 END_PROLOG

--- a/sbndcode/OpT0Finder/job/opt0finder_sbnd_data.fcl
+++ b/sbndcode/OpT0Finder/job/opt0finder_sbnd_data.fcl
@@ -1,0 +1,18 @@
+#include "opt0finder_sbnd.fcl"
+
+BEGIN_PROLOG
+
+sbnd_opt0_finder_data: @local::sbnd_opt0_finder_one_to_many
+
+sbnd_opt0_finder_data.CaloProducer:     "pandoraCaloData"
+sbnd_opt0_finder_data.SelectNeutrino:   false # for data, unsure about trusting pandora to select neutrinos
+sbnd_opt0_finder_data.CalAreaConstants: [ 0.0204 , 0.0210, 0.0193 ]
+sbnd_opt0_finder_data.OpChannelsToSkip: [39, 66, 67, 69, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302, # OFF/uncalibrated PMTs
+                                        134,135,150,151,152,153,154,155,156,157,158,159,160,161,176,177] # APSIA channels
+sbnd_opt0_finder_data.FlashVetoTimeStart: -1
+sbnd_opt0_finder_data.FlashVetoTimeEnd:    5
+
+# set to arbitrary high value to ignore saturation correction until we know it better
+sbnd_opt0_finder_data.FlashMatchConfig.QLLMatch.SaturatedThreshold: 1e9  
+
+END_PROLOG

--- a/sbndcode/OpT0Finder/job/run_opt0finder_sbnd_data.fcl
+++ b/sbndcode/OpT0Finder/job/run_opt0finder_sbnd_data.fcl
@@ -1,0 +1,83 @@
+#include "services_sbnd.fcl"
+#include "simulationservices_sbnd.fcl"
+#include "messages_sbnd.fcl"
+#include "sam_sbnd.fcl"
+
+#include "opt0finder_sbnd_data.fcl"
+#include "opt0finderana_sbnd.fcl"
+
+process_name: OpT0Finder
+
+services:
+{
+  # Load the service that manages root files for histograms.
+  TFileService:              { fileName: "opt0finder_tree.root" }
+  RandomNumberGenerator:     {}
+  message:                   @local::sbnd_message_services_prod # from messages_sbnd.fcl
+  FileCatalogMetadata:       @local::sbnd_file_catalog_mc       # from sam_sbnd.fcl
+                             @table::sbnd_services              # from services_sbnd.fcl
+                             @table::sbnd_g4_services
+}
+
+
+#source is now a root file
+source:
+{
+  module_type: RootInput
+  maxEvents:  -1  # Number of events to create
+}
+
+
+#block to define where the output goes.  if you defined a filter in the physics
+#block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
+#entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
+outputs:
+{
+  out1:
+  {
+    module_type: RootOutput
+    fileName:    "opt0finder-art.root"
+    dataTier:    "reconstructed"
+    compressionLevel: 1
+    SelectEvents: ["reco"]
+ }
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+  producers:
+  {
+    opt0finder:    @local::sbnd_opt0_finder_data
+  }
+
+  analyzers:
+  {
+    opt0finderana:     @local::sbnd_opt0_finder_ana
+  }
+
+
+  #define the producer and filter modules for this path, order matters,
+  #filters reject all following items.  see lines starting physics.producers below
+  reco: [
+    opt0finder
+  ]
+
+  ana: [
+    opt0finderana
+  ]
+
+  # define the output stream, there could be more than one if using filters
+  stream1: [out1]
+
+  # trigger_paths is a keyword and contains the paths that modify the art::event,
+  # ie filters and producers
+  trigger_paths: [reco]
+
+  # end_paths is a keyword and contains the paths that do not modify the art::Event,
+  # ie analyzers and output streams.  these all run simultaneously
+  end_paths: [ana, stream1]
+}
+


### PR DESCRIPTION
## Description 
Adds new fcl blocks to including running OpT0Finder in data reco2 stage. This is meant to be a first-pass inclusion of flash-matching for data; more validation and testing to come! 

This may increase the number of OpT0Finder matches in simulation; a requirement on the neutrino-likeness of a `recob::Slice` has been loosened (we now accept anything that is not a clear cosmic, rather than requiring that the reco chain has identified a specific neutrino type within a given slice). 

### Data configurations to note: 
- global scaling from 1.0 -> 0.25 to match approximate light yield seen in data. 
- The allowed time range for in-beam light is currently -1 to 5 us; the reference time for BNB+Light streams is the SPEC TDC ETRIG, which may move with light arrival time (t=0 is not aligned with the beam acceptance), so I increase the time range available. 
- should have interfacing with the calibration database in the near future to grab TPC gain calibration constants and PMT channel numbers to mask. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [N/A] Linked any relevant issues under `Developement`
- [N/A] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Link(s) to docdb describing changes (optional)
Some data/MC plots shown during 2025 SBND Analysis workshop ([docdb40138](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40138)) and December 2024 Collaboration meeting ([docdb39278](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=39278)).