### PR TITLE
TEMPORARY CHANGE: Disable vertex refinement in pandora

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -91,11 +91,11 @@
     <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
     <EnableCrossingCandidates>false</EnableCrossingCandidates>
   </algorithm>
-  <algorithm type = "LArVertexRefinement">
+  <!--<algorithm type = "LArVertexRefinement">
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     <InputVertexListName>CandidateVertices3D</InputVertexListName>
     <OutputVertexListName>RefinedVertices3D</OutputVertexListName>
-  </algorithm>
+  </algorithm>-->
   <algorithm type = "LArBdtVertexSelection">
     <InputCaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</InputCaloHitListNames>
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
@@ -460,7 +460,8 @@
   <!-- Output list management -->
   <algorithm type = "LArPostProcessing">
     <PfoListNames>NeutrinoParticles3D TrackParticles3D ShowerParticles3D</PfoListNames>
-    <VertexListNames>NeutrinoVertices3D DaughterVertices3D RefinedVertices3D</VertexListNames>
+    <!--<VertexListNames>NeutrinoVertices3D DaughterVertices3D RefinedVertices3D</VertexListNames>-->
+    <VertexListNames>NeutrinoVertices3D DaughterVertices3D CandidateVertices3D</VertexListNames>
     <ClusterListNames>ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</ClusterListNames>
     <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
     <CurrentPfoListReplacement>NeutrinoParticles3D</CurrentPfoListReplacement>


### PR DESCRIPTION
## Description 
This PR disables the vertex refinement in SBND's pandora workflow.  This is a temporary change while an upstream larcontent issue is resolved.
This PR will mean vertex positions are less precise, but otherwise should not impact the downstream reco.
Thanks @henrylay97 for helping to understand the disabling procedure.


## Checklist
- [x ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x ] Assigned at least 1 reviewer under `Reviewers`,
- [x ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)


### Link(s) to docdb describing changes (optional)

