### PR TITLE
Adding nonSCE cosmic MC cafmaker fcl

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_cosmics.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_cosmics.fcl
@@ -1,0 +1,3 @@
+#include "cafmakerjob_sbnd.fcl"
+
+physics.producers.cafmaker.SaveGENIEEventRecord: false

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -13,6 +13,7 @@ physics.producers.cafmaker.SBNDCRTTrackMatchLabel: "crttrackmatchingSCE"
 physics.producers.cafmaker.CRTHitMatchLabel: "pandoraSCETrackCRTHit"
 physics.producers.cafmaker.CRTTrackMatchLabel: "pandoraSCETrackCRTTrack"
 physics.producers.cafmaker.OpT0Label: "opt0finderSCE"
+physics.producers.cafmaker.CVNLabel: "cvnSCE"
 
 physics.producers.cnnid.ClusterModuleLabel:        "pandoraSCE"
 physics.producers.cnnid.PFParticleModuleLabel:     "pandoraSCE"

--- a/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
@@ -72,6 +72,7 @@ sbnd_reco2_producers:{
 
     ### CVN
     cvn:                 @local::standard_sbndcvnevaluatorslc
+    cvnSCE:              @local::standard_sbndcvnevaluatorslc
 }
 
 sbnd_reco2_producer_sequence: [  
@@ -130,6 +131,10 @@ sbnd_reco2_producers.pandoraCaloData.FieldDistortionEfield:             false
 sbnd_reco2_producers.pandoraCaloData.TrackIsFieldDistortionCorrected:   false
 sbnd_reco2_producers.pandoraPidData.TrackModuleLabel:                   "pandoraTrack"
 sbnd_reco2_producers.pandoraPidData.CalorimetryModuleLabel:             "pandoraCaloData"
+
+sbnd_reco2_producers.cvn.SliceLabel: "pandora"
+sbnd_reco2_producers.cvn.PFParticleModuleLabel: "pandora"
+sbnd_reco2_producers.cvn.T0Label: "pandora"
 
 physics.analyzers.caloskim.SimChannelproducer: "simtpc2d:simpleSC"
 

--- a/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
@@ -108,6 +108,7 @@ sbnd_reco2_producer_sequence: [
     , fmatchoparaSCE
     , opt0finderSCE
     , cvn
+    , cvnSCE
 ]
 
 #FIXME override the producer labels.  This should really happen in the module's config fcl


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

**This is needed to create CAFs without the SCE corrections applied, this will allow us to produce files consistent between data and MC**

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [X] Linked any relevant issues under `Developement`
- [X] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? **Yes**

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
**Nope**
### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
**Nope**