### PR TITLE
Cafmakerjob unify pot data label

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_bnblight.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_bnblight.fcl
@@ -1,3 +1,3 @@
 #include "cafmakerjob_sbnd_data_base.fcl"
 
-physics.producers.cafmaker.BNBPOTDataLabel: "sbndbnbinfo"
+physics.producers.cafmaker.BNBPOTDataLabel: "bnbinfo"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_offbeamlight.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_offbeamlight.fcl
@@ -1,3 +1,3 @@
 #include "cafmakerjob_sbnd_data_base.fcl"
 
-physics.producers.cafmaker.OffbeamBNBCountDataLabel: "sbndbnbextinfo"
+physics.producers.cafmaker.OffbeamBNBCountDataLabel: "bnbextinfo"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnblight.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnblight.fcl
@@ -1,3 +1,3 @@
 #include "cafmakerjob_sbnd_data_sce.fcl"
 
-physics.producers.cafmaker.BNBPOTDataLabel: "sbndbnbinfo"
+physics.producers.cafmaker.BNBPOTDataLabel: "bnbinfo"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_offbeamlight.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_offbeamlight.fcl
@@ -1,3 +1,3 @@
 #include "cafmakerjob_sbnd_data_sce.fcl"
 
-physics.producers.cafmaker.OffbeamBNBCountDataLabel: "sbndbnbextinfo"
+physics.producers.cafmaker.OffbeamBNBCountDataLabel: "bnbextinfo"


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [X ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

Requires https://github.com/SBNSoftware/sbncode/pull/523 before merging.

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?

As mentioned in https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=41545, swap to using same labels bnbinfo and extinfo for both SBND and ICARUS.