### PR TITLE
Adding caloskim RawDigitproducers labels

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco2_data_rawdigit_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data_rawdigit_sbnd.fcl
@@ -3,6 +3,7 @@
 analyzers.caloskim: @local::caloskim_nodigits_goldentracks
 
 physics.analyzers.caloskim.SelectionTools: []
+physics.analyzers.caloskim.RawDigitproducers: ["daq"]
 physics.analyzers.caloskim.RequireT0: false
 physics.analyzers.caloskim.HitRawDigitsTickCollectWidth: 200
 

--- a/sbndcode/JobConfigurations/standard/reco/reco2_mc_rawdigit_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_mc_rawdigit_sbnd.fcl
@@ -1,6 +1,8 @@
 #include "standard_reco2_sbnd.fcl"
-#
+
 analyzers.caloskim: @local::caloskim_nodigits_goldentracks
+
+physics.analyzers.caloskim.RawDigitproducers: ["simtpc2d:daq"]
 
 physics.analyzers.caloskim.SelectionTools: []
 physics.analyzers.caloskim.RequireT0: false


### PR DESCRIPTION
## Description 
This is for the workflow with raw digits. 
In the test production raw digits are saved in reco1 and reco2 files, but not in calib ntuple. It turned out the reco2 fcl miss the RawDigitproducers labels for caloskim. This fcl patches that. This fcl is needed for the 2025 Feb workshop production.

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
