### PR TITLE
Add tpcpdbarycentermatching to standard workflow

### DIFF
--- a/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
+++ b/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
@@ -151,7 +151,7 @@ physics.producers.cafmaker.TrackCaloLabel: "pandoraCaloData"
 physics.producers.cafmaker.TrackChi2PidLabel: "pandoraPidData"
 
 # Include 3D barycenter flahs matching 
-physics.producers.cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatch"
+physics.producers.cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatching"
 
 # Blinding not needed for MC
 physics.producers.cafmaker.CreateBlindedCAF: false

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -147,6 +147,9 @@ physics.producers.cafmaker.SaveGENIEEventRecord: true
 physics.producers.cafmaker.FlashMatchOpDetSuffixes: ["", "op", "ara", "opara"]
 physics.producers.cafmaker.FlashMatchSCECryoSuffixes: [""]
 
+# Include 3D barycenter flahs matching 
+physics.producers.cafmaker.TPCPMTBarycenterMatchLabel: "tpcpmtbarycentermatching"
+
 # Overwrite weight_functions label:
 physics.producers.fluxweight.weight_functions: @local::physics.producers.fluxweight.weight_functions_flux
 

--- a/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
@@ -11,6 +11,8 @@
 
 #include "opt0finder_sbnd.fcl"
 
+#include "sbnd_tpcpmt3dbarycentermatching_config.fcl"
+
 #include "sbnd_trackcalo_skimmer.fcl"
 #include "crtana_sbnd.fcl"
 #include "pmtskim_sbnd.fcl"
@@ -60,6 +62,7 @@ sbnd_reco2_producers:{
     fmatchoparaSCE:      @local::sbnd_simple_flashmatch_opara_sce
     opt0finder:          @local::sbnd_opt0_finder_one_to_many
     opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
+    tpcpmtbarycentermatching: @local::TPCPMTBarycenterMatchProducer
 
     ### Uncalibrated calorimetry producer for calibration caloskimmer
     caloskimCalorimetry: @local::caloskim_calorimetry
@@ -85,6 +88,7 @@ sbnd_reco2_producer_sequence: [
     , fmatchopara
     , caloskimCalorimetry
     , opt0finder
+    , tpcpmtbarycentermatching
     , pandoraSCE
     , pandoraSCETrack
     , pandoraSCEShower

--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -16,10 +16,11 @@ physics.producers:
 {
     @table::physics.producers
     opt0finder:     @local::sbnd_opt0_finder_data
+    tpcpmtbarycentermatching: @local::TPCPMTBarycenterMatchProducer
 }
 
 physics.reco2: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, caloskimCalorimetry,
-  cvn, opt0finder]
+  cvn, opt0finder, tpcpmtbarycentermatching]
 
 #The next 3 lines need to be commented out once data use pandoraSCE by default. 
 physics.producers.cvn.SliceLabel: "pandora"


### PR DESCRIPTION
## Description 
This PR includes tpcpmtbarycenterflashmatching module as a part of the standard reconstruction workflow both in data and MC.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
