### PR TITLE
CCNueFilter (v10_06_00 production PR)

### DIFF
--- a/sbndcode/Filters/fcls/filters_sbnd.fcl
+++ b/sbndcode/Filters/fcls/filters_sbnd.fcl
@@ -7,10 +7,13 @@ sbnd_finalstateparticlefilter:
   PDG:                   [13, 2212]
 }
 
-sbnd_nuefilter:
+sbnd_ccnuefilter:
 {
- module_type:    NueFilter
- PdgCode:  12  # 12=nue, 14=numu
+  module_type:    GenNuFilter
+  VtxInTPC:       true
+  CC:             true
+  NC:             false
+  LepPDGs:        [11,-11]
 }
 
 

--- a/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_ccnue_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_ccnue_sbnd.fcl
@@ -3,6 +3,10 @@
 
 physics.filters.ccnuefilter: @local::sbnd_ccnuefilter
 
-physics.simulatetpc:  [ rns, generator, loader, largeantnu, tpcfilter, 
-                        ccnuefilter, # adding this filter to the path
-                        corsika, largeantcosmic, largeant, largeantdropped, simplemerge ]
+physics.simulatetpc:  [ rns, generator, loader, largeantnu, 
+                        ccnuefilter, 
+                        corsika, largeantcosmic, largeant, largeantdropped, simplemerge]
+
+physics.simulatedirt: [ rns, generator, loader, largeantnu, "!tpcfilter",
+                        dirtfilter, corsika, largeantcosmic, largeant, largeantdropped, simplemerge,
+                        ccnuefilter]

--- a/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_ccnue_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_ccnue_sbnd.fcl
@@ -1,0 +1,8 @@
+#include "filters_sbnd.fcl"
+#include "prodgenie_corsika_proton_rockbox_sbnd.fcl"
+
+physics.filters.ccnuefilter: @local::sbnd_ccnuefilter
+
+physics.simulatetpc:  [ rns, generator, loader, largeantnu, tpcfilter, 
+                        ccnuefilter, # adding this filter to the path
+                        corsika, largeantcosmic, largeant, largeantdropped, simplemerge ]

--- a/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/gen/genie_corsika/prodgenie_corsika_proton_rockbox_sbnd.fcl
@@ -22,13 +22,13 @@ physics.producers.largeant: @local::sbnd_merge_overlay_sim_sources
 # Tell the dirt filter to use the new largeant for neutrinos only
 physics.filters.dirtfilter.SimEnergyDepModuleName: "largeantnu:LArG4DetectorServicevolTPCActive"
 
-#Merge dropped MCParticle collections
+# Merge dropped MCParticle collections
 physics.producers.largeantdropped: @local::sbnd_merge_dropped_mcpart_overlay
 
 # Change simple merge inputs since we're using an overlay sample
 physics.producers.simplemerge.InputSourcesLabels: ["largeant", "largeantdropped"]
 
-// Change the name of largeant->largeantnu and add corsika and largeant merging
+# Change the name of largeant->largeantnu and add corsika and largeant merging
 physics.simulatetpc:  [ rns, generator, loader, largeantnu, tpcfilter, corsika, largeantcosmic, largeant, largeantdropped, simplemerge ]
 physics.simulatedirt: [ rns, generator, loader, largeantnu, "!tpcfilter", dirtfilter, corsika, largeantcosmic, largeant, largeantdropped, simplemerge ]
 


### PR DESCRIPTION
## Description 
- Adds a new fcl block inside `Filters/filters.fcl` for a charged-current electron-neutrino interaction inside the TPC active volume.
- Adds a new gen fcl that runs rockbox + the ccnue filter. Events with an AV CC nue interaction will be passed, as well dirt activity in the same event.

Partially resolves issue #655. Some validation and discussion in the develop PR #748. 
## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [N/A] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [N/A] Does this affect the standard workflow? 
- [x] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

