### PR TITLE
Drop PDS and CRT DAQ fragments, and Wiener wires

### DIFF
--- a/sbndcode/Decoders/run_decoders_job.fcl
+++ b/sbndcode/Decoders/run_decoders_job.fcl
@@ -20,6 +20,7 @@
 
 #include "services_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
+#include "decoder_drops.fcl"
 
 #include "pmtdecoder.fcl"
 
@@ -95,7 +96,7 @@ outputs:
         dataTier: "decoded-raw"
         fastCloning: true
         SelectEvents: [ dropchoppy ]
-        outputCommands: [ "keep *", "drop artdaq::Fragments_*_*TPC_*" ]
+        outputCommands: [ @sequence::decoder_drops ]
    }
 
    // choppy events
@@ -106,6 +107,6 @@ outputs:
         dataTier:    "decoded-raw"
         fastCloning: true
         SelectEvents: [ savechoppy ]
-        outputCommands: [ "keep *", "drop artdaq::Fragments_*_*TPC_*" ]
+        outputCommands: [ @sequence::decoder_drops ]
    }
 }

--- a/sbndcode/JobConfigurations/base/decoder_drops.fcl
+++ b/sbndcode/JobConfigurations/base/decoder_drops.fcl
@@ -1,0 +1,25 @@
+#=============================================================================
+#
+# Name: decoder_drops.fcl
+#
+# Purpose: Sequence of RootOutput drop commands to drop data products after
+#          decoding DAQ data files.
+#
+# Created: 26-Mar-2025  L. Yates
+#
+# Notes.
+#
+# 1.  Drop DAQ fragments for TPC, PDS, CRTs
+#
+#=============================================================================
+
+BEGIN_PROLOG
+
+decoder_drops: [ "keep *_*_*_*",
+	       	 "drop artdaq::Fragments_*_*TPC_*",  # drop TPC DAQ fragments
+		 "drop artdaq::Fragments_*_*CAENV1730_*",  # drop PMT DAQ fragments (from CAEN 1730 digitizers)
+		 "drop artdaq::Fragments_*_*CAENV1740_*",  # drop X-ARAPUCA DAQ fragments (from CAEN 1740 digitizers)
+		 "drop artdaq::Fragments_*_*BERNCRTV2_*"  # drop CRT DAQ fragments
+		 ]
+
+END_PROLOG

--- a/sbndcode/JobConfigurations/base/reco_drops.fcl
+++ b/sbndcode/JobConfigurations/base/reco_drops.fcl
@@ -6,10 +6,12 @@
 #          stage 1 reconstruction.
 #
 # Created: 28-Mar-2022  H. Greenlee
+# Modified: 26-Mar-2025  J. Zennamo & L. Yates
 #
 # Notes.
 #
 # 1.  Drop raw data (RawDigits and OpDetWaveforms).
+# 2.  Drop Wiener wires
 #
 #=============================================================================
 
@@ -22,7 +24,8 @@ reco_drops: [ @sequence::detsim_drops,
               "drop raw::OpDetWaveforms_*_*_*",
               "drop *_sedlite_*_*", #drop all mlreco output
               "drop *_cluster3d_*_*", #drop cluster3d output
-              "drop *_simplemerge_*_*" #drop all mlreco output
+              "drop *_simplemerge_*_*", #drop all mlreco output
+	      "drop recob::Wires_*_wiener_*"  #drop wiener wires
                ]
 
 END_PROLOG


### PR DESCRIPTION
## Description 
Drop PDS and CRT DAQ fragments after the decoders have been run. Drop Wiener wires after reco has been run.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer. _It does not affect CAF data format_
- [x] Does this affect the standard workflow? _Yes, this affects the standard workflow_

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
_Does not require merging any other PRs. Replacing PR #700._

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
_No_