### PR TITLE
fix overwrite bug with the BadChannels block

### DIFF
--- a/sbndcode/Utilities/channelstatus_sbnd.fcl
+++ b/sbndcode/Utilities/channelstatus_sbnd.fcl
@@ -11,10 +11,14 @@ sbnd_channelstatus: {
   
   # list of bad channels:
   BadChannels:   [ 
+    @sequence::sbnd_data_badchannels_east_dead_femb,
+    @sequence::sbnd_data_badchannels_west_plane0_shorted,
+    @sequence::sbnd_data_badchannels_west_plane1_shorted,
+    @sequence::sbnd_data_badchannels_no_response,
+    @sequence::sbnd_data_badchannels_east_plane2_missing_combs,
+    @sequence::sbnd_data_badchannels_west_plane2_missing_combs,
     @sequence::sbnd_badchannels_tpc0_plane2_missing_jumpered,
-    @sequence::sbnd_badchannels_tpc1_plane2_missing_jumpered,
-    @sequence::sbnd_badchannels_tpc0_plane2_missing_combs,
-    @sequence::sbnd_badchannels_tpc1_plane2_missing_combs
+    @sequence::sbnd_badchannels_tpc1_plane2_missing_jumpered
   ]
   
   # list of bad noisy channels:
@@ -26,15 +30,6 @@ sbnd_channelstatus: {
 sbnd_data_channelstatus: {
 
   @table::sbnd_channelstatus
-
-  BadChannels: [
-      @sequence::sbnd_data_badchannels_east_dead_femb
-    , @sequence::sbnd_data_badchannels_west_plane0_shorted
-    , @sequence::sbnd_data_badchannels_west_plane1_shorted
-    , @sequence::sbnd_data_badchannels_no_response
-    , @sequence::sbnd_data_badchannels_east_plane2_missing_combs
-    , @sequence::sbnd_data_badchannels_west_plane2_missing_combs
-  ]
 
   NoisyChannels: [
     @sequence::sbnd_data_badchannels_noisy


### PR DESCRIPTION

## Description 
fix overwrite bug with the BadChannels block and put the entire set in sbnd_channelstatus, copied for sbnd_data_channelstatus

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this affect the standard workflow? 

