### PR TITLE
Simulate dirt neutrinos in MPV

### DIFF
--- a/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
@@ -8,7 +8,7 @@ MultiPartVertex : {
     TPCRange     : [[0,0],[0,1]]
     XRange       : [30,30]
     YRange       : [30,30]
-    ZRange       : [30,30]
+    ZRange       : [-30,30]
     MultiMax     : 7
     MultiMin     : 2
     GammaBetaRange : [0.0, 3.0]

--- a/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
@@ -8,7 +8,7 @@ MultiPartVertex : {
     TPCRange     : [[0,0],[0,1]]
     XRange       : [30,30]
     YRange       : [30,30]
-    ZRange       : [-50,30]
+    ZRange       : [30,30]
     MultiMax     : 7
     MultiMin     : 2
     GammaBetaRange : [0.0, 3.0]
@@ -30,9 +30,9 @@ MultiPartRain : {
     G4Time       : 819.2 # [ns]
     G4TimeJitter : 1638.4 # [ns]
     TPCRange     : [[0,0],[0,1]]
-    XRange       : [20,20]
-    YRange       : [20,20]
-    ZRange       : [20,20]
+    XRange       : [-20,-20]
+    YRange       : [-20,-20]
+    ZRange       : [-20,-20]
     DirectInward : true
     CosmicDistribution : false
     MultiMax     : 5

--- a/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/MultiPart/multipartvertex_sbnd.fcl
@@ -8,7 +8,7 @@ MultiPartVertex : {
     TPCRange     : [[0,0],[0,1]]
     XRange       : [30,30]
     YRange       : [30,30]
-    ZRange       : [-30,30]
+    ZRange       : [-50,30]
     MultiMax     : 7
     MultiMin     : 2
     GammaBetaRange : [0.0, 3.0]


### PR DESCRIPTION
## Description 
Simulate MPV upstream of detector to train for dirt neutrinos.

<img width="1192" alt="Screenshot 2025-04-14 at 3 50 41 PM" src="https://github.com/user-attachments/assets/ef4bfed1-f2a5-4dc9-b07a-d6d2a90d6915" />
^^ shows reconstructed neutrino vertex from Pandora after selection. Most are within 50 cm of TPC face in z-direction. 
<img width="836" alt="image" src="https://github.com/user-attachments/assets/399ece47-4a51-45ba-b2c1-13c218a2a358" />


^^ shows the density of neutrino interactions by true type after fv cut in pandora selection.
See docdb [36641](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36641)


This expands the volume by 75% `(440*440*540)/(360*360*460)=1.753`, so one would need to scale the training dataset size by 75% more events to reproduce a similar training set of the old volume (for the rain/MPR sample).

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 

### Link(s) to docdb describing changes (optional)
docdb [36641](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36641)
