### PR TITLE
Revert "TEMPORARY CHANGE: Disable vertex refinement in pandora"

### DIFF
--- a/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
+++ b/sbndcode/SBNDPandora/scripts/PandoraSettings_Neutrino_SBND.xml
@@ -91,11 +91,11 @@
     <ReplaceCurrentVertexList>true</ReplaceCurrentVertexList>
     <EnableCrossingCandidates>false</EnableCrossingCandidates>
   </algorithm>
-  <!--<algorithm type = "LArVertexRefinement">
+  <algorithm type = "LArVertexRefinement">
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
     <InputVertexListName>CandidateVertices3D</InputVertexListName>
     <OutputVertexListName>RefinedVertices3D</OutputVertexListName>
-  </algorithm>-->
+  </algorithm>
   <algorithm type = "LArBdtVertexSelection">
     <InputCaloHitListNames>CaloHitListU CaloHitListV CaloHitListW</InputCaloHitListNames>
     <InputClusterListNames>ClustersU ClustersV ClustersW</InputClusterListNames>
@@ -460,8 +460,7 @@
   <!-- Output list management -->
   <algorithm type = "LArPostProcessing">
     <PfoListNames>NeutrinoParticles3D TrackParticles3D ShowerParticles3D</PfoListNames>
-    <!--<VertexListNames>NeutrinoVertices3D DaughterVertices3D RefinedVertices3D</VertexListNames>-->
-    <VertexListNames>NeutrinoVertices3D DaughterVertices3D CandidateVertices3D</VertexListNames>
+    <VertexListNames>NeutrinoVertices3D DaughterVertices3D RefinedVertices3D</VertexListNames>
     <ClusterListNames>ClustersU ClustersV ClustersW TrackClusters3D ShowerClusters3D</ClusterListNames>
     <CaloHitListNames>CaloHitListU CaloHitListV CaloHitListW CaloHitList2D</CaloHitListNames>
     <CurrentPfoListReplacement>NeutrinoParticles3D</CurrentPfoListReplacement>


### PR DESCRIPTION
Reverts SBNSoftware/sbndcode#659

sbncode v10_04_03 includes the proper fix in larpandoracontent, so this can now be reverted.