### PR TITLE
Added appropriate delete calls for fCalAlg and fBlipAlg

### DIFF
--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -228,6 +228,7 @@ namespace blip {
   //Destructor
   BlipRecoAlg::~BlipRecoAlg()
   {
+    delete fCaloAlg;
   }
   
   

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -840,7 +840,10 @@ BlipAna::BlipAna(fhicl::ParameterSet const& pset) :
   InitializeHistograms();
     
 }
-BlipAna::~BlipAna(){}
+BlipAna::~BlipAna()
+{
+  delete fBlipAlg;
+}
 
 
 


### PR DESCRIPTION
Fixed missing delete calls for pointers initialized with new. Allows LArSoft to exit sucessfully 