### PR TITLE
Stop pretending to simulate the PPS

### DIFF
--- a/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
+++ b/sbndcode/CRT/CRTSimulation/CRTDetSimAlg.cxx
@@ -435,9 +435,6 @@ namespace crt {
                 ts1_ch1 = ts1_ch0;
             }
 
-            // Time relative to PPS: Random for now! (FIXME)
-            uint32_t ppsTicks = CLHEP::RandFlat::shootInt(&fEngine, fParams.ClockSpeedCRT() * 1e6);
-
             // Adjacent channels on a strip are numbered sequentially.
             //
             // In the AuxDetWireReadoutGeom methods, channels are identified by an
@@ -477,14 +474,18 @@ namespace crt {
                 std::swap(sipm0ID, sipm1ID);
             }
 
+            // Note we use the time relative to the event trigger for both
+            // T0 and T1 because we cannot simulate T0 effectively.
+            // This will make MC/Data comparisons much easier.
+
             SiPMData sipm0 = SiPMData(sipm0ID,
                                       channel0ID,
-                                      ppsTicks,
+                                      ts1_ch0,
                                       ts1_ch0,
                                       q0);
             SiPMData sipm1 = SiPMData(sipm1ID,
                                       channel1ID,
-                                      ppsTicks,
+                                      ts1_ch1,
                                       ts1_ch1,
                                       q1);
 


### PR DESCRIPTION
## Description 
We don't need to pretend to simulate the PPS - assigning it to a random value for every piece of activity doesn't replicate what actually happens in data.

In data reconstruction we reference the T0 to the event trigger, thus replicating closely what T1 represents in the simulation. In aid of simplifying concepts and making data / MC comparisons easier I am suggesting we move to make T0 & T1 the same in MC.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
N/A

### Link(s) to docdb describing changes (optional)
N/A
