### PR TITLE
Feature/sungbin emb4data

### DIFF
--- a/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
@@ -37,6 +37,10 @@ sbnd_calomc.CaloAlg.ModBoxA: 0.904
 sbnd_calomc.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
 sbnd_calomc.CaloAlg.ModBoxBParam: [0.204, 1.25]
 
+sbnd_gnewcalodata.CaloAlg.ModBoxA: 0.904
+sbnd_gnewcalodata.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
+sbnd_gnewcalodata.CaloAlg.ModBoxBParam: [0.204, 1.25]
+
 sbnd_calodata.CaloAlg.ModBoxA: 0.904
 sbnd_calodata.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
 sbnd_calodata.CaloAlg.ModBoxBParam: [0.204, 1.25]

--- a/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
@@ -3,11 +3,11 @@
 BEGIN_PROLOG
 
 sbnd_calorimetryalgdata:    @local::standard_calorimetryalgdata
-sbnd_calorimetryalgdata.CalAreaConstants: [ 0.0204 , 0.0210, 0.0193 ]
+sbnd_calorimetryalgdata.CalAreaConstants: [ 0.0211 , 0.0209, 0.0204 ]
 #values below aren't correct
 sbnd_calorimetryalgdata.CalAmpConstants:    [ 0.588726e-3, 0.588726e-3, 1.18998e-3 ]
 sbnd_calorimetryalgmc:      @local::standard_calorimetryalgmc
-sbnd_calorimetryalgmc.CalAreaConstants:  [ 0.0200906, 0.0200016, 0.0201293 ]
+sbnd_calorimetryalgmc.CalAreaConstants:  [ 0.0206, 0.0204, 0.0202 ]
 # amplitude constants below are arbitrary and have not yet been tuned
 sbnd_calorimetryalgmc.CalAmpConstants:    [ 0.588726e-3, 0.588726e-3, 1.18998e-3 ]
 

--- a/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/calorimetry_sbnd.fcl
@@ -34,15 +34,15 @@ sbnd_gnewcalomc.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/18
 sbnd_gnewcalomc.CaloAlg.ModBoxBParam: [0.204, 1.25]
 
 sbnd_calomc.CaloAlg.ModBoxA: 0.904
-sbnd_calomc.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
+sbnd_calomc.CaloAlg.ModBoxBTF1: @local::sbnd_gnewcalomc.CaloAlg.ModBoxBTF1
 sbnd_calomc.CaloAlg.ModBoxBParam: [0.204, 1.25]
 
 sbnd_gnewcalodata.CaloAlg.ModBoxA: 0.904
-sbnd_gnewcalodata.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
+sbnd_gnewcalodata.CaloAlg.ModBoxBTF1: @local::sbnd_gnewcalomc.CaloAlg.ModBoxBTF1
 sbnd_gnewcalodata.CaloAlg.ModBoxBParam: [0.204, 1.25]
 
 sbnd_calodata.CaloAlg.ModBoxA: 0.904
-sbnd_calodata.CaloAlg.ModBoxBTF1: "[0]/TMath::Sqrt(TMath::Sin(x*TMath::Pi()/180)**2 + TMath::Cos(x*TMath::Pi()/180)**2/[1]**2)"
+sbnd_calodata.CaloAlg.ModBoxBTF1: @local::sbnd_gnewcalomc.CaloAlg.ModBoxBTF1
 sbnd_calodata.CaloAlg.ModBoxBParam: [0.204, 1.25]
 
 END_PROLOG


### PR DESCRIPTION
## Description 
Updating TPC dQ/dx to dE/dx recombination model to EMB from MB for data. (MC is already using EMB.)
Updating TPC gain calibration constants for MC and Data.

Used samples
- Data: Run 17665 (v09_03_01_01) calibration ntuples `(samweb list-files "production.type polaris and sbnd_project.stage reco2 and file_name like hist%")`
- MC: 2025 Feb Workshop MC sample, v10_04_1 + timing offset bug fix

For plots and numbers, please refer to [sbn-docdb-40108](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40108). Calibration constants with inclusive measurements are used.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
[sbn-docdb-40108](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40108).