### PR TITLE
Inherit genie config from genie_beam_settings.fcl in sbncode

### DIFF
--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -320,6 +320,10 @@ sbnd_genie_simple_rockbox: {
   GeomScan: "file: GENIE/sbnd_rock_maxpathlength_fluxI_gdmlv02_00.xml"
 }
 
+# Rotated bucket configuration
+sbnd_fluxbucket_bnb_rotated: {
+  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
+}
 
 #
 # Basic configurations (NuMI beam)

--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -291,6 +291,7 @@ sbnd_flux_numi_dirt: {
 
 sbnd_genie_simple: {
   @table::sbn_genie_BNB_base
+  @table::sbnd_flux_bnb_nu
   MaxFluxFileMB: 100
 }
 

--- a/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/gen/genie_sbnd.fcl
@@ -11,8 +11,15 @@
 # * GENIE: configuration of the GENIEGen module, to be included in the job
 #
 #
+# Comments:
+# Bunch sigma taken from 
+# https://beamdocs.fnal.gov/AD/DocDB/0050/005000/001/bunchLength_1st_draft.pdf
+# Bunch spacing taken from
+# https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
+# GlobalTimeOffset:   0  # Brailsford 2017/10/09 Simulation currently only reads out one drift frame so having a 1.6ms offset (one drift frame) means almost all events get placed outside the readout window.  We COULD make the readout window 2 or 3 drift frames long but we also have a disk space problem (we don't have any free).  The solution is to remove the offset and keep one frame readout
 
 #include "genie.fcl"
+#include "genie_beam_settings.fcl"
 
 BEGIN_PROLOG
 
@@ -255,48 +262,6 @@ sbnd_flux_numi_dirt: {
 }
 
 
-################################################################################
-### Bucket structure configuration (Implemented by A. C. Ezeribe)
-###
-#
-# These are FCL tables that setup arranging the neutrino interactions into BNB buckets.
-# Use them in its configuration as:
-#
-#     physics: {
-#       producers: {
-#         generator: {
-#           module_type: GenieGen
-#           # ...
-#           @table: fluxbucket_bub
-#         }
-#       }
-#     }
-#
-# or, if needed to override an existing configuration, with the less
-# straightforward:
-#
-#     physics.producers.generator: {
-#       @table::physics.producers.generator
-#       @table: fluxbucket_bnb
-#     }
-#
-#
-# Booster Neutrino Beam, bucket
-#
-# Bunch sigma taken from 
-# https://beamdocs.fnal.gov/AD/DocDB/0050/005000/001/bunchLength_1st_draft.pdf
-# Bunch spacing taken from
-# https://inspirehep.net/files/610a942fd8632bbbca2c8ad90da86670
-
-sbnd_fluxbucket_bnb: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
-}
-
-# Booster Neutrino Beam, rotated bucket
-#
-sbnd_fluxbucket_bnb_rotated: {
-  SpillTimeConfig:  "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308"
-}
 
 ################################################################################
 ### GENIE module configurations
@@ -319,48 +284,24 @@ sbnd_fluxbucket_bnb_rotated: {
 ###
 ###
 
-sbnd_genie: {
-  @table::standard_genie
-  @table::sbnd_flux_bnb_nu
-  @table::sbnd_fluxbucket_bnb
-  BeamName:           "booster"
-# GlobalTimeOffset:   1.28e6                  #sbnd reads out 1.6ms before the spill
-  GlobalTimeOffset:   0                  #Brailsford 2017/10/09 Simulation currently only reads out one drift frame so having a 1.6ms offset (one drift frame) means almost all events get placed outside the readout window.  We COULD make the readout window 2 or 3 drift frames long but we also have a disk space problem (we don't have any free).  The solution is to remove the offset and keep one frame readout
-  #EventGeneratorList:      "Default+CCMEC+NCMEC" # Only needed to generate partial samples in GENIE v3
-   DefinedVtxHistRange: true
-   VtxPosHistRange:     [ -210, 210, -210, 210, -10, 510 ]
-   AddGenieVtxTime: true		#Enable adding time of flight to neutrino vertex   
-} # sbnd_genie
-
-sbnd_genie_hist: {
-  @table::sbnd_genie
-  @table::sbnd_flux_bnb_nu_Bv1_hist
-  BeamCenter:    [0., 0., 0.]
-  BeamDirection: [0., 0., 1.]
-  BeamRadius:    4.
-}
-
 
 #
-# Basic configuration (BnB beam)
+# Basic configurations (BNB beam)
 #
+
 sbnd_genie_simple: {
-  @table::sbnd_genie
-  @table::sbnd_flux_bnb_nu
-  EventsPerSpill: 0
-  POTPerSpill: 5e12
+  @table::sbn_genie_BNB_base
   MaxFluxFileMB: 100
 }
 
 
 sbnd_genie_simple_dirt: {
-  @table::sbnd_genie
+  @table::sbn_genie_BNB_base
   @table::sbnd_flux_bnb_dirt
-  EventsPerSpill: 0
-  POTPerSpill: 5e12
   MaxFluxFileMB: 100
   TopVolume: "volWorld"
-  #Start the flux rays at 18m upstream of the TPC frontface.  Chosen as this is the distance a muon of 8 GeV (max flux sim. energy) can travel
+  # Start the flux rays at 18m upstream of the TPC frontface.
+  # Chosen as this is the distance a muon of 8 GeV (max flux sim. energy) can travel
   FluxUpstreamZ: -18
 }
 
@@ -380,14 +321,13 @@ sbnd_genie_simple_rockbox: {
 }
 
 
+#
+# Basic configurations (NuMI beam)
+#
 
 sbnd_genie_simple_numi: {
-  @table::standard_genie
+  @table::sbn_genie_NuMI_base
   @table::sbnd_flux_numi
-  BeamName:          "numi"
-  GlobalTimeOffset:  1.6e6
-  POTPerSpill:       3e13
-  EventsPerSpill:    0
 }
 
 sbnd_genie_simple_numi_dirt: {


### PR DESCRIPTION
## Description 
`sbncode` PR https://github.com/SBNSoftware/sbncode/pull/492 introduces a common genie settings file to be used across SBN. With this PR, SBND inherits the GENIE configuration from it.

Fixeds #588.

Running `fhicl-dump` on `prodgenie_corsika_proton_rockbox_sbnd.fcl` gives the following differences:

|            New | Original | Comment |
| ------------ | --------- |--------|
|           BeamCenter: [0,0,0] | BeamCenter: [-1400, -350, 0] | Good to change, used if we had a histogram-based flux |
|            N/A | BeamRadius: 3 | Good to change, used if we had a histogram-based flux |
|          DefinedVtxHistRange: false | DefinedVtxHistRange: true | Good to change, used if we had a histogram-based flux |
|          N/A | EventsPerSpill: 0 | Same as 0, OK |
|         GHepPrintLevel: -1 | N/A | OK, -1 is no print |
|          N/A |MonoEnergy: 2 | OK, we should not set options for FluxType = "mono" |
|          SpillTimeConfig: "\n    evgb::EvtTimeFNALBeam booster\n    nperbatch  84\n    nfilled    81\n    intensity  1.0\n    dtbucket  18.936\n    sigma      1.308\n    global     0.0\n    " |  SpillTimeConfig: "evgb::EvtTimeFNALBeam  booster,  dtbucket=18.936, sigma=1.308" | OK, as nperbatch 84 nfilled 81 intensity 1.0 are defaults |
|         N/A |RandomTimeOffset: 10000 | OK |
|          N/A | SurroundingMass: 0| OK, we shouldn't set this, it's for fluxes that don't know pot normalization |
|          VtxPosHistRange: [] | VtxPosHistRange: [-210, 210, -210, 210, 10, 510] | Good to change, used if we had a histogram-based flux |



## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer. No
- [x] Does this affect the standard workflow? Yes

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
