### PR TITLE
Revert "Revert "Save pedestal and RMS calculation in ChannelInfo object per TPC channel.""

### DIFF
--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder.h
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder.h
@@ -94,6 +94,9 @@ private:
   Config _config;
 
   void getMedianSigma(const std::vector<int16_t> &v_adc, float &median, float &sigma);
+  float getEvenFraction(const std::vector<int16_t> &v_adc) const;
+  float getxBADFraction(const std::vector<int16_t> &v_adc) const;
+
 
 };
 

--- a/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
+++ b/sbndcode/Decoders/TPC/SBNDTPCDecoder_module.cc
@@ -34,6 +34,7 @@
 #include "sbndaq-artdaq-core/Overlays/SBND/NevisTPCFragment.hh"
 #include "sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCTypes.hh"
 #include "sbndaq-artdaq-core/Overlays/SBND/NevisTPC/NevisTPCUtilities.hh"
+#include "sbnobj/Common/Analysis/TPCChannelInfo.hh"
 
 
 DEFINE_ART_MODULE(daq::SBNDTPCDecoder)
@@ -77,6 +78,7 @@ daq::SBNDTPCDecoder::SBNDTPCDecoder(fhicl::ParameterSet const & param):
   produces<RawDigits>();
   produces<RDTimeStamps>();
   produces<RDTsAssocs>();
+  produces<std::vector<anab::TPCChannelInfo>>();
   if (_config.produce_header) {
     produces<std::vector<tpcAnalysis::TPCDecodeAna>>();
   }
@@ -113,6 +115,7 @@ void daq::SBNDTPCDecoder::produce(art::Event & event)
   std::unique_ptr<RawDigits> rawdigit_collection(new RawDigits);
   std::unique_ptr<RDTimeStamps> rdts_collection(new RDTimeStamps);
   std::unique_ptr<RDTsAssocs> rdtsassoc_collection(new RDTsAssocs);
+  std::unique_ptr<std::vector<anab::TPCChannelInfo>> channeldata_collection(new std::vector<anab::TPCChannelInfo>);
   std::unique_ptr<std::vector<tpcAnalysis::TPCDecodeAna>> header_collection(new std::vector<tpcAnalysis::TPCDecodeAna>);
 
   if ( daq_handle.isValid() ) {
@@ -125,10 +128,16 @@ void daq::SBNDTPCDecoder::produce(art::Event & event)
       mf::LogWarning("SBNDTPCDecoder_module") <<  " Invalid fragment handle: Skipping TPC digit decoding";
     }
 
+  for (const raw::RawDigit &r: *rawdigit_collection) {
+    anab::TPCChannelInfo i {r.Channel(), r.GetPedestal(), r.GetSigma(), getEvenFraction(r.ADCs()), getxBADFraction(r.ADCs())};
+    channeldata_collection->push_back(i);
+  }
+
   
   event.put(std::move(rawdigit_collection));
   event.put(std::move(rdts_collection));
   event.put(std::move(rdtsassoc_collection));
+  event.put(std::move(channeldata_collection));
 
   if (_config.produce_header) {
     event.put(std::move(header_collection));
@@ -219,6 +228,23 @@ uint32_t daq::SBNDTPCDecoder::compute_checksum(sbndaq::NevisTPCFragment &fragmen
 
 }
 
+float daq::SBNDTPCDecoder::getxBADFraction(const std::vector<int16_t> &v_adc) const {
+  int n_bad = 0;
+  for (int16_t s: v_adc) {
+    if (s == 0xBAD) n_bad += 1;
+  }
+  return ((float)n_bad) / v_adc.size();
+  
+}
+
+float daq::SBNDTPCDecoder::getEvenFraction(const std::vector<int16_t> &v_adc) const {
+  int n_even = 0;
+  for (int16_t s: v_adc) {
+    if (s % 2 == 0) n_even += 1;
+  }
+  return ((float)n_even) / v_adc.size();
+  
+}
 
 
 void daq::SBNDTPCDecoder::getMedianSigma(const std::vector<int16_t> &v_adc, float &median,


### PR DESCRIPTION
## Description 

This enables retrieval of the two metrics from files where the RawDigit object is dropped. These metrics are necessary for identifying the presence of CE noise per-half-board per-event.

Depends on https://github.com/SBNSoftware/sbnobj/pull/120.