### PR TITLE
Update parameters of in-time cosmic MC gen filter modules

### DIFF
--- a/sbndcode/Filters/fcls/filtersgenintime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filtersgenintime_sbnd.fcl
@@ -6,11 +6,10 @@ BEGIN_PROLOG
 sbnd_filtergenintime: {
   KeepOnlyMuons: false
   MinKE: 1e-1 # some energy threshold to produce a PE
-  MaxT: 1900 # [ns] add a little buffer on the far end of the photon time window
-  # About 1 in 30e6 particles will produce a flash 15us after entering the cryostat
-  # so this gives us a good buffer and is still computationally feasible
-  # MinT: -15202 # [ns]
-  MinT: -200 # [ns] Change: filter to only allow muons starting at the beam spill (with a small buffer)
+  # Filter to only allow muons starting within the Run 1 trigger acceptance window of [-873, 2467] ns
+  # With a 200 ns buffer on the leading side and a 300 ns buffer on the late side
+  MaxT:  2767 # [ns]
+  MinT: -1073 # [ns]
   SortParticles: true
   module_type: "FilterGenInTime"
 }

--- a/sbndcode/Filters/fcls/filtersgenintime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filtersgenintime_sbnd.fcl
@@ -7,8 +7,8 @@ sbnd_filtergenintime: {
   KeepOnlyMuons: false
   MinKE: 1e-1 # some energy threshold to produce a PE
   # Filter to only allow muons starting within the Run 1 trigger acceptance window of [-873, 2467] ns
-  # With a 200 ns buffer on the leading side and a 300 ns buffer on the late side
-  MaxT:  2767 # [ns]
+  # With a 200 ns buffer on the leading side and a 100 ns buffer on the late side
+  MaxT:  2567 # [ns]
   MinT: -1073 # [ns]
   SortParticles: true
   module_type: "FilterGenInTime"

--- a/sbndcode/Filters/fcls/filterssimphotonlitetime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filterssimphotonlitetime_sbnd.fcl
@@ -6,7 +6,8 @@ sbnd_timefilterssimphotonlitetime: {
    # Generate in-time cosmics uniformly in a window [-873, 2467] ns
    # To simulate a 3.34us trigger acceptance window that starts 1.24us before the beam spill that starts at +367ns
    # Consistent with the trigger acceptance window for light-based trigger streams in Run 1 data (docdb-40000, slides from Feb 21)
-   TimeWindows: [ [-873, 2467] ] # ns
+   # With a 100 ns buffer on either side
+   TimeWindows: [ [-973, 2567] ] # ns
    # 10 PE
    MinTotalPhotons: 10
    # Reflected photons are not used in trigger -- we can ignore them

--- a/sbndcode/Filters/fcls/filterssimphotonlitetime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filterssimphotonlitetime_sbnd.fcl
@@ -3,10 +3,10 @@ BEGIN_PROLOG
 sbnd_timefilterssimphotonlitetime: {
    module_type: "FilterSimPhotonLiteTime"
    SimPhotonsLiteCollectionLabel: larg4intime
-   # Currently in overlay generation, events are generated
-   # uniformly in a window [0, 1596ns] to approximate a beam spill.
-   # Add a little width here to up that width to 2000ns
-   TimeWindows: [ [-202, 1798] ] # ns
+   # Generate in-time cosmics uniformly in a window [-873, 2467] ns
+   # To simulate a 3.34us trigger acceptance window that starts 1.24us before the beam spill that starts at +367ns
+   # Consistent with the trigger acceptance window for light-based trigger streams in Run 1 data (docdb-40000, slides from Feb 21)
+   TimeWindows: [ [-873, 2467] ] # ns
    # 10 PE
    MinTotalPhotons: 10
    # Reflected photons are not used in trigger -- we can ignore them

--- a/sbndcode/Filters/fcls/filterssimphotontime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filterssimphotontime_sbnd.fcl
@@ -3,10 +3,10 @@ BEGIN_PROLOG
 sbnd_timefilterssimphotontime: {
    module_type: "FilterSimPhotonTime"
    SimPhotonsCollectionLabel: largeant
-   # Currently in overlay generation, events are generated
-   # uniformly in a window [0, 1596ns] to approximate a beam spill.
-   # Add a little width here to up that width to 2000ns
-   TimeWindows: [ [-202, 1798] ] # ns
+   # Generate in-time cosmics uniformly in a window [-873, 2467] ns
+   # To simulate a 3.34us trigger acceptance window that starts 1.24us before the beam spill that starts at +367ns
+   # Consistent with the trigger acceptance window for light-based trigger streams in Run 1 data (docdb-40000, slides from Feb 21)
+   TimeWindows: [ [-873, 2467] ] # ns
    MinPhotonEnergy: -1
    # 10 PE -- in the case of reflected photons, this may be more than 10 photons
    MinTotalEnergy: 9.7e-5

--- a/sbndcode/Filters/fcls/filterssimphotontime_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filterssimphotontime_sbnd.fcl
@@ -6,7 +6,8 @@ sbnd_timefilterssimphotontime: {
    # Generate in-time cosmics uniformly in a window [-873, 2467] ns
    # To simulate a 3.34us trigger acceptance window that starts 1.24us before the beam spill that starts at +367ns
    # Consistent with the trigger acceptance window for light-based trigger streams in Run 1 data (docdb-40000, slides from Feb 21)
-   TimeWindows: [ [-873, 2467] ] # ns
+   # With a 100 ns buffer on either side
+   TimeWindows: [ [-973, 2567] ] # ns
    MinPhotonEnergy: -1
    # 10 PE -- in the case of reflected photons, this may be more than 10 photons
    MinTotalEnergy: 9.7e-5


### PR DESCRIPTION
Update parameters of in-time cosmic MC gen filter modules to use a data-like time window. Light-based trigger acceptance window for Run 1 data is 3.34us wide and starts ~1.24us before a 1.6us beam spill.

## Description 
Please provide a detailed description of the changes this pull request introduces. 

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer. _No, this does not affect CAF data format_
- [x] Does this affect the standard workflow? _Yes, this changes some of the parameters of the standard in-time cosmic MC generation workflow_

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
