### PR TITLE
Adjust offset to align SimChannel and recob::Wire

### DIFF
--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/sp.jsonnet
@@ -51,7 +51,7 @@ function(params, tools, override = {}) {
       field_response: wc.tn(tools.field),
       elecresponse: wc.tn(tools.elec_resp),
       ftoffset: 0.0, // default 0.0
-      ctoffset: 2.0*wc.microsecond, // default -8.0
+      ctoffset: 1.0*wc.microsecond, // default -8.0
       per_chan_resp: pc.name,
       fft_flag: 0,  // 1 is faster but higher memory, 0 is slightly slower but lower memory
       postgain: 1.0,  // default 1.2


### PR DESCRIPTION
## Description 
Adjust the offset by 1 us (2 ticks) to align truth (SimChannel) and reco (recob::Wire).  Closes Issue #680. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [N/A] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 