### PR TITLE
[Bug] Store all MCParticles

### DIFF
--- a/sbndcode/LArG4/larg4_services_sbnd.fcl
+++ b/sbndcode/LArG4/larg4_services_sbnd.fcl
@@ -71,18 +71,6 @@ sbnd_particle_list_action:
   KeepDroppedParticlesInVolumes: ["volTPCActive"]   # list of volumes for which we want to store particles that were dropped
                                                     # (i.e. particles that are not included in the standard list, mainly em shower
                                                     # daughters). Used for ml reco workflow.
-  
-  # --Temporary fix--
-  # This causes the parentage chain to be broken in MCTrack. Perhaps the upstream sim needs to be checked to ensure proper filtering
-
-  #KeepParticlesInVolumes: ["volCryostat",           # Keep list of nominal mc particles that interact within the cryostat and CRTs
-  #   "volTaggerTopHigh", 
-  #   "volTaggerTopLow",
-  #   "volTaggerSideLeft", 
-  #   "volTaggerSideRight", 
-  #   "volTaggerFaceFront", 
-  #   "volTaggerFaceBack", 
-  #   "volTaggerBot"]
 }
 
 #

--- a/sbndcode/LArG4/larg4_services_sbnd.fcl
+++ b/sbndcode/LArG4/larg4_services_sbnd.fcl
@@ -72,14 +72,17 @@ sbnd_particle_list_action:
                                                     # (i.e. particles that are not included in the standard list, mainly em shower
                                                     # daughters). Used for ml reco workflow.
   
-  KeepParticlesInVolumes: ["volCryostat",           # Keep list of nominal mc particles that interact within the cryostat and CRTs
-     "volTaggerTopHigh", 
-     "volTaggerTopLow",
-     "volTaggerSideLeft", 
-     "volTaggerSideRight", 
-     "volTaggerFaceFront", 
-     "volTaggerFaceBack", 
-     "volTaggerBot"]
+  # --Temporary fix--
+  # This causes the parentage chain to be broken in MCTrack. Perhaps the upstream sim needs to be checked to ensure proper filtering
+
+  #KeepParticlesInVolumes: ["volCryostat",           # Keep list of nominal mc particles that interact within the cryostat and CRTs
+  #   "volTaggerTopHigh", 
+  #   "volTaggerTopLow",
+  #   "volTaggerSideLeft", 
+  #   "volTaggerSideRight", 
+  #   "volTaggerFaceFront", 
+  #   "volTaggerFaceBack", 
+  #   "volTaggerBot"]
 }
 
 #


### PR DESCRIPTION
## Description 
This causes the parentage chain to be broken in MCTrack. Perhaps the upstream sim needs to be checked to ensure proper filtering. This should be put in to fix the attached issue.

Simply adding `volTPCActive` to the existing list does not fix the problem.

Comparing a few events before and after the change.
```
#v10_04_06_01
418303      0.005 simb::MCParticles_largeant__GenieGen.
#v10_04_06_01 with change 
462982      0.010 simb::MCParticles_largeant__GenieGen.
```
Adds ~50 kB / event based on this.

## Checklist
- [X] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [X] Assigned at least 1 reviewer under `Reviewers`,
- [X] Assigned all contributers including yourself under `Assignees`
- [X] Linked any relevant issues under `Developement`
- [na] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X] Does this affect the standard workflow? 

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
