### PR TITLE
Revert "Save pedestal and RMS calculation in ChannelInfo object per TPC channel."

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder.h
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder.h
@@ -94,9 +94,6 @@ private:
   Config _config;
 
   void getMedianSigma(const std::vector<int16_t> &v_adc, float &median, float &sigma);
-  float getEvenFraction(const std::vector<int16_t> &v_adc) const;
-  float getxBADFraction(const std::vector<int16_t> &v_adc) const;
-
 
 };
 


### PR DESCRIPTION
## Description
Reverts SBNSoftware/sbndcode#642. Wasn't ready due to missing https://github.com/SBNSoftware/sbnobj/pull/120.