### PR TITLE
Drop PDS & CRT DAQ Fragments and weiner wires

### DIFF
--- a/sbndcode/JobConfigurations/base/reco_drops.fcl
+++ b/sbndcode/JobConfigurations/base/reco_drops.fcl
@@ -6,10 +6,12 @@
 #          stage 1 reconstruction.
 #
 # Created: 28-Mar-2022  H. Greenlee
+# Modified: 26-Mar-2025 J. Zennamo 
 #
 # Notes.
 #
 # 1.  Drop raw data (RawDigits and OpDetWaveforms).
+# 2.  Drop DAQ PDS fragments 
 #
 #=============================================================================
 
@@ -18,12 +20,16 @@
 BEGIN_PROLOG
 
 reco_drops: [ @sequence::detsim_drops,
-              "drop raw::RawDigits_*_*_*",
-              "drop raw::OpDetWaveforms_*_*_*",
-              "drop *_sedlite_*_*", #drop all mlreco output
-              "drop *_cluster3d_*_*", #drop cluster3d output
-              "drop *_simplemerge_*_*" #drop all mlreco output
-               ]
+              , "drop raw::RawDigits_*_*_*"
+              , "drop raw::OpDetWaveforms_*_*_*"
+              , "drop *_sedlite_*_*" #drop all mlreco output
+              , "drop *_cluster3d_*_*" #drop cluster3d output
+              , "drop *_simplemerge_*_*" #drop all mlreco output
+              , "drop artdaq::Fragments_daq_ContainerCAENV1740_*"
+              , "drop artdaq::Fragments_daq_ContainerCAENV1730_*"
+              , "drop artdaq::Fragments_daq_ContainerBERNCRTV2_*"
+              , "drop recob::Wires_*_wiener_*"
+              ]
 
 END_PROLOG
 


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

This aims to drop the heaviest parts of `reco2` data files. This reduces our file sizes from O(25 MB/event) to O(5 MB/event). 

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [X] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer. *It does not*
- [X] Does this affect the standard workflow? *Yes*

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
*Nope*
### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
