### PR TITLE
Use doublets in Cluster3D

### DIFF
--- a/sbndcode/LArSoftConfigurations/cluster_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/cluster_sbnd.fcl
@@ -3,7 +3,7 @@
 BEGIN_PROLOG
 
 sbnd_cluster3d: @local::sbn_cluster3d
-sbnd_cluster3d.Hit3DBuilderAlg.SaveMythicalPoints: false
+sbnd_cluster3d.Hit3DBuilderAlg.SaveMythicalPoints: true #true = doublets, false = triplets
 sbnd_cluster3d.MakeSpacePointsOnly: true
 
 END_PROLOG


### PR DESCRIPTION
## Description 
Use doublets instead of triplets. 4-5x larcv file size, increases RAM useage.

### Space
2.4 GB -> 12 GB for 1k MPVMPR events

### RAM
Doublets:
- Peak virtual memory usage (VmPeak)  : 5729.37 MB
- Peak resident set size usage (VmHWM): 4295.55 MB
Triplets: 
- Peak virtual memory usage (VmPeak)  : 3292.9 MB
- Peak resident set size usage (VmHWM): 1934.36 MB


## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [na] Linked any relevant issues under `Developement`
- [na] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
~~Depends on [Supera PR](https://github.com/DeepLearnPhysics/Supera/pull/53) , which needs a `sbncode` PR.~~

### Link(s) to docdb describing changes (optional)
docDB [32034](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=32034), docDB [40099](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40099)

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/3c8fa96f-67ea-4229-aa7a-94c413d0d82e" alt="sbnd_purity_efficiency_points" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/3322fac0-0190-4abf-bd3a-91ceba4e61fb" alt="sbnd_sim_track_missing_length_vs_vx" width="400"/></td>
  </tr>
  <tr>
    <td colspan="2" style="text-align: center;">Triplet space points, using sbndcode v10_04_03 for MPMVPR sample and optimized ghost labeling parameters.</td>
  </tr>
</table>

<table>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/b88c8b23-15eb-4cb1-9d49-6231176e72c2" alt="sbnd_purity_efficiency_points" width="400"/></td>
    <td><img src="https://github.com/user-attachments/assets/d9faf8b1-4d02-4516-ae41-e7f41b8e4a9e" alt="sbnd_sim_track_missing_length_vs_vx" width="400"/></td>
  </tr>
  <tr>
    <td colspan="2" style="text-align: center;">Doublet space points, using sbndcode v10_04_03 for MPMVPR sample and optimized ghost labeling parameters.</td>
  </tr>
</table>

