### PR TITLE
DNN ROI Finding 

### DIFF
--- a/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
+++ b/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
@@ -125,8 +125,11 @@ physics:
 # change tools in sbn to have 2D TPC sim/sp input
 physics.producers.pandoraShowerRazzle.SimChannelLabel: "sptpc2d:gauss"
 physics.producers.pandoraTrackDazzle.SimChannelLabel: "sptpc2d:gauss"
-
 physics.producers.cnnid.WireLabel: "sptpc2d:gauss"
+# uncomment below lines to use DNN ROI SP for Razzle/Dazzle/CNNID
+#physics.producers.pandoraShowerRazzle.SimChannelLabel: "sptpc2d:dnnsp"
+#physics.producers.pandoraTrackDazzle.SimChannelLabel: "sptpc2d:dnnsp"
+#physics.producers.cnnid.WireLabel: "sptpc2d:dnnsp"
 
 ### Calorimetry for data
 physics.producers.cnnid.PointIdAlg.CalorimetryAlg: @local::sbnd_calorimetryalgdata

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd.fcl
@@ -127,6 +127,8 @@ physics:
 physics.producers.pandoraShowerRazzle.SimChannelLabel: "simtpc2d:simpleSC"
 physics.producers.pandoraTrackDazzle.SimChannelLabel: "simtpc2d:simpleSC"
 physics.producers.cnnid.WireLabel: "simtpc2d:gauss"
+# uncomment below line for to use DNN ROI SP for CNNID scores
+#physics.producers.cnnid.WireLabel: "simtpc2d:dnnsp"
 
 physics.producers.vertexCharge.CaloAlg: @local::sbnd_calorimetryalgmc
 physics.producers.vertexStub.CaloAlg: @local::sbnd_calorimetryalgmc

--- a/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
@@ -35,3 +35,12 @@ physics.ana: [superadata]
 outputs.out1.SelectEvents: [ "reco1" ]
 
 physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:gauss"
+
+# uncomment below 4 lines to run DNN ROI finding SP
+#physics.producers.sptpc2d.wcls_main.outputers: ["wclsFrameSaver:spsaver" , "wclsFrameSaver:dnnsaver"]
+#physics.producers.sptpc2d.wcls_main.structs.use_dnnroi: true
+#physics.producers.sptpc2d.wcls_main.structs.nchunks: 2 # should match training config
+#physics.producers.sptpc2d.wcls_main.structs.tick_per_slice: 4 # should match training config
+
+# uncomment below line to run DNN ROI finding SP for reco
+#physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
@@ -92,3 +92,9 @@ outputs:
                     ]
   }
 }
+
+# uncomment below 4 lines to run DNN ROI finding SP
+# physics.producers.simtpc2d.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+# physics.producers.simtpc2d.wcls_main.structs.use_dnnroi: true
+# physics.producers.simtpc2d.wcls_main.structs.nchunks: 2 # should match training config
+# physics.producers.simtpc2d.wcls_main.structs.tick_per_slice: 4 # should match training config

--- a/sbndcode/JobConfigurations/standard/standard_reco1_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco1_sbnd.fcl
@@ -35,3 +35,6 @@ physics.end_paths:      [ @sequence::physics.end_paths, ana ]
 #outputs table overrides
 outputs.out1.dataTier:       "reconstructed"
 outputs.out1.outputCommands:  [@sequence::outputs.out1.outputCommands, @sequence::sbnd_reco1_drops]
+
+# uncomment below line to run DNN ROI finding SP for reco -- must have run DNN ROI finding in detsim stage
+#physics.producers.gaushit.CalDataModuleLabel: "simtpc2d:dnnsp"

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/dnnroi.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/dnnroi.jsonnet
@@ -1,0 +1,112 @@
+// This produces a function to configure DNN-ROI for one APA given
+// anode and torch service (ts) objects.
+// 
+// The prefix is prepended to all internal node names if uniqueness
+// beyond anode ID is needed.  The output_scale allows for an ad-hoc
+// scaling of dnnroi output.  The U and W planes will go through
+// dnnroi while hte W plane will be shunted.  What comes out will be a
+// unified frame with frame tag "dnnspN" where "N" is the anode ID.
+
+local wc = import "wirecell.jsonnet";
+local pg = import "pgraph.jsonnet";
+
+
+function (anode, ts_p0, ts_p1, prefix="dnnroi", output_scale=1.0, nticks=3428, tick_per_slice=4, nchunks=1)
+    local apaid = anode.data.ident;
+    local prename = prefix + std.toString(apaid);
+    local intags = ['loose_lf%d'%apaid, 'mp2_roi%d'%apaid,
+                     'mp3_roi%d'%apaid];
+
+    local dnnroi_u = pg.pnode({
+        type: "DNNROIFinding",
+        name: prename+"u",
+        data: {
+            anode: wc.tn(anode),
+            plane: 0,
+            intags: intags,
+            decon_charge_tag: "decon_charge%d" %apaid,
+            outtag: "dnnsp%du"%apaid,
+            input_scale: 0.00025, // 1/4000
+            output_scale: output_scale,
+            forward: wc.tn(ts_p0),
+            tick_per_slice: tick_per_slice,
+            nticks: nticks,
+            nchunks: nchunks
+        }
+    }, nin=1, nout=1, uses=[ts_p0, anode]);
+    local dnnroi_v = pg.pnode({
+        type: "DNNROIFinding",
+        name: prename+"v",
+        data: {
+            anode: wc.tn(anode),
+            plane: 1,
+            intags: intags,
+            decon_charge_tag: "decon_charge%d" %apaid,
+            outtag: "dnnsp%dv"%apaid,
+            input_scale: 0.00025, // 1/4000
+            output_scale: output_scale,
+            forward: wc.tn(ts_p1),
+            tick_per_slice: tick_per_slice,
+            nticks: nticks,
+            nchunks: nchunks
+        }
+    }, nin=1, nout=1, uses=[ts_p1, anode]);
+    local dnnroi_w = pg.pnode({
+        type: "PlaneSelector",
+        name: prename+"w",
+        data: {
+            anode: wc.tn(anode),
+            plane: 2,
+            tags: ["gauss%d"%apaid],
+            tag_rules: [{
+                frame: {".*":"DNNROIFinding"},
+                trace: {["gauss%d"%apaid]:"dnnsp%dw"%apaid},
+            }],
+        }
+    }, nin=1, nout=1, uses=[anode]);
+
+    local dnnpipes = [dnnroi_u, dnnroi_v, dnnroi_w];
+    local dnnfanout = pg.pnode({
+        type: "FrameFanout",
+        name: prename,
+        data: {
+            multiplicity: 3
+        }
+    }, nin=1, nout=3);
+
+    local dnnfanin = pg.pnode({
+        type: "FrameFanin",
+        name: prename,
+        data: {
+            multiplicity: 3,
+            tag_rules: [{
+                frame: {".*": "dnnsp%d%s" % [apaid,plane]},
+                trace: {".*": "dnnsp%d%s" % [apaid,plane]},
+            } for plane in ["u", "v", "w"]]
+        },
+    }, nin=3, nout=1);
+
+    local retagger = pg.pnode({
+      type: "Retagger",
+      name: 'dnnroi%d' % apaid,
+      data: {
+        // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+        tag_rules: [{
+          // Retagger also handles "frame" and "trace" like fanin/fanout
+          // merge separately all traces like gaussN to gauss.
+          frame: {
+            ".*": "dnnsp%d" % apaid
+          },
+          merge: {
+            ".*": "dnnsp%d" % apaid
+          },
+        }],
+      },
+    }, nin=1, nout=1);
+    
+    pg.intern(innodes=[dnnfanout],
+              outnodes=[retagger],
+              centernodes=dnnpipes+[dnnfanin],
+              edges=[pg.edge(dnnfanout, dnnpipes[ind], ind, 0) for ind in [0,1,2]] +
+              [pg.edge(dnnpipes[ind], dnnfanin, 0, ind) for ind in [0,1,2]] +
+              [pg.edge(dnnfanin, retagger, 0, 0)])

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
@@ -24,6 +24,11 @@
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
 local raw_input_label = std.extVar('raw_input_label');  // eg "daq"
 local use_paramresp = std.extVar('use_paramresp');  // eg "true" or "false"
+local use_dnnroi = std.extVar('use_dnnroi');
+local nchunks = std.extVar('nchunks');
+local tick_per_slice = std.extVar('tick_per_slice');
+local dnnroi_model_p0 = std.extVar('dnnroi_model_p0');
+local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
@@ -124,6 +129,22 @@ local wcls_output = {
       chanmaskmaps: ['bad'],
     },
   }, nin=1, nout=1, uses=[mega_anode]),
+
+  dnnsp_signals: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'dnnsaver',
+    data: {
+      anode: wc.tn(mega_anode),
+      digitize: false,  // true means save as RawDigit, else recob::Wire
+      frame_tags: ['dnnsp'],
+
+      // this may be needed to convert the decon charge [units:e-] to be consistent with the LArSoft default ?unit? e.g. decon charge * 0.005 --> "charge value" to GaussHitFinder
+      frame_scale: [0.02, 0.02, 0.02],
+      nticks: params.daq.nticks,
+
+      chanmaskmaps: ['dnnspbad'],
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
 };
 
 local base = import 'pgrapher/experiment/sbnd/chndb-base.jsonnet';
@@ -151,14 +172,85 @@ local nf_maker = import 'pgrapher/experiment/sbnd/nf-data.jsonnet'; //added Ewer
 local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in std.range(0, std.length(tools.anodes) - 1)];
 
 local sp_maker = import 'pgrapher/experiment/sbnd/sp.jsonnet';
-local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
+local sp_override = if use_dnnroi then {
+    sparse: true,
+    use_roi_debug_mode: true,
+    save_negtive_charge: true, // TODO: no negative charge in gauss, default is false
+    use_multi_plane_protection: true,
+    mp_tick_resolution: 4,
+    tight_lf_tag: "",
+    // loose_lf_tag: "",
+    cleanup_roi_tag: "",
+    break_roi_loop1_tag: "",
+    break_roi_loop2_tag: "",
+    shrink_roi_tag: "",
+    extend_roi_tag: "",
+    // m_decon_charge_tag: "",
+} else {
+    sparse: true,
+};
+//local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
+local sp = sp_maker(params, tools, sp_override);
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+local dnnroi = import 'dnnroi.jsonnet';
+local ts_p0 = {
+    type: "TorchService",
+    name: "dnnroi_p0",
+    tick_per_slice: tick_per_slice, 
+    data: {
+        model: dnnroi_model_p0,
+        device: "cpu",
+        concurrency: 1,
+    },
+};
+
+local ts_p1 = {
+    type: "TorchService",
+    name: "dnnroi_p1",
+    tick_per_slice: tick_per_slice, 
+    data: {
+        model: dnnroi_model_p1,
+        device: "cpu",
+        concurrency: 1,
+    },
+};
 
 local magoutput = 'sbnd-data-check.root';
 local magnify = import 'pgrapher/experiment/sbnd/magnify-sinks.jsonnet';
 local sinks = magnify(tools, magoutput);
 
-local nfsp_pipes = [
+local fanout = function (name, multiplicity=2)
+  g.pnode({
+    type: 'FrameFanout',
+    name: name,
+    data: {
+        multiplicity: multiplicity
+    },
+  }, nin=1, nout=multiplicity);
+
+local sp_fans = [fanout("sp_fan_%d" % n) for n in std.range(0, std.length(tools.anodes) - 1)];
+local dnnroi_pipes = [ dnnroi(tools.anodes[n], ts_p0, ts_p1, output_scale=1, nchunks=nchunks) for n in std.range(0, std.length(tools.anodes) - 1) ];
+local nfsp_pipes = if use_dnnroi then 
+[
+  g.intern(
+    innodes=[chsel_pipes[n]],
+    outnodes=[dnnroi_pipes[n],sinks.decon_pipe[n]],
+    centernodes=[nf_pipes[n], sp_pipes[n], sp_fans[n], sinks.decon_pipe[n]],
+    edges=[
+      g.edge(chsel_pipes[n], nf_pipes[n], 0, 0),
+      g.edge(nf_pipes[n], sp_pipes[n], 0, 0),
+      g.edge(sp_pipes[n], sp_fans[n], 0, 0),
+      g.edge(sp_fans[n], dnnroi_pipes[n], 0, 0),
+      g.edge(sp_fans[n], sinks.decon_pipe[n], 1, 0),
+    ],
+    iports=chsel_pipes[n].iports,
+    oports=dnnroi_pipes[n].oports+sinks.decon_pipe[n].oports,
+    name='nfsp_pipe_%d' % n,
+  )
+  for n in std.range(0, std.length(tools.anodes) - 1)
+]
+else
+[
   g.pipeline([
                chsel_pipes[n],
                //sinks.orig_pipe[n],
@@ -177,8 +269,9 @@ local nfsp_pipes = [
 
 local fanpipe = f.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf');
 
-local retagger = g.pnode({
+local retagger = function(name) g.pnode({
   type: 'Retagger',
+  name: name,
   data: {
     // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
     tag_rules: [{
@@ -190,16 +283,89 @@ local retagger = g.pnode({
       merge: {
         'gauss\\d': 'gauss',
         'wiener\\d': 'wiener',
+        'dnnsp\\d': 'dnnsp',
       },
     }],
   },
 }, nin=1, nout=1);
 
-local sink = g.pnode({ type: 'DumpFrames' }, nin=1, nout=0);
+local retag_dnnroi = retagger("retag_dnnroi");
+local retag_sp = retagger("retag_sp");
 
 
-// local graph = g.pipeline([wcls_input.adc_digits, rootfile_creation_frames, fanpipe, retagger, wcls_output.sp_signals, sink]);
-local graph = g.pipeline([wcls_input.adc_digits, fanpipe, retagger, wcls_output.sp_signals, sink]);
+local sink = function(name) g.pnode({ type: 'DumpFrames', name: name }, nin=1, nout=0);
+local sink_dnnroi = sink("sink_dnnroi");
+local sink_sp = sink("sink_sp");
+
+local fanout_apa = g.pnode({
+    type: 'FrameFanout',
+    name: 'fanout_apa',
+    data: {
+        multiplicity: std.length(tools.anodes),
+        "tag_rules": [
+            {
+               "frame": {
+                  ".*": "orig%d" % n
+               },
+               "trace": { }
+            }
+            for n in std.range(0, std.length(tools.anodes) - 1)
+        ]
+        }},
+    nin=1, nout=std.length(tools.anodes));
+local framefanin = function(name) g.pnode({
+    type: 'FrameFanin', 
+    name: name,
+    data: {
+        multiplicity: std.length(tools.anodes),
+
+         "tag_rules": [
+            {     
+                "frame": {
+                  ".*": "framefanin"
+                },
+                trace: {
+                  ['dnnsp%d' % n]: ['dnnsp%d' % n],
+                  ['gauss%d' % n]: ['gauss%d' % n],
+                  ['wiener%d' % n]: ['wiener%d' % n],
+                  ['threshold%d' % n]: ['threshold%d' % n],
+                },
+            }
+            for n in std.range(0, std.length(tools.anodes) - 1)
+         ],    
+         "tags": [ ]
+    },
+}, nin=std.length(tools.anodes), nout=1);
+local fanin_apa_dnnroi = framefanin('fanin_apa_dnnroi');
+local fanin_apa_sp = framefanin('fanin_apa_sp');
+
+local graph = if use_dnnroi then
+ g.intern(
+  innodes=[wcls_input.adc_digits],
+  outnodes=[],
+  centernodes=nfsp_pipes+[fanout_apa, retag_dnnroi, retag_sp, fanin_apa_dnnroi, fanin_apa_sp, wcls_output.sp_signals, wcls_output.dnnsp_signals, sink_dnnroi, sink_sp],
+  edges=[
+    g.edge(wcls_input.adc_digits, fanout_apa, 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[0], 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[1], 1, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_dnnroi, 0, 1),
+    g.edge(fanin_apa_dnnroi, retag_dnnroi, 0, 0),
+    g.edge(retag_dnnroi, wcls_output.dnnsp_signals, 0, 0),
+    g.edge(wcls_output.dnnsp_signals, sink_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_sp, 1, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_sp, 1, 1),
+    g.edge(fanin_apa_sp, retag_sp, 0, 0),
+    g.edge(retag_sp, wcls_output.sp_signals, 0, 0),
+    g.edge(wcls_output.sp_signals, sink_sp, 0, 0),
+  ]
+)
+else
+g.pipeline([wcls_input.adc_digits, 
+fanpipe, 
+retag_sp, 
+wcls_output.sp_signals, 
+sink_sp]);
 
 local app = {
   type: 'TbbFlow',
@@ -210,3 +376,4 @@ local app = {
 
 // Finally, the configuration sequence
 g.uses(graph) + [app]
+

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
@@ -23,6 +23,11 @@
 local epoch = std.extVar('epoch');  // eg "dynamic", "after", "before", "perfect"
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
 local raw_input_label = std.extVar('raw_input_label');  // eg "daq"
+local use_dnnroi = std.extVar('use_dnnroi');
+local nchunks = std.extVar('nchunks');
+local tick_per_slice = std.extVar('tick_per_slice');
+local dnnroi_model_p0 = std.extVar('dnnroi_model_p0');
+local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
@@ -104,6 +109,21 @@ local wcls_output = {
       chanmaskmaps: [],
     },
   }, nin=1, nout=1, uses=[mega_anode]),
+ dnnsp_signals: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'dnnsaver',
+    data: {
+      anode: wc.tn(mega_anode),
+      digitize: false,  // true means save as RawDigit, else recob::Wire
+      frame_tags: ['dnnsp'],
+
+      // this may be needed to convert the decon charge [units:e-] to be consistent with the LArSoft default ?unit? e.g. decon charge * 0.005 --> "charge value" to GaussHitFinder
+      frame_scale: [0.02, 0.02, 0.02],
+      nticks: params.daq.nticks,
+      chanmaskmaps: [],
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
+
 };
 
 local perfect = import 'pgrapher/experiment/sbnd/chndb-perfect.jsonnet';
@@ -133,14 +153,88 @@ local nf_maker = import 'pgrapher/experiment/sbnd/nf.jsonnet';
 local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in std.range(0, std.length(tools.anodes) - 1)];
 
 local sp_maker = import 'pgrapher/experiment/sbnd/sp.jsonnet';
+local sp_override = if use_dnnroi then {
+    sparse: true,
+    use_roi_debug_mode: true,
+    save_negative_charge: false, // TODO: no negative charge in gauss, default is false
+    use_multi_plane_protection: true,
+    do_not_mp_protect_traditional: false, // TODO: do_not_mp_protect_traditional to make a clear ref, defualt is false 
+    mp_tick_resolution:4,
+    tight_lf_tag: "",
+    // loose_lf_tag: "",
+    cleanup_roi_tag: "",
+    break_roi_loop1_tag: "",
+    break_roi_loop2_tag: "",
+    shrink_roi_tag: "",
+    extend_roi_tag: "",
+} else {
+    sparse: true,
+};
 local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+
+local dnnroi = import 'dnnroi.jsonnet';
+local ts_p0 = {
+    type: "TorchService",
+    name: "dnnroi_p0",
+    tick_per_slice: tick_per_slice, 
+    data: {
+        model: dnnroi_model_p0,
+        device: "cpu",
+        concurrency: 1,
+    },
+};
+
+local ts_p1 = {
+    type: "TorchService",
+    name: "dnnroi_p1",
+    tick_per_slice: tick_per_slice, 
+    data: {
+        model: dnnroi_model_p1,
+        device: "cpu",
+        concurrency: 1,
+    },
+};
+
+local fanout = function (name, multiplicity=2)
+  g.pnode({
+    type: 'FrameFanout',
+    name: name,
+    data: {
+        multiplicity: multiplicity
+    },
+  }, nin=1, nout=multiplicity);
+
+local sp_fans = [fanout("sp_fan_%d" % n) for n in std.range(0, std.length(tools.anodes) - 1)];
+local dnnroi_pipes = [ dnnroi(tools.anodes[n], ts_p0, ts_p1, output_scale=1, nchunks=nchunks) for n in std.range(0, std.length(tools.anodes) - 1) ];
+
+
 
 local magoutput = 'sbnd-data-check.root';
 local magnify = import 'pgrapher/experiment/sbnd/magnify-sinks.jsonnet';
 local sinks = magnify(tools, magoutput);
 
-local nfsp_pipes = [
+local nfsp_pipes = if use_dnnroi then
+// oports: 0: dnnroi, 1: traditional sp
+[
+  g.intern(
+    innodes=[chsel_pipes[n]],
+    outnodes=[dnnroi_pipes[n],sp_fans[n]],
+    centernodes=[nf_pipes[n], sp_pipes[n], sp_fans[n]],
+    edges=[
+      g.edge(chsel_pipes[n], nf_pipes[n], 0, 0),
+      g.edge(nf_pipes[n], sp_pipes[n], 0, 0),
+      g.edge(sp_pipes[n], sp_fans[n], 0, 0),
+      g.edge(sp_fans[n], dnnroi_pipes[n], 0, 0),
+    ],
+    iports=chsel_pipes[n].iports,
+    oports=dnnroi_pipes[n].oports+[sp_fans[n].oports[1]],
+    name='nfsp_pipe_%d' % n,
+  )
+  for n in std.range(0, std.length(tools.anodes) - 1)
+]
+else
+[
   g.pipeline([
                chsel_pipes[n],
                //sinks.orig_pipe[n],
@@ -159,8 +253,9 @@ local nfsp_pipes = [
 
 local fanpipe = f.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf');
 
-local retagger = g.pnode({
+local retagger = function(name) g.pnode({
   type: 'Retagger',
+  name: name,
   data: {
     // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
     tag_rules: [{
@@ -172,16 +267,90 @@ local retagger = g.pnode({
       merge: {
         'gauss\\d': 'gauss',
         'wiener\\d': 'wiener',
+        'dnnsp\\d': 'dnnsp',
       },
     }],
   },
 }, nin=1, nout=1);
+local retag_dnnroi = retagger("retag_dnnroi");
+local retag_sp = retagger("retag_sp");
 
-local sink = g.pnode({ type: 'DumpFrames' }, nin=1, nout=0);
+local sink = function(name) g.pnode({ type: 'DumpFrames', name: name }, nin=1, nout=0);
+local sink_dnnroi = sink("sink_dnnroi");
+local sink_sp = sink("sink_sp");
 
+local fanout_apa = g.pnode({
+    type: 'FrameFanout',
+    name: 'fanout_apa',
+    data: {
+        multiplicity: std.length(tools.anodes),
+        "tag_rules": [
+            {
+               "frame": {
+                  ".*": "orig%d" % n
+               },
+               "trace": { }
+            }
+            for n in std.range(0, std.length(tools.anodes) - 1)
+        ]
+        }},
+    nin=1, nout=std.length(tools.anodes));
+local framefanin = function(name) g.pnode({
+    type: 'FrameFanin', 
+    name: name,
+    data: {
+        multiplicity: std.length(tools.anodes),
 
+         "tag_rules": [
+            {     
+                "frame": {
+                  ".*": "framefanin"
+                },
+                trace: {
+                  ['dnnsp%d' % n]: ['dnnsp%d' % n],
+                  ['gauss%d' % n]: ['gauss%d' % n],
+                  ['wiener%d' % n]: ['wiener%d' % n],
+                  ['threshold%d' % n]: ['threshold%d' % n],
+                },
+            }
+            for n in std.range(0, std.length(tools.anodes) - 1)
+         ],    
+         "tags": [ ]
+    },
+}, nin=std.length(tools.anodes), nout=1);
+local fanin_apa_dnnroi = framefanin('fanin_apa_dnnroi');
+local fanin_apa_sp = framefanin('fanin_apa_sp');
+
+local fanpipe = f.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf');
 // local graph = g.pipeline([wcls_input.adc_digits, rootfile_creation_frames, fanpipe, retagger, wcls_output.sp_signals, sink]);
-local graph = g.pipeline([wcls_input.adc_digits, fanpipe, retagger, wcls_output.sp_signals, sink]);
+local graph = if use_dnnroi then
+g.intern(
+  innodes=[wcls_input.adc_digits],
+  outnodes=[],
+  centernodes=nfsp_pipes+[fanout_apa, retag_dnnroi, retag_sp, fanin_apa_dnnroi, fanin_apa_sp, wcls_output.sp_signals, wcls_output.dnnsp_signals, sink_dnnroi, sink_sp],
+  edges=[
+    g.edge(wcls_input.adc_digits, fanout_apa, 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[0], 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[1], 1, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_dnnroi, 0, 1),
+    g.edge(fanin_apa_dnnroi, retag_dnnroi, 0, 0),
+    g.edge(retag_dnnroi, wcls_output.dnnsp_signals, 0, 0),
+    g.edge(wcls_output.dnnsp_signals, sink_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_sp, 1, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_sp, 1, 1),
+    g.edge(fanin_apa_sp, retag_sp, 0, 0),
+    g.edge(retag_sp, wcls_output.sp_signals, 0, 0),
+    g.edge(wcls_output.sp_signals, sink_sp, 0, 0),
+  ]
+)
+else
+g.pipeline([wcls_input.adc_digits, 
+fanpipe,  // nfsp_pipes
+retag_sp,  
+wcls_output.sp_signals, 
+sink_sp]);
+
 
 local app = {
   type: 'TbbFlow',

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_rec.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_rec.jsonnet
@@ -5,11 +5,6 @@
 local reality = std.extVar('reality');
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
 local savetid = std.extVar("save_track_id");
-local use_dnnroi = std.extVar('use_dnnroi');
-local nchunks = std.extVar('nchunks');
-local tick_per_slice = std.extVar('tick_per_slice');
-local dnnroi_model_p0 = std.extVar('dnnroi_model_p0');
-local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/common/funcs.jsonnet';
@@ -33,10 +28,6 @@ local params = base {
     // Electron drift speed, assumes a certain applied E-field
     drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
   },
-  sim: super.sim {
-    // front porch size [us]
-    tick0_time: std.extVar('tick0_time') * wc.us,
-  }
 };
 
 local tools = tools_maker(params);
@@ -116,6 +107,34 @@ local setdrifter = g.pnode({
 // signal plus noise pipelines
 local sn_pipes = sim.splusn_pipelines;
 
+local hio_sp = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_sp%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['loose_lf%d' % n
+        #, 'tight_lf%d' % n
+        #, 'cleanup_roi%d' % n
+        #, 'break_roi_1st%d' % n
+        #, 'break_roi_2nd%d' % n
+        #, 'shrink_roi%d' % n
+        #, 'extend_roi%d' % n
+        , 'mp3_roi%d' % n
+        , 'mp2_roi%d' % n
+        , 'decon_charge%d' % n
+        , 'gauss%d' % n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        tick0: 0,
+        nticks: 3427,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+
 local rng = tools.random;
 local wcls_depoflux_writer = g.pnode({
   type: 'wclsDepoFluxWriter',
@@ -138,24 +157,7 @@ local wcls_depoflux_writer = g.pnode({
 }, nin=1, nout=1, uses=tools.anodes + [tools.field]);
 
 local sp_maker = import 'pgrapher/experiment/sbnd/sp.jsonnet';
-local sp_override = if use_dnnroi then {
-    sparse: true,
-    use_roi_debug_mode: true,
-    save_negative_charge: false, // TODO: no negative charge in gauss, default is false
-    use_multi_plane_protection: true,
-    do_not_mp_protect_traditional: false, // TODO: do_not_mp_protect_traditional to make a clear ref, defualt is false 
-    mp_tick_resolution:4,
-    tight_lf_tag: "",
-    // loose_lf_tag: "", // comment to use as input to dnnsp
-    cleanup_roi_tag: "",
-    break_roi_loop1_tag: "",
-    break_roi_loop2_tag: "",
-    shrink_roi_tag: "",
-    extend_roi_tag: "",
-} else {
-    sparse: true,
-};
-local sp = sp_maker(params, tools, sp_override);
+local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
 local magoutput = 'sbnd-data-check.root';
@@ -193,6 +195,7 @@ local multipass2 = [
                //sinks.raw_pipe[n], 
                
                sp_pipes[n], 
+               hio_sp[n],
 
                //sinks.decon_pipe[n],
                //sinks.threshold_pipe[n],
@@ -273,59 +276,8 @@ local wcls_output_sp = {
        chanmaskmaps: ['bad'],
     },
   }, nin=1, nout=1, uses=[mega_anode]),
- dnnsp_signals: g.pnode({
-    type: 'wclsFrameSaver',
-    name: 'dnnsaver',
-    data: {
-      anode: wc.tn(mega_anode),
-      digitize: false,  // true means save as RawDigit, else recob::Wire
-      frame_tags: ['dnnsp'],
-
-      // this may be needed to convert the decon charge [units:e-] to be consistent with the LArSoft default ?unit? e.g. decon charge * 0.005 --> "charge value" to GaussHitFinder
-      frame_scale: [0.02],
-      nticks: params.daq.nticks,
-      chanmaskmaps: [],
-    },
-  }, nin=1, nout=1, uses=[mega_anode]),
 
 };
-local dnnroi = import 'dnnroi.jsonnet';
-
-local ts_p0 = {
-    type: "TorchService",
-    name: "dnnroi_p0",
-    tick_per_slice: tick_per_slice, 
-    data: {
-        model: dnnroi_model_p0,
-        device: "cpu",
-        concurrency: 1,
-    },
-};
-
-local ts_p1 = {
-    type: "TorchService",
-    name: "dnnroi_p1",
-    tick_per_slice: tick_per_slice, 
-    data: {
-        model: dnnroi_model_p1,
-        device: "cpu",
-        concurrency: 1,
-    },
-};
-
-local dnnroi_pipes = [ dnnroi(tools.anodes[n], ts_p0, ts_p1, output_scale=1, nchunks=nchunks) for n in std.range(0, std.length(tools.anodes) - 1) ];
-
-local fanout = function (name, multiplicity=2)
-  g.pnode({
-    type: 'FrameFanout',
-    name: name,
-    data: {
-        multiplicity: multiplicity
-    },
-  }, nin=1, nout=multiplicity);
-
-local sp_fans = [fanout("sp_fan_%d" % n) for n in std.range(0, std.length(tools.anodes) - 1)];
-
 
 
 local chsel_pipes = [
@@ -340,27 +292,7 @@ local chsel_pipes = [
 ];
 
 
-local nfsp_pipes = if use_dnnroi then
-// oports: 0: dnnroi, 1: traditional sp
-[
-  g.intern(
-    innodes=[chsel_pipes[n]],
-    outnodes=[dnnroi_pipes[n],sp_fans[n]],
-    centernodes=[nf_pipes[n], sp_pipes[n], sp_fans[n]],
-    edges=[
-      g.edge(chsel_pipes[n], nf_pipes[n], 0, 0),
-      g.edge(nf_pipes[n], sp_pipes[n], 0, 0),
-      g.edge(sp_pipes[n], sp_fans[n], 0, 0),
-      g.edge(sp_fans[n], dnnroi_pipes[n], 0, 0),
-    ],
-    iports=chsel_pipes[n].iports,
-    oports=dnnroi_pipes[n].oports+[sp_fans[n].oports[1]],
-    name='nfsp_pipe_%d' % n,
-  )
-  for n in std.range(0, std.length(tools.anodes) - 1)
-]
-else
-[
+local nfsp_pipes = [
   g.pipeline([
                chsel_pipes[n],
                //sinks.orig_pipe[n],
@@ -380,9 +312,9 @@ else
 //local fanpipe = f_sp.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf'); // commented Ewerton 2023-05-24
 local fanpipe = f_sp.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf_mod');   //added Ewerton 2023-05-24
 
-local retagger = function(name) g.pnode({
+local retagger_sp = g.pnode({
   type: 'Retagger',
-  name: name,
+  name: 'sp',  //added Ewerton 2023-05-24
   data: {
     // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
     tag_rules: [{
@@ -394,63 +326,14 @@ local retagger = function(name) g.pnode({
       merge: {
         'gauss\\d': 'gauss',
         'wiener\\d': 'wiener',
-        'dnnsp\\d': 'dnnsp',
       },
     }],
   },
 }, nin=1, nout=1);
 
-local retagger_dnnroi = retagger("retagger_dnnroi");
-local retagger_sp = retagger("retagger_sp");
+local sink_sp = g.pnode({ type: 'DumpFrames' }, nin=1, nout=0);
 
-local sink = function(name) g.pnode({ type: 'DumpFrames', name: name }, nin=1, nout=0);
-local sink_dnnroi = sink("sink_dnnroi");
-local sink_sp = sink("sink_sp");
-
-local fanout_apa = g.pnode({
-    type: 'FrameFanout',
-    name: 'fanout_apa',
-    data: {
-        multiplicity: std.length(tools.anodes),
-        "tag_rules": [
-            {
-               "frame": {
-                  ".*": "orig%d" % n
-               },
-               "trace": { }
-            }
-            for n in std.range(0, std.length(tools.anodes) - 1)
-        ]
-        }},
-    nin=1, nout=std.length(tools.anodes));
-
-local framefanin = function(name) g.pnode({
-    type: 'FrameFanin', 
-    name: name,
-    data: {
-        multiplicity: std.length(tools.anodes),
-
-         "tag_rules": [
-            {     
-                "frame": {
-                  ".*": "framefanin"
-                },
-                trace: {
-                  ['dnnsp%d' % n]: ['dnnsp%d' % n],
-                  ['gauss%d' % n]: ['gauss%d' % n],
-                  ['wiener%d' % n]: ['wiener%d' % n],
-                  ['threshold%d' % n]: ['threshold%d' % n],
-                },
-            }
-            for n in std.range(0, std.length(tools.anodes) - 1)
-         ],    
-         "tags": [ ]
-    },
-}, nin=std.length(tools.anodes), nout=1);
-local fanin_apa_dnnroi = framefanin('fanin_apa_dnnroi');
-local fanin_apa_sp = framefanin('fanin_apa_sp');
-
-local graph1_trad = g.pipeline([
+local graph1 = g.pipeline([
 wcls_input_sim.deposet,         //sim
 setdrifter,                     //sim
 wcls_depoflux_writer,           //sim
@@ -464,7 +347,7 @@ sink_sp                         //sp
 ]);
 
 
-local graph2_trad = g.pipeline([
+local graph2 = g.pipeline([
 wcls_input_sim.deposet,         //sim
 setdrifter,                     //sim
 wcls_depoflux_writer,           //sim
@@ -474,45 +357,9 @@ wcls_output_sp.sp_signals,      //sp
 sink_sp                         //sp
 ]);
 
-local graph_sim_dnn = g.pipeline([
-wcls_input_sim.deposet,         //sim
-setdrifter,                     //sim
-wcls_depoflux_writer,           //sim
-bi_manifold1,                   //sim
-]);
-
-
-local graph_sp_dnn = 
-g.intern(
-  innodes=[retagger_sim],
-  outnodes=[],
-  centernodes=nfsp_pipes+[wcls_output_sim.sim_digits, fanout_apa, retagger_dnnroi, retagger_sp, fanin_apa_dnnroi, fanin_apa_sp, wcls_output_sp.sp_signals, wcls_output_sp.dnnsp_signals, sink_dnnroi, sink_sp],
-  edges=[
-    g.edge(retagger_sim, wcls_output_sim.sim_digits, 0, 0),
-    g.edge(wcls_output_sim.sim_digits, fanout_apa, 0, 0),
-    g.edge(fanout_apa, nfsp_pipes[0], 0, 0),
-    g.edge(fanout_apa, nfsp_pipes[1], 1, 0),
-    g.edge(nfsp_pipes[0], fanin_apa_dnnroi, 0, 0),
-    g.edge(nfsp_pipes[1], fanin_apa_dnnroi, 0, 1),
-    g.edge(fanin_apa_dnnroi, retagger_dnnroi, 0, 0),
-    g.edge(retagger_dnnroi, wcls_output_sp.dnnsp_signals, 0, 0),
-    g.edge(wcls_output_sp.dnnsp_signals, sink_dnnroi, 0, 0),
-    g.edge(nfsp_pipes[0], fanin_apa_sp, 1, 0),
-    g.edge(nfsp_pipes[1], fanin_apa_sp, 1, 1),
-    g.edge(fanin_apa_sp, retagger_sp, 0, 0),
-    g.edge(retagger_sp, wcls_output_sp.sp_signals, 0, 0),
-    g.edge(wcls_output_sp.sp_signals, sink_sp, 0, 0),
-  ]
-);
-
-local graph_dnn = g.pipeline([
-graph_sim_dnn,
-graph_sp_dnn,
-]);
-
 local save_simdigits = std.extVar('save_simdigits');
 
-local graph = if use_dnnroi then graph_dnn else if save_simdigits == "true" then graph1_trad else graph2_trad;
+local graph = if save_simdigits == "true" then graph1 else graph2;
 
 local app = {
   type: 'TbbFlow',
@@ -523,4 +370,4 @@ local app = {
 
 // Finally, the configuration sequence
 g.uses(graph) + [app]
-
+  

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_tru.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_tru.jsonnet
@@ -1,0 +1,474 @@
+// This is a main entry point for configuring a wire-cell CLI job to
+// simulate SBND.  It is simplest signal-only simulation with
+// one set of nominal field response function.  
+
+local epoch = std.extVar('epoch');  // eg "dynamic", "after", "before", "perfect"
+local reality = std.extVar('reality');
+// local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
+local sigoutform = "sparse";  // eg "sparse" or "dense"
+local savetid = std.extVar("save_track_id");
+
+local g = import 'pgraph.jsonnet';
+local f = import 'pgrapher/common/funcs.jsonnet';
+local wc = import 'wirecell.jsonnet';
+local io = import 'pgrapher/common/fileio.jsonnet';
+local tools_maker = import 'pgrapher/common/tools.jsonnet';
+
+local data_params = import 'params.jsonnet';
+local simu_params = import 'simparams.jsonnet';
+local params = if reality == 'data' then data_params else simu_params;
+
+local base = import 'pgrapher/experiment/sbnd/simparams.jsonnet';
+local params = base {
+  lar: super.lar { // <- super.lar overrides default values
+    // Longitudinal diffusion constant
+    DL: std.extVar('DL') * wc.cm2 / wc.s,
+    // Transverse diffusion constant
+    DT: std.extVar('DT') * wc.cm2 / wc.s,
+    // Electron lifetime
+    lifetime: std.extVar('lifetime') * wc.ms,
+    // Electron drift speed, assumes a certain applied E-field
+    drift_speed: std.extVar('driftSpeed') * wc.mm / wc.us,
+  },
+};
+
+local tools = tools_maker(params);
+local sim_maker = import 'pgrapher/experiment/sbnd/sim.jsonnet';
+local sim = sim_maker(params, tools);
+local nanodes = std.length(tools.anodes);
+local anode_iota = std.range(0, nanodes - 1);
+
+local wcls_maker = import "pgrapher/ui/wcls/nodes.jsonnet";
+local wcls = wcls_maker(params, tools);
+
+// added Ewerton 2023-03-14
+local wcls_input_sim = {
+    depos: wcls.input.depos(name="", art_tag=std.extVar('inputTag')), //commented Ewerton 2023-03-15
+    deposet: g.pnode({
+            type: 'wclsSimDepoSetSource',
+            name: "",
+            data: {
+                model: "",
+                scale: -1, //scale is -1 to correct a sign error in the SimDepoSource converter.
+                // art_tag: std.extVar('inputTag'), //name of upstream art producer of depos "label:instance:processName"
+                art_tag: std.extVar('inputTag'), //name of upstream art producer of depos "label:instance:processName"
+                id_is_track: if (savetid == 'true') then false else true,
+                assn_art_tag: "",
+            },
+        }, nin=0, nout=1),
+};
+// Collect all the wc/ls output converters for use below.  Note the
+// "name" MUST match what is used in theh "outputers" parameter in the
+// FHiCL that loads this file.
+local mega_anode = {
+  type: 'MegaAnodePlane',
+  name: 'meganodes',
+  data: {
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+  },
+};
+local wcls_output_sim = {
+  // ADC output from simulation
+  // sim_digits: wcls.output.digits(name="simdigits", tags=["orig"]),
+  sim_digits: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'simdigits',
+    data: {
+      // anode: wc.tn(tools.anode),
+      anode: wc.tn(mega_anode),
+      digitize: true,  // true means save as RawDigit, else recob::Wire
+     frame_tags: ['daq'],
+      // nticks: params.daq.nticks,
+      // chanmaskmaps: ['bad'],
+      pedestal_mean: 'native',
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
+ // The noise filtered "ADC" values.  These are truncated for
+  // art::Event but left as floats for the WCT SP.  Note, the tag
+  // "raw" is somewhat historical as the output is not equivalent to
+  // "raw data".
+  nf_digits: wcls.output.digits(name="nfdigits", tags=["raw"]),
+  // The output of signal processing.  Note, there are two signal
+  // sets each created with its own filter.  The "gauss" one is best
+  // for charge reconstruction, the "wiener" is best for S/N
+  // separation.  Both are used in downstream WC code.
+  sp_signals: wcls.output.signals(name="spsignals", tags=["gauss", "wiener"]),
+  // save "threshold" from normal decon for each channel noise
+  // used in imaging
+  sp_thresholds: wcls.output.thresholds(name="spthresholds", tags=["threshold"]),
+};
+
+
+local drifter = sim.drifter;
+
+// added Ewerton 2023-03-14
+local setdrifter = g.pnode({
+            type: 'DepoDrifter',
+            data: {
+                drifter: "Drifter"
+            }
+        }, nin=1, nout=1,
+        uses=[drifter]);
+
+// signal plus noise pipelines
+// local sn_pipes = sim.signal_pipelines;
+local sn_pipes = sim.splusn_pipelines;
+
+local hio_sp = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_sp%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['loose_lf%d' % n
+        , 'tight_lf%d' % n
+        , 'cleanup_roi%d' % n
+        , 'break_roi_1st%d' % n
+        , 'break_roi_2nd%d' % n
+        , 'shrink_roi%d' % n
+        , 'extend_roi%d' % n
+        , 'mp3_roi%d' % n
+        , 'mp2_roi%d' % n
+        , 'decon_charge%d' % n
+        , 'gauss%d' % n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        tick0: 0,
+        nticks: 3427,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+
+local rng = tools.random;
+local wcls_deposetsimchannel_sink = g.pnode({
+  type: 'wclsSimChannelSink',
+  name: 'postdrift',
+  data: {
+    artlabel: 'simpleSC',  // where to save in art::Event
+    anodes_tn: [wc.tn(anode) for anode in tools.anodes],
+    rng: wc.tn(rng),
+    tick: 0.5 * wc.us,
+    start_time: -0.205 * wc.ms,
+    readout_time: self.tick * 3427,
+    nsigma: 3.0,
+    drift_speed: params.lar.drift_speed,
+    u_to_rp: 100 * wc.mm,  // time to collection plane
+    v_to_rp: 100 * wc.mm,  // time to collection plane
+    y_to_rp: 100 * wc.mm,
+    u_time_offset: 0.0 * wc.us,
+    v_time_offset: 0.0 * wc.us,
+    y_time_offset: 0.0 * wc.us,
+    g4_ref_time: -1700 * wc.us,
+    use_energy: true,
+  },
+}, nin=1, nout=1, uses=tools.anodes);
+
+local hio_orig = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_orig%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['orig%d'%n],
+        filename: "g4-rec-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+local sp_maker = import 'pgrapher/experiment/sbnd/sp.jsonnet';
+local sp = sp_maker(params, tools, { sparse: sigoutform == 'sparse' });
+local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
+
+local magoutput = 'sbnd-data-check.root';
+local magnify = import 'pgrapher/experiment/sbnd/magnify-sinks.jsonnet';
+local sinks = magnify(tools, magoutput);
+
+local perfect = import 'pgrapher/experiment/sbnd/chndb-perfect.jsonnet';
+//local base = import 'chndb-base_sbnd.jsonnet';
+
+local chndb = [{
+  type: 'OmniChannelNoiseDB',
+  name: 'ocndbperfect%d' % n,
+  data: perfect(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  // data: base(params, tools.anodes[n], tools.field, n){dft:wc.tn(tools.dft)},
+  uses: [tools.anodes[n], tools.field, tools.dft],
+} for n in anode_iota];
+
+local nf_maker = import 'pgrapher/experiment/sbnd/nf.jsonnet';
+local nf_pipes = [nf_maker(params, tools.anodes[n], chndb[n], n, name='nf%d' % n) for n in anode_iota];
+
+local depo_fanout = [g.pnode({
+    type:'DepoFanout',
+    name:'depo_fanout-%d'%n,
+    data:{
+        multiplicity:2,
+        tags: [],
+    }}, nin=1, nout=2) for n in anode_iota];
+
+// local deposplats = [sim.make_ductor('splat%d'%n, tools.anodes[n], tools.pirs[0], 'DepoSplat', 'deposplat%d'%n) for n in anode_iota] ;
+
+// The approximated sim+sigproc
+local splat = function(params, tools, anode, name=null) {
+    local apaid = anode.data.ident,
+    local sufix = if std.type(name) == "null" then apaid else name,
+    local bg = g.pnode({
+        type:'DepoBagger',
+        name: sufix,
+        data: {
+            gate: [params.sim.ductor.start_time,
+                   params.sim.ductor.start_time+params.sim.ductor.readout_time],
+        },
+    }, nin=1, nout=1),
+    local sp = g.pnode({
+        type: 'DepoFluxSplat',
+        name: sufix,
+        data: {
+            anode: wc.tn(anode),
+            field_response: wc.tn(tools.field), // for speed and origin
+            sparse: true,
+            tick: 0.5 * wc.us,
+            window_start: -0.205 * wc.ms, // TODO: there seems to be an offset between sim and rec?
+            window_duration: self.tick * params.daq.nticks,
+            reference_time: 0.0,
+            "smear_long": [
+                3.5,
+                3.5,
+                3.5
+              ],
+            "smear_tran": [
+                0.4, //can use 0.3 if too strong, otherwise can use 0.4
+                0.4,
+                0.14
+            ]
+        },
+    }, nin=1, nout=1, uses=[anode, tools.field]),
+    local rt = g.pnode({
+        type: 'Retagger',
+        name: sufix,
+        data: {
+            // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+            tag_rules: [{
+                // Retagger also handles "frame" and "trace" like fanin/fanout
+                // merge separately all traces like gaussN to gauss.
+                frame: {
+                ".*": "deposplat%d" % apaid
+                },
+                merge: {
+                ".*": "deposplat%d" % apaid
+                },
+            }],
+        },
+    }, nin=1, nout=1),
+    ret: g.pipeline([bg, sp, rt],"%s-%s" % [bg.name, sp.name]),
+}.ret;
+    
+local deposplats = [splat(params, tools, tools.anodes[n]) for n in anode_iota] ;
+
+local hio_truth = [g.pnode({
+      type: 'HDF5FrameTap',
+      name: 'hio_truth%d' % n,
+      data: {
+        anode: wc.tn(tools.anodes[n]),
+        trace_tags: ['deposplat%d'%n],
+        filename: "g4-tru-%d.h5" % n,
+        chunk: [0, 0], // ncol, nrow
+        gzip: 2,
+        tick0: 0,
+        nticks: 3427,
+        high_throughput: true,
+      },  
+    }, nin=1, nout=1),
+    for n in std.range(0, std.length(tools.anodes) - 1)
+    ];
+
+
+local multipass1 = [
+  g.pipeline([
+               sn_pipes[n],
+             ],
+             'multipass%d' % n)
+  for n in anode_iota
+];
+
+local multipass2 = [
+  g.pipeline([
+               deposplats[n],
+               hio_truth[n],
+             ],
+             'multipass%d' % n)
+  for n in anode_iota
+];
+
+
+local f_sp = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
+local outtags = ['orig%d' % n for n in anode_iota];
+local bi_manifold1 = f.fanpipe('DepoFanout', multipass1, 'FrameFanin', 'sn_mag_nf', outtags);
+// local bi_manifold2 = f_sp.fanpipe('DepoFanout', multipass2, 'FrameFanin', 'sn_mag_nf_mod2', outtags, "true");
+// local bi_manifold2 = f_sp.fanpipe('DepoFanout', multipass2, 'FrameFanin', 'sn_mag_nf_mod2', outtags, "true");
+local bi_manifold2 = f_sp.fanpipe('DepoFanout', multipass2, 'FrameFanin');
+
+local retagger_sim = g.pnode({
+  type: 'Retagger',
+  data: {
+    // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+    tag_rules: [{
+      // Retagger also handles "frame" and "trace" like fanin/fanout
+      // merge separately all traces like gaussN to gauss.
+      frame: {
+        '.*': 'orig',
+      },
+      merge: {
+        'orig\\d': 'daq',
+      },
+    }],
+  },
+}, nin=1, nout=1);
+
+local sink_sim = sim.frame_sink;
+
+//===============================NF+SP============================================
+
+// Collect all the wc/ls output converters for use below.  Note the
+// "name" MUST match what is used in theh "outputers" parameter in the
+// FHiCL that loads this file.
+
+local wcls_output_sp = {
+  // The noise filtered "ADC" values.  These are truncated for
+  // art::Event but left as floats for the WCT SP.  Note, the tag
+  // "raw" is somewhat historical as the output is not equivalent to
+  // "raw data".
+  nf_digits: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'nfsaver',
+    data: {
+      // anode: wc.tn(tools.anode),
+      anode: wc.tn(mega_anode),
+      digitize: true,  // true means save as RawDigit, else recob::Wire
+      frame_tags: ['raw'],
+      // nticks: params.daq.nticks,
+      chanmaskmaps: ['bad'],
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
+
+
+  // The output of signal processing.  Note, there are two signal
+  // sets each created with its own filter.  The "gauss" one is best
+  // for charge reconstruction, the "wiener" is best for S/N
+  // separation.  Both are used in downstream WC code.
+  sp_signals: g.pnode({
+    type: 'wclsFrameSaver',
+    name: 'spsaver',
+    data: {
+      // anode: wc.tn(tools.anode),
+      anode: wc.tn(mega_anode),
+      digitize: false,  // true means save as RawDigit, else recob::Wire
+      frame_tags: ['gauss', 'wiener'],
+
+      // this may be needed to convert the decon charge [units:e-] to be consistent with the LArSoft default ?unit? e.g. decon charge * 0.005 --> "charge value" to GaussHitFinder
+      frame_scale: [1.0, 1.0],
+       nticks: params.daq.nticks,
+      chanmaskmaps: [],
+      //nticks: -1,
+    },
+  }, nin=1, nout=1, uses=[mega_anode]),
+};
+
+
+local chsel_pipes = [
+  g.pnode({
+    type: 'ChannelSelector',
+    name: 'chsel%d' % n,
+    data: {
+      channels: std.range(5632 * n, 5632 * (n + 1) - 1),
+      //tags: ['orig%d' % n], // traces tag
+    },
+  }, nin=1, nout=1)
+  for n in anode_iota
+];
+
+
+local nfsp_pipes = [
+  g.pipeline([
+               chsel_pipes[n],
+               //sinks.orig_pipe[n],
+
+               //nf_pipes[n],
+               //sinks.raw_pipe[n],
+
+               sp_pipes[n],
+              //  hio_sp[n],
+               //sinks.decon_pipe[n],
+               //sinks.threshold_pipe[n],
+               // sinks.debug_pipe[n], // use_roi_debug_mode=true in sp.jsonnet
+             ],
+             'nfsp_pipe_%d' % n)
+  for n in anode_iota
+];
+
+local f_sp = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
+//local fanpipe = f_sp.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf'); // commented Ewerton 2023-05-24
+local fanpipe = f_sp.fanpipe('FrameFanout', nfsp_pipes, 'FrameFanin', 'sn_mag_nf_mod');   //added Ewerton 2023-05-24
+
+local retagger_sp = g.pnode({
+  type: 'Retagger',
+  name: 'sp',  //added Ewerton 2023-05-24
+  data: {
+    // Note: retagger keeps tag_rules an array to be like frame fanin/fanout.
+    tag_rules: [{
+      // Retagger also handles "frame" and "trace" like fanin/fanout
+      // merge separately all traces like gaussN to gauss.
+      frame: {
+        '.*': 'retagger',
+      },
+      merge: {
+        'gauss\\d': 'gauss',
+        'wiener\\d': 'wiener',
+      },
+    }],
+  },
+}, nin=1, nout=1);
+
+local sink_sp = g.pnode({ type: 'DumpFrames' }, nin=1, nout=0);
+
+local graph1 = g.pipeline([
+wcls_input_sim.deposet,         //sim
+setdrifter,                     //sim
+wcls_deposetsimchannel_sink,    //sim
+bi_manifold1,                   //sim // sn_pipes[n]
+retagger_sim,                   //sim
+wcls_output_sim.sim_digits,     //sim
+fanpipe,                        //sp <- nf_pipes[n], sp_pipes[n] (needs channel selector to do fanout correctly)
+retagger_sp,                    //sp
+wcls_output_sp.sp_signals,      //sp
+sink_sp                         //sp
+]);
+
+
+local graph2 = g.pipeline([
+wcls_input_sim.depos,         //sim
+drifter,                     //sim
+wcls_deposetsimchannel_sink,    //sim
+bi_manifold2,                   //sim // changed Ewerton 2023-05-28
+sink_sp                         //sp
+]);
+
+// local save_simdigits = std.extVar('save_simdigits');
+local save_simdigits = "false";
+
+local graph = if save_simdigits == "true" then graph1 else graph2;
+
+local app = {
+  type: 'TbbFlow',
+  data: {
+    edges: g.edges(graph),
+  },
+};
+
+// Finally, the configuration sequence
+g.uses(graph) + [app]

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -17,7 +17,7 @@ sbnd_wcls: {
         configs: []
 
         ## Libraries in which to look for WCT components
-        plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb"]
+        plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb", "WireCellPytorch"]
         inputers: []
         outputers: []
         
@@ -58,6 +58,9 @@ sbnd_wcls_simsp.wcls_main.params:   {
                                      save_simdigits: "false"
           
                                      save_track_id: "true"
+
+                                     dnnroi_model_p0: "DNN_ROI/plane0.ts"
+                                     dnnroi_model_p1: "DNN_ROI/plane1.ts"
                                     }
                                     
 sbnd_wcls_simsp.wcls_main.structs:  {
@@ -71,6 +74,10 @@ sbnd_wcls_simsp.wcls_main.structs:  {
                                      driftSpeed: 1.563
                                      ## simulated front porch size [us]
                                      tick0_time: @local::sbnd_detectorclocks.TriggerOffsetTPC
+                                     nticks: 3427
+                                     use_dnnroi: false
+                                     nchunks: 2
+                                     tick_per_slice: 4
                                     }
 
 # ------------------------------------------------------------------------------------ #
@@ -83,7 +90,9 @@ sbnd_wcls_sp.wcls_main.inputers:  ["wclsRawFrameSource"
                                     # and you must have geo::Geometry service in your environment.
                                     # ,"wclsMultiChannelNoiseDB"
                                   ]
-sbnd_wcls_sp.wcls_main.outputers: ["wclsFrameSaver:spsaver"]
+sbnd_wcls_sp.wcls_main.outputers: ["wclsFrameSaver:spsaver"
+                                   # "wclsFrameSaver:dnnsaver"
+                                  ]
 sbnd_wcls_sp.wcls_main.params :   {
                                    # This locates the input raw::RawDigit collection in the art::Event 
                                    raw_input_label: "daq"   
@@ -98,5 +107,103 @@ sbnd_wcls_sp.wcls_main.params :   {
 
                                    # Save output signal waveforms (recob::Wire) in "sparse" or "dense" form
                                    signal_output_form: "sparse"
+
+                                   dnnroi_model_p0: "DNN_ROI/plane0.ts"
+                                   dnnroi_model_p1: "DNN_ROI/plane1.ts"
+
                                    }
+
+sbnd_wcls_sp.wcls_main.structs:   {
+                                   nticks: 3427
+                                   use_dnnroi: false
+                                   nchunks: 2
+                                   tick_per_slice: 4
+                                  }
+
+
+# ------------------------------------------------------------------------------------ #
+
+## Configuration for generating training samples -- input images
+sbnd_wcls_samples_rec: @local::sbnd_wcls
+sbnd_wcls_samples_rec.wcls_main.plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb", "WireCellPytorch", "WireCellHio"]
+sbnd_wcls_samples_rec.wcls_main.configs:  ["pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_rec.jsonnet"]
+sbnd_wcls_samples_rec.wcls_main.inputers: ["wclsSimDepoSetSource:"]
+sbnd_wcls_samples_rec.wcls_main.outputers:[]
+sbnd_wcls_samples_rec.wcls_main.params:   {
+                                     ## This locates the input SimEnergyDeposits in the art::Event
+                                     inputTag: "ionandscint:"             
+             
+                                     ## Set "data" vs. "sim".  The epoch below probably should follow suit.
+                                     reality: "sim"
+             
+                                     ## if epoch is "dynamic" you MUST add
+                                     ## "wclsMultiChannelNoiseDB" to "inputers" and must NOT
+                                     ## add it if not "dynamic"
+                                     epoch: "perfect"
+             
+                                     ## Save output signal waveforms (recob::Wire) in "sparse" or "dense" form
+                                     signal_output_form: "sparse"
+             
+                                     ## If save_simdigits="false", comment line with "wclsFrameSaver:simdigits" in outputers
+                                     ## If save_simdigits="true", uncomment line with "wclsFrameSaver:simdigits" in outputers
+                                     ## this is whether or not to save raw digits!!! 
+                                     save_simdigits: "false"
+          
+                                     save_track_id: "true"
+                                    }
+                                    
+sbnd_wcls_samples_rec.wcls_main.structs:  {
+                                     ## Longitudinal diffusion constant [cm2/s]
+                                     DL: 4.0
+                                     ## Transverse diffusion constant [cm2/s]
+                                     DT: 8.8
+                                     ## Electron lifetime [ms]
+                                     lifetime: 100.0
+                                     ## Electron drift speed, assumes 0.5 kV/cm and 88.4 K. Units: mm/us
+                                     driftSpeed: 1.563
+                                    }
+
+
+# ------------------------------------------------------------------------------------ #
+
+## Configuration for generating training samples -- target images
+sbnd_wcls_samples_tru: @local::sbnd_wcls
+sbnd_wcls_samples_tru.wcls_main.plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb", "WireCellPytorch", "WireCellHio"]
+sbnd_wcls_samples_tru.wcls_main.configs:  ["pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp-samples_tru.jsonnet"]
+sbnd_wcls_samples_tru.wcls_main.inputers: ["wclsSimDepoSource:"]
+sbnd_wcls_samples_tru.wcls_main.outputers:[] 
+sbnd_wcls_samples_tru.wcls_main.params:   {
+                                     ## This locates the input SimEnergyDeposits in the art::Event
+                                     inputTag: "ionandscint:"             
+             
+                                     ## Set "data" vs. "sim".  The epoch below probably should follow suit.
+                                     reality: "sim"
+             
+                                     ## if epoch is "dynamic" you MUST add
+                                     ## "wclsMultiChannelNoiseDB" to "inputers" and must NOT
+                                     ## add it if not "dynamic"
+                                     epoch: "perfect"
+             
+                                     ## Save output signal waveforms (recob::Wire) in "sparse" or "dense" form
+                                     signal_output_form: "sparse"
+             
+                                     ## If save_simdigits="false", comment line with "wclsFrameSaver:simdigits" in outputers
+                                     ## If save_simdigits="true", uncomment line with "wclsFrameSaver:simdigits" in outputers
+                                     ## this is whether or not to save raw digits!!! 
+                                     save_simdigits: "false"
+          
+                                     save_track_id: "true"
+                                    }
+                                    
+sbnd_wcls_samples_tru.wcls_main.structs:  {
+                                     ## Longitudinal diffusion constant [cm2/s]
+                                     DL: 4.0
+                                     ## Transverse diffusion constant [cm2/s]
+                                     DT: 8.8
+                                     ## Electron lifetime [ms]
+                                     lifetime: 100.0
+                                     ## Electron drift speed, assumes 0.5 kV/cm and 88.4 K. Units: mm/us
+                                     driftSpeed: 1.563
+                                    }
+
 END_PROLOG

--- a/sbndcode/WireCell/wcsp_data_sbnd.fcl
+++ b/sbndcode/WireCell/wcsp_data_sbnd.fcl
@@ -16,7 +16,7 @@ sbnd_wcls: {
         configs: []
 
         ## Libraries in which to look for WCT components
-        plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb"]
+        plugins: ["WireCellGen", "WireCellSigProc", "WireCellRoot", "WireCellPgraph", "WireCellLarsoft", "WireCellTbb", "WireCellPytorch"]
         inputers: []
         outputers: []
         
@@ -53,11 +53,17 @@ sbnd_wcls_sp_data.wcls_main.params :   {
                                         # whether or not to use calibrated, parametrized electronics response
                                         # MUST be a string!
                                         use_paramresp: "true"
-                                        }
+
+                                        dnnroi_model_p0: "DNN_ROI/plane0.ts"
+                                        dnnroi_model_p1: "DNN_ROI/plane1.ts"
+                                       }
 
 sbnd_wcls_sp_data.wcls_main.structs:   { 
                                         # Set the waveform sample length, eg, 6000, 15000, "auto"
                                         nticks: 3427
+                                        use_dnnroi: false
+                                        nchunks: 2
+                                        tick_per_slice: 4
                                        }
 
 END_PROLOG

--- a/sbndcode/WireCell/wirecell_sim_rec_sbnd.fcl
+++ b/sbndcode/WireCell/wirecell_sim_rec_sbnd.fcl
@@ -1,0 +1,90 @@
+#
+# File:    wirecell_sim_rec.fcl
+# Purpose: generates training input images for DNN ROI network
+#
+# This configuration runs Wire-Cell TPC Simulation and Signal Processing
+#
+# Input:
+# - std::vector<sim::SimEnergyDeposit> with label `ionandscint`
+#
+# Output:
+# - h5 file with images of intermediate ROIs
+
+
+#
+# services
+#
+
+#include "simulationservices_sbnd.fcl"
+#include "messages_sbnd.fcl"
+
+#
+# modules
+#
+
+#include "detsimmodules_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "wcsimsp_sbnd.fcl"
+
+process_name: DNNsamplerec
+
+services:
+{
+  TFileService: { fileName: @local::sbnd_tfileoutput.fileName }
+  @table::sbnd_g4_services
+  FileCatalogMetadata: @local::sbnd_file_catalog_mc
+  message:      { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "INFO"} } } #added Ewerton 2023-06-30
+  TimeTracker:  { printSummary: true } 
+}
+
+
+source:
+{
+  module_type:     RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput # inherit shared settings
+    dataTier: "reconstructed"
+    #compressionLevel: 1 # TODO better to use no compression here and Huffman encoding
+  }
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+
+  producers:
+  {
+    # 2D TPC Simulation & Signal Processing 
+    simtpc2d : @local::sbnd_wcls_samples_rec
+  }
+
+  #define the producer and filter modules for this path, order matters,
+  simulate:  [ simtpc2d ] #added wctsp Ewerton 2023-05-16
+
+  trigger_paths : [ simulate ]
+
+  #define the output stream, there could be more than one if using filters
+  stream1:   [ out1 ]
+
+  #ie analyzers and output streams.  these all run simultaneously
+  end_paths: [ stream1 ]
+}
+
+# block to define where the output goes.  if you defined a filter in the physics
+# block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
+# entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
+
+outputs.out1.outputCommands: [ 
+                      "keep *_*_*_*" ,
+                      # "drop *_ionandscint_*_*"
+                      "keep *_simdigits_*_*"
+                    ]
+
+

--- a/sbndcode/WireCell/wirecell_sim_tru_sbnd.fcl
+++ b/sbndcode/WireCell/wirecell_sim_tru_sbnd.fcl
@@ -1,0 +1,91 @@
+# File:    wirecell_sim_tru.fcl
+# Purpose: generates training target images for DNN ROI network
+#
+# This configuration runs Wire-Cell TPC Simulation and Signal Processing
+#
+# Input:
+# - std::vector<sim::SimEnergyDeposit> with label `ionandscint`
+#
+# Output:
+# - h5 file with target image from simulation
+
+#
+# services
+#
+
+#include "simulationservices_sbnd.fcl"
+#include "messages_sbnd.fcl"
+
+#
+# modules
+#
+
+#include "detsimmodules_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "wcsimsp_sbnd.fcl"
+
+
+process_name: DNNsampletru
+
+services:
+{
+  TFileService: { fileName: @local::sbnd_tfileoutput.fileName }
+  @table::sbnd_g4_services
+  FileCatalogMetadata: @local::sbnd_file_catalog_mc
+  message:      { debugModules: ["*"] destinations: { debugmsg:{type: "cout" threshold: "INFO"} } } #added Ewerton 2023-06-30
+  TimeTracker:  { printSummary: true } 
+  
+}
+
+
+source:
+{
+  module_type:     RootInput
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput # inherit shared settings
+    dataTier: "reconstructed"
+    #compressionLevel: 1 # TODO better to use no compression here and Huffman encoding
+  }
+}
+
+# Define and configure some modules to do work on each event.
+# First modules are defined; they are scheduled later.
+# Modules are grouped by type.
+physics:
+{
+
+  producers:
+  {
+    # 2D TPC Simulation & Signal Processing 
+    simtpc2d : @local::sbnd_wcls_samples_tru
+  }
+
+  #define the producer and filter modules for this path, order matters,
+  simulate:  [ simtpc2d ] #added wctsp Ewerton 2023-05-16
+
+  trigger_paths : [ simulate ]
+
+  #define the output stream, there could be more than one if using filters
+  stream1:   [ out1 ]
+
+  #ie analyzers and output streams.  these all run simultaneously
+  end_paths: [ stream1 ]
+}
+
+# block to define where the output goes.  if you defined a filter in the physics
+# block and put it in the trigger_paths then you need to put a SelectEvents: {SelectEvents: [XXX]}
+# entry in the output stream you want those to go to, where XXX is the label of the filter module(s)
+
+outputs.out1.outputCommands: [ 
+                      "keep *_*_*_*" ,
+                      # "drop *_ionandscint_*_*"
+                      "keep *_simdigits_*_*"
+                    ]
+
+
+


### PR DESCRIPTION
## Description 

This PR includes updates to enable DNN ROI finding, as well as configurations for generating samples for training the DNN. When DNN ROI is enabled, `simtpc2d:dnnsp` (or `sptpc2d:dnnsp` for data) `recob:Wire` products are saved, _in addition to_ the traditional `gauss` and `wiener` products.

For now, the option to run signal processing with DNN ROI is set to false, so this PR doesn't immediately affect the current workflow in any way. Using the DNN ROI correctly will require [wirecell release](https://cdcvs.fnal.gov/redmine/issues/29487) and [larwirecell PR#56](https://github.com/LArSoft/larwirecell/pull/56) -- without these updates, the DNN ROI will still run, but the outputs will be wrong.

Detailed notes on updates:

- `wcls-sim-drift-depoflux-nf-sp.jsonnet`, `wcls-nf-sp-data.jsonnet`, `wcls-nf-sp.jsonnet` were updated to run just the current SP chain using traditional ROI finding workflow by default (`use_dnnroi == false`) and run both traditional and DNN ROI finding SP chains when `use_dnnroi == true`.

- `dnnroi.jsonnet` contains the function to run DNN ROI finding on an APA
    
- `wcsimsp_sbnd.fcl` and `wcsp_data_sbnd.fcl` fcls are updated with DNN ROI specific external variables:
    
    - `use_dnnroi`: option to run SP chain using DNN ROI finding, in addition to the traditional SP chain
    - `nchunks`: number of chunks to divide the wire dimension in for inference, must match the NN training configuration
    - `tick_per_slice`: scale factor for downsampling in the time dimension for inference, must match the NN training configuration
    - `dnnroi_model_p0`, `dnnroi_model_p1`: path to NN file, to be stored in `/cvmfs/sbnd.opensciencegrid.org/products/sbnd/sbnd_data/<version>/WireCell`, which is on $WIRECELL_PATH.
- `cafmakerjob_sbnd.fcl`,  `cafmakerjob_sbnd_data_base.fcl`, `standard_detsim_sbnd.fcl`, `standard_reco1_sbnd.fcl`, `reco1_data.fcl`, were updated with commented lines that can be uncommented to run the workflow with DNN ROI finding, using the `dnnsp` product.
    
- `wcls-sim-drift-depoflux-nf-sp-samples_{tru,rec}.jsonnet`, `wirecell_sim_{tru,rec}.fcl`: jsonnets and fcls for generating training samples

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
