### PR TITLE
Save OpFlash information in CAF files in SBND

### DIFF
--- a/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
+++ b/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
@@ -161,6 +161,9 @@ physics.producers.cafmaker.CreateBlindedCAF: false
 # More details can be found in here: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36869
 physics.producers.cafmaker.SaveGENIEEventRecord: false #comment to get CI to run on v09_90_00. This should be uncommented in v09_91_01 and later.
 
+# Iclude OpFlash information
+physics.producers.cafmaker.OpFlashLabel: "opflash"
+
 # Include Simple/OpFlashes for PMT/XARAPUCA
 physics.producers.cafmaker.FlashMatchOpDetSuffixes: ["", "op", "ara", "opara"]
 physics.producers.cafmaker.FlashMatchSCECryoSuffixes: [""]

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -143,6 +143,9 @@ physics.producers.cafmaker.CreateBlindedCAF: false
 # More details can be found in here: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=36869
 physics.producers.cafmaker.SaveGENIEEventRecord: true
 
+# Include OpFlash information
+physics.producers.cafmaker.OpFlashLabel: "opflash"
+
 # Include Simple/OpFlashes for PMT/XARAPUCA
 physics.producers.cafmaker.FlashMatchOpDetSuffixes: ["", "op", "ara", "opara"]
 physics.producers.cafmaker.FlashMatchSCECryoSuffixes: [""]


### PR DESCRIPTION
## Description 
OpFlash information was not being saved in CAF files in SBND. This PRs incorporates the required changes to do so.

This PR depends on https://github.com/SBNSoftware/sbnanaobj/pull/138 and https://github.com/SBNSoftware/sbncode/pull/534

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
