### PR TITLE
Add fcl configuration TwoBodyAnisotropyIncludeInterference to match s…

### DIFF
--- a/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MeVPrtl/hnl_config.fcl
@@ -46,7 +46,8 @@ decay_hnl: {
   tool_type: HNLMakeDecay
   Decays: ["mu_pi"]
   Majorana: true
-  DecayIsThreeBodyAnisotropic: false
+  DecayIsThreeBodyAnisotropic: true
+  TwoBodyAnisotropyIncludeInterference: false
   ReferenceUE4: 0
   ReferenceUT4: 0
   ReferenceUM4: 1e-7


### PR DESCRIPTION
Commit to match lastest changes to sbncode MeVprtlGen. The fhicl configuration parameter TwoBodyAnisotropyIncludeInterference is added. Not adding this parameter into the configuration fhicl makes the generator code to crash and not generate any input. ThreeBodyAnisotropies are also turned on by default.

The relevant sbncode pull request is:
https://github.com/SBNSoftware/sbncode/pull/502