### PR TITLE
Feature/acastill pmt eff

### DIFF
--- a/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
@@ -28,7 +28,7 @@ sbnd_opticalproperties: {
     ScintByParticleType: true
 
     # ScintPreScale MUST be equal/larger than the largest detection efficiency applied at DetSim stage
-    # This corresponds to the uncoated PMTs detection efficiency (15.2%)
+    # This corresponds to the coated PMTs detection efficiency (3.9% see docdb-40444)
     # See sbndcode/OpDetSim/digi_pmt_sbnd.fcl
     ScintPreScale:  0.039
 

--- a/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
@@ -30,7 +30,7 @@ sbnd_opticalproperties: {
     # ScintPreScale MUST be equal/larger than the largest detection efficiency applied at DetSim stage
     # This corresponds to the uncoated PMTs detection efficiency (15.2%)
     # See sbndcode/OpDetSim/digi_pmt_sbnd.fcl
-    ScintPreScale:  0.152
+    ScintPreScale:  0.039
 
     EnableCerenkovLight: false # Cerenkov light OFF by default
 

--- a/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpHit/job/ophit_finder_sbnd.fcl
@@ -8,7 +8,7 @@ sbnd_ophit_finder:
   GenModule:      "generator"
   InputModule:    "opdaq"
   InputLabels:    [""]
-  ChannelMasks:   []                  # Will ignore channels in this list
+  ChannelMasks:    [ 39, 66, 67, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302 ] #Channels that are not being run for data reconstruction
   PD:             ["pmt_coated", "pmt_uncoated"]  # Will only use PDS in this list
   Electronics:    "CAEN" #Will only use PDS with CAEN/Daphne readouts (500/62.5MHz sampling frec)
   DaphneFreq:     62.5  # Frequency of Daphne(XArapucas) readouts (in MHz)

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -62,9 +62,12 @@ namespace opdet {
       double PMTBaselineRMS; //Pedestal RMS in ADC counts
       double PMTDarkNoiseRate; //in Hz
       double PMTADCDynamicRange; //ADC dynbamic range
-      double PMTCoatedVUVEff; //PMT (coated) efficiency for direct (VUV) light
-      double PMTCoatedVISEff; //PMT (coated) efficiency for reflected (VIS) light
-      double PMTUncoatedEff; //PMT (uncoated) efficiency
+      double PMTCoatedVUVEff_tpc0; //PMT (coated) efficiency for direct (VUV) light (TPC0)
+      double PMTCoatedVISEff_tpc0; //PMT (coated) efficiency for reflected (VIS) light (TPC0)
+      double PMTUncoatedEff_tpc0; //PMT (uncoated) efficiency (TPC0)
+      double PMTCoatedVUVEff_tpc1; //PMT (coated) efficiency for direct (VUV) light (TPC1)
+      double PMTCoatedVISEff_tpc1; //PMT (coated) efficiency for reflected (VIS) light (TPC1)
+      double PMTUncoatedEff_tpc1; //PMT (uncoated) efficiency (TPC1)
       std::string PMTDataFile; //File containing timing emission structure for TPB, and single PE profile from data
       bool PMTSinglePEmodel; //Model for single pe response, false for ideal, true for test bench meas
       bool MakeGainFluctuations; //Fluctuate PMT gain
@@ -127,9 +130,12 @@ namespace opdet {
     // Declare member data here.
     double fSampling;       //wave sampling frequency (GHz)
     double fSamplingPeriod; //wave sampling period (ns)
-    double fPMTCoatedVUVEff;
-    double fPMTCoatedVISEff;
-    double fPMTUncoatedEff;
+    double fPMTCoatedVUVEff_tpc0;
+    double fPMTCoatedVISEff_tpc0;
+    double fPMTUncoatedEff_tpc0;
+    double fPMTCoatedVUVEff_tpc1;
+    double fPMTCoatedVISEff_tpc1;
+    double fPMTUncoatedEff_tpc1;
     bool fPositivePolarity;
     int fADCSaturation;
 
@@ -263,19 +269,34 @@ namespace opdet {
         Comment("Saturation in number of ADCs")
       };
 
-      fhicl::Atom<double> pmtcoatedVUVEff {
-        Name("PMTCoatedVUVEff"),
-        Comment("PMT (coated) detection efficiency for direct (VUV) light")
+      fhicl::Atom<double> pmtcoatedVUVEff_tpc0 {
+        Name("PMTCoatedVUVEff_tpc0"),
+        Comment("PMT (coated) detection efficiency for direct (VUV) light (TPC0)")
       };
 
-      fhicl::Atom<double> pmtcoatedVISEff {
-        Name("PMTCoatedVISEff"),
-        Comment("PMT (coated) detection efficiency for reflected (VIS) light")
+      fhicl::Atom<double> pmtcoatedVISEff_tpc0 {
+        Name("PMTCoatedVISEff_tpc0"),
+        Comment("PMT (coated) detection efficiency for reflected (VIS) light (TPC0)")
       };
 
-      fhicl::Atom<double> pmtuncoatedEff {
-        Name("PMTUncoatedEff"),
-        Comment("PMT (uncoated) detection efficiency")
+      fhicl::Atom<double> pmtuncoatedEff_tpc0 {
+        Name("PMTUncoatedEff_tpc0"),
+        Comment("PMT (uncoated) detection efficiency (TPC0)")
+      };
+
+      fhicl::Atom<double> pmtcoatedVUVEff_tpc1 {
+        Name("PMTCoatedVUVEff_tpc1"),
+        Comment("PMT (coated) detection efficiency for direct (VUV) light (TPC1)")
+      };
+
+      fhicl::Atom<double> pmtcoatedVISEff_tpc1 {
+        Name("PMTCoatedVISEff_tpc1"),
+        Comment("PMT (coated) detection efficiency for reflected (VIS) light (TPC1)")
+      };
+
+      fhicl::Atom<double> pmtuncoatedEff_tpc1 {
+        Name("PMTUncoatedEff_tpc1"),
+        Comment("PMT (uncoated) detection efficiency (TPC1)")
       };
 
       fhicl::Atom<bool> PMTsinglePEmodel {

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -31,9 +31,13 @@ sbnd_digipmt_alg:
   PMTDarkNoiseRate:      1000.0     #in Hz
   
   # Detection efficiencies
-  PMTCoatedVUVEff:       0.096      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff:       0.104      #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff:        0.152      #PMT uncoated detection efficiency
+  PMTCoatedVUVEff_tpc0:       0.096      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc0:       0.104      #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff_tpc0:        0.152      #PMT uncoated detection efficiency
+
+  PMTCoatedVUVEff_tpc1:       0.096      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc1:       0.104      #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff_tpc1:        0.152      #PMT uncoated detection efficiency
 
   # Simulate gain fluctuations
   # (comment-out to skip gain fluctuations simulation)

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -31,13 +31,13 @@ sbnd_digipmt_alg:
   PMTDarkNoiseRate:      1000.0     #in Hz
   
   # Detection efficiencies
-  PMTCoatedVUVEff_tpc0:       0.096      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff_tpc0:       0.104      #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff_tpc0:        0.152      #PMT uncoated detection efficiency
+  PMTCoatedVUVEff_tpc0:       0.035      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc0:       0.03882      #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff_tpc0:        0.03758     #PMT uncoated detection efficiency
 
-  PMTCoatedVUVEff_tpc1:       0.096      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff_tpc1:       0.104      #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff_tpc1:        0.152      #PMT uncoated detection efficiency
+  PMTCoatedVUVEff_tpc1:       0.03      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc1:       0.03882      #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff_tpc1:        0.03758      #PMT uncoated detection efficiency
 
   # Simulate gain fluctuations
   # (comment-out to skip gain fluctuations simulation)


### PR DESCRIPTION
## Description 
This PR changes the PMTs detection efficiencies to match the observed light yield in data. The detection efficiencies are changed for each of the TPCs independently to match their light yield. The PTMs that are not currently being reconstructed in data are turned off at the reconstruction stage. 

To make sure that the topologies of the cosmic muons that was used is the same for data and MC, the histogram of steps for both samples is plotted here:

![output](https://github.com/user-attachments/assets/8fd041b5-6b68-4ba2-95fc-f468a2a73ee6)

![image (2)](https://github.com/user-attachments/assets/1943e00c-4fc2-44cc-b0be-666c5dbb050e)

The same efficiencies were obtained using a sample of muons distributed isotropically on the YZ plane. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
[docdb-40444
](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=40444)