### PR TITLE
Change number of events in data caf CI test from 2 to 5

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -1061,7 +1061,7 @@ output1=%(TFILENAME)s
 [test data_offBeamZeroBias_caf_quick_test_sbndcode]
 STAGE_NAME=caf
 INPUT_STAGE_NAME=reco2
-NEVENTS=2
+NEVENTS=5
 cpu_usage_range=200:1000
 mem_usage_range=1000000:3000000
 


### PR DESCRIPTION
## Description 
Changed the number of events ran from 2 to 5 for the data caf CI test. This needs to be changed as we are getting the following warning in the data caf log files: 

`378: Files have different numbers of entries: 5 vs 2`

This warning was preventing the ref files from being updated. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Relevant PR links (optional)
N/A

### Link(s) to docdb describing changes (optional)
No
