### PR TITLE
Add Data-motivated pandoraShower modules that make use of the data calo alg

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
@@ -34,6 +34,7 @@ sbnd_reco2_producers:{
     pandoraCalo:         @local::sbnd_gnewcalomc
     pandoraPid:          @local::sbnd_chi2pid
 
+
     pandoraSCECalo:      @local::sbnd_gnewcalomc
     pandoraSCEPid:       @local::sbnd_chi2pid
 
@@ -49,6 +50,7 @@ sbnd_reco2_producers:{
     pandoraSCEShower:    @local::sbnd_sce_incremental_pandoraModularShowerCreation
     pandoraSCEShowerSBN: @local::sbnd_sce_sbn_pandoraModularShowerCreation
     
+
     ### CRT Veto
     crtveto:        @local::crtvetoproducer_sbnd
 

--- a/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco2_data.fcl
@@ -24,6 +24,14 @@ physics.producers:
     opt0finder:     @local::sbnd_opt0_finder_data
     opt0finderSCE:  @local::sbnd_opt0_finder_data
     tpcpmtbarycentermatching: @local::TPCPMTBarycenterMatchProducer
+
+    ### shower reco for data
+    pandoraShower:       @local::sbnd_incremental_pandoraModularShowerCreationData
+    pandoraShowerSBN:    @local::sbnd_sbn_pandoraModularShowerCreationData
+    ### SCE-aware shower reco for data
+    pandoraSCEShower:    @local::sbnd_sce_incremental_pandoraModularShowerCreationData
+    pandoraSCEShowerSBN: @local::sbnd_sce_sbn_pandoraModularShowerCreationData
+ 
 }
 
 physics.reco2: [ pandora, pandoraTrack, pandoraShower, pandoraShowerSBN, pandoraCaloData, pandoraPidData, 
@@ -48,6 +56,10 @@ physics.producers.opt0finderSCE.SliceProducer:    "pandoraSCE"
 physics.producers.opt0finderSCE.TrackProducer:    "pandoraSCETrack"
 physics.producers.opt0finderSCE.ShowerProducer:   "pandoraSCEShowerSBN"
 physics.producers.opt0finderSCE.CaloProducer:     "pandoraSCECaloData"
+physics.producers.pandoraSCEShower.PFParticleLabel:              "pandoraSCE"
+physics.producers.pandoraSCEShowerSBN.PFParticleLabel:           "pandoraSCE"
+
+
 
 physics.caloskimana: [ caloskim, crtana ]
 physics.end_paths: [stream1, caloskimana ]

--- a/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
+++ b/sbndcode/SBNDPandora/pandoramodules_sbnd.fcl
@@ -133,6 +133,11 @@ sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[8].ShowerDirecti
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].FirstDirectionInputLabel: "TrajDirection"
 sbnd_incremental_pandoraModularShowerCreation.ShowerFinderTools[9].SecondDirectionInputLabel: "ShowerDirection"
 
+sbnd_incremental_pandoraModularShowerCreationData: @local::sbnd_incremental_pandoraModularShowerCreation
+sbnd_incremental_pandoraModularShowerCreationData.ShowerFinderTools[3].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+sbnd_incremental_pandoraModularShowerCreationData.ShowerFinderTools[4].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+sbnd_incremental_pandoraModularShowerCreationData.ShowerFinderTools[7].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+
 sbnd_cheat_pandoraModularShowerCreation.ShowerFinderTools: [
   @local::sbnd_showerstartpositioncheater,
   @local::sbnd_showerdirectioncheater,
@@ -156,6 +161,11 @@ sbnd_sce_incremental_pandoraModularShowerCreation: @local::sbnd_incremental_pand
 sbnd_sce_3dTraj_pandoraModularShowerCreation.ShowerFinderTools[7]:      @local::sbnd_sce_showertrajpointdedx
 sbnd_sce_incremental_pandoraModularShowerCreation.ShowerFinderTools[7]: @local::sbnd_sce_showertrajpointdedx
 
+sbnd_sce_incremental_pandoraModularShowerCreationData: @local::sbnd_sce_incremental_pandoraModularShowerCreation
+sbnd_sce_incremental_pandoraModularShowerCreationData.ShowerFinderTools[3].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+sbnd_sce_incremental_pandoraModularShowerCreationData.ShowerFinderTools[4].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+sbnd_sce_incremental_pandoraModularShowerCreationData.ShowerFinderTools[7].CalorimetryAlg: @local::sbnd_calorimetryalgdata
+
 # SBND config of the sbn common tool set
 sbnd_sbn_showertrajpointdedx:     @local::sbnd_showertrajpointdedx
 sbnd_sce_sbn_showertrajpointdedx: @local::sbnd_sce_showertrajpointdedx
@@ -168,5 +178,16 @@ sbnd_sce_sbn_pandoraModularShowerCreation:  @local::sbnd_3dTraj_pandoraModularSh
 
 sbnd_sbn_pandoraModularShowerCreation.ShowerFinderTools[7]:      @local::sbnd_sbn_showertrajpointdedx
 sbnd_sce_sbn_pandoraModularShowerCreation.ShowerFinderTools[7]:  @local::sbnd_sce_sbn_showertrajpointdedx
+
+sbnd_sbn_pandoraModularShowerCreationData: @local::sbnd_sbn_pandoraModularShowerCreation
+sbnd_sbn_pandoraModularShowerCreationData.ShowerFinderTools[3].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+sbnd_sbn_pandoraModularShowerCreationData.ShowerFinderTools[5].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+sbnd_sbn_pandoraModularShowerCreationData.ShowerFinderTools[7].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+
+sbnd_sce_sbn_pandoraModularShowerCreationData:  @local::sbnd_sce_sbn_pandoraModularShowerCreation
+sbnd_sce_sbn_pandoraModularShowerCreationData.ShowerFinderTools[3].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+sbnd_sce_sbn_pandoraModularShowerCreationData.ShowerFinderTools[5].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+sbnd_sce_sbn_pandoraModularShowerCreationData.ShowerFinderTools[7].CalorimetryAlg:  @local::sbnd_calorimetryalgdata
+
 
 END_PROLOG


### PR DESCRIPTION


## Description 
pandoraShower uses the calo alg in a few places.  Thus there needs to be data versions of the fcl blocks that point to the correct calo alg

## Checklist
- [x ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x ] Assigned at least 1 reviewer under `Reviewers`,
- [x ] Assigned all contributers including yourself under `Assignees`
- [x ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x ] Does this affect the standard workflow? 

### Relevant PR links (optional)
No related PRs

### Link(s) to docdb describing changes (optional)
No docdb describing the issue
