### PR TITLE
Ensure deposits from all CRT types are retained when merging multiple geant outputs

### DIFF
--- a/sbndcode/LArG4/mergesimsources_sbnd.fcl
+++ b/sbndcode/LArG4/mergesimsources_sbnd.fcl
@@ -29,6 +29,11 @@ largeant_crt_volumes: [ "LArG4DetectorServicevolAuxDetSensitiveCRTStripY"
                       , "LArG4DetectorServicevolAuxDetSensitiveCRTStripX"
                       , "LArG4DetectorServicevolAuxDetSensitiveCRTStripBERN"
                       , "LArG4DetectorServicevolAuxDetSensitiveCRTStripMINOS"
+                      , "LArG4DetectorServicevolAuxDetSensitiveCRTStripSquare"
+                      , "LArG4DetectorServicevolAuxDetSensitiveCRTStripSquareuB"
+                      , "LArG4DetectorServicevolAuxDetSensitiveCRTStripuB"
+                      , "LArG4DetectorServicevolAuxDetSensitiveCRTStripuBnl"
+                      , "LArG4DetectorServicevolAuxDetSensitiveCRTStripuBns"
                       ]
 
 # Merge seperate instances of largeant for GENIE and CORSIKA


### PR DESCRIPTION
## Description 
Bug found during Analysis Workshop. GDML adopted in December/January introduced a number of new "types" of CRT. These need explicity listing in this fcl otherwise the energy deposits in them get dropped in any MC workflows with multiple geant4 instances (like rockbox or intime samples). 

Our MC testing was done with a pure cosmics sample so we didn't encounter this.

For anyone looking at the samples - this impacts the Top & some of the North CRTs.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
N/A

### Link(s) to docdb describing changes (optional)
I will mention it in a future docDB about CRT-TPC matching and try to remember to link it here.
