### PR TITLE
Update DNN ROI fcls for validation production, add option of run only DNN ROI

### DIFF
--- a/sbndcode/JobConfigurations/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(base)
 add_subdirectory(standard)
+add_subdirectory(dnnroi)
 

--- a/sbndcode/JobConfigurations/dnnroi/CMakeLists.txt
+++ b/sbndcode/JobConfigurations/dnnroi/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_fhicl()

--- a/sbndcode/JobConfigurations/dnnroi/reco1_data_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_data_bothrois.fcl
@@ -1,0 +1,12 @@
+# File: reco1_data_bothrois.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# runs Reco1 on data
+# for SP, use both traditional and DNN-based ROI finding, creating three Wire products: simtpc2d:gauss, simtpc2d:wiener (from traditional), simtpc2d:dnnsp (from DNN)
+# for downstream reco1, run gaushitfinder on sptpc2d:gauss, from traditional ROI finding
+#                       to generate matching files with downstream reco1 run on sptpc2d:dnnsp, gaushits should be scrubbed and run again
+#
+#include "reco1_data.fcl"
+
+physics.producers.sptpc2d: @local::sbnd_wcls_sp_data_bothrois
+

--- a/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data.fcl
@@ -1,0 +1,43 @@
+# File: reco1_nosp_data.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# runs everything downstream of sptpc2d in the reco1 chain for data
+# runs gaushitfinder on sptpc2d:guass 
+
+#include "wcsp_data_sbnd.fcl"
+#include "opdeconvolution_sbnd_data.fcl"
+#include "sbnd_ophitfinder_deco_data.fcl"
+#include "sbnd_flashfinder_deco_data.fcl"
+#include "crt_channel_map_service.fcl"
+#include "crt_calib_service.fcl"
+#include "standard_reco1_sbnd.fcl"
+
+services:
+{
+    @table::services
+    @table::sbnd_data_services
+    CRTChannelMapService: @local::crt_channel_map_standard
+    CRTCalibService:      @local::crt_calib_service
+}
+
+physics.producers:
+{
+    @table::physics.producers
+    sptpc2d:   @local::sbnd_wcls_sp_data
+    crtstrips: @local::crtstriphitproducer_data_sbnd
+    crtclustering:  @local::crtclusterproducer_data_sbnd
+    crtspacepoints: @local::crtspacepointproducer_data_sbnd
+    crttracks:      @local::crttrackproducer_data_sbnd
+    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
+    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
+    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
+    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
+}
+
+physics.reco1: [gaushit, numberofhitsfilter, cluster3d, crtstrips, 
+    crtclustering, crtspacepoints, crttracks, opdecopmt, ophitpmt, opflashtpc0, opflashtpc1]
+physics.ana: [superadata]
+
+outputs.out1.SelectEvents: [ "reco1" ]
+
+physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:gauss"

--- a/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data.fcl
@@ -2,37 +2,9 @@
 # Authors: Mun Jung Jung (munjung@uchicago.edu)
 
 # runs everything downstream of sptpc2d in the reco1 chain for data
-# runs gaushitfinder on sptpc2d:guass 
+# runs gaushitfinder on sptpc2d:gauss 
 
-#include "wcsp_data_sbnd.fcl"
-#include "opdeconvolution_sbnd_data.fcl"
-#include "sbnd_ophitfinder_deco_data.fcl"
-#include "sbnd_flashfinder_deco_data.fcl"
-#include "crt_channel_map_service.fcl"
-#include "crt_calib_service.fcl"
-#include "standard_reco1_sbnd.fcl"
-
-services:
-{
-    @table::services
-    @table::sbnd_data_services
-    CRTChannelMapService: @local::crt_channel_map_standard
-    CRTCalibService:      @local::crt_calib_service
-}
-
-physics.producers:
-{
-    @table::physics.producers
-    sptpc2d:   @local::sbnd_wcls_sp_data
-    crtstrips: @local::crtstriphitproducer_data_sbnd
-    crtclustering:  @local::crtclusterproducer_data_sbnd
-    crtspacepoints: @local::crtspacepointproducer_data_sbnd
-    crttracks:      @local::crttrackproducer_data_sbnd
-    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
-    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
-    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
-    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
-}
+#include "reco1_data.fcl"
 
 physics.reco1: [gaushit, numberofhitsfilter, cluster3d, crtstrips, 
     crtclustering, crtspacepoints, crttracks, opdecopmt, ophitpmt, opflashtpc0, opflashtpc1]

--- a/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data_dnnroi.fcl
@@ -1,0 +1,43 @@
+# File: reco1_nosp_data_dnnroi.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# runs everything downstream of sptpc2d in the reco1 chain for data
+# runs gaushitfinder on sptpc2d:dnnsp 
+
+#include "wcsp_data_sbnd.fcl"
+#include "opdeconvolution_sbnd_data.fcl"
+#include "sbnd_ophitfinder_deco_data.fcl"
+#include "sbnd_flashfinder_deco_data.fcl"
+#include "crt_channel_map_service.fcl"
+#include "crt_calib_service.fcl"
+#include "standard_reco1_sbnd.fcl"
+
+services:
+{
+    @table::services
+    @table::sbnd_data_services
+    CRTChannelMapService: @local::crt_channel_map_standard
+    CRTCalibService:      @local::crt_calib_service
+}
+
+physics.producers:
+{
+    @table::physics.producers
+    sptpc2d:   @local::sbnd_wcls_sp_data
+    crtstrips: @local::crtstriphitproducer_data_sbnd
+    crtclustering:  @local::crtclusterproducer_data_sbnd
+    crtspacepoints: @local::crtspacepointproducer_data_sbnd
+    crttracks:      @local::crttrackproducer_data_sbnd
+    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
+    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
+    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
+    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
+}
+
+physics.reco1: [gaushit, numberofhitsfilter, cluster3d, crtstrips, 
+    crtclustering, crtspacepoints, crttracks, opdecopmt, ophitpmt, opflashtpc0, opflashtpc1]
+physics.ana: [superadata]
+
+outputs.out1.SelectEvents: [ "reco1" ]
+
+physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_nosp_data_dnnroi.fcl
@@ -4,35 +4,7 @@
 # runs everything downstream of sptpc2d in the reco1 chain for data
 # runs gaushitfinder on sptpc2d:dnnsp 
 
-#include "wcsp_data_sbnd.fcl"
-#include "opdeconvolution_sbnd_data.fcl"
-#include "sbnd_ophitfinder_deco_data.fcl"
-#include "sbnd_flashfinder_deco_data.fcl"
-#include "crt_channel_map_service.fcl"
-#include "crt_calib_service.fcl"
-#include "standard_reco1_sbnd.fcl"
-
-services:
-{
-    @table::services
-    @table::sbnd_data_services
-    CRTChannelMapService: @local::crt_channel_map_standard
-    CRTCalibService:      @local::crt_calib_service
-}
-
-physics.producers:
-{
-    @table::physics.producers
-    sptpc2d:   @local::sbnd_wcls_sp_data
-    crtstrips: @local::crtstriphitproducer_data_sbnd
-    crtclustering:  @local::crtclusterproducer_data_sbnd
-    crtspacepoints: @local::crtspacepointproducer_data_sbnd
-    crttracks:      @local::crttrackproducer_data_sbnd
-    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
-    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
-    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
-    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
-}
+#include "reco1_data.fcl"
 
 physics.reco1: [gaushit, numberofhitsfilter, cluster3d, crtstrips, 
     crtclustering, crtspacepoints, crttracks, opdecopmt, ophitpmt, opflashtpc0, opflashtpc1]

--- a/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
@@ -15,5 +15,4 @@ physics.ana: [superadata]
 
 outputs.out1.SelectEvents: [ "reco1" ]
 
-# uncomment below line to run DNN ROI finding SP for reco
 physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
@@ -1,0 +1,47 @@
+# File: reco1_postscrub_data_dnnroi.fcl
+# Authors: Linyan Wan (lwan@fnal.gov) and Mun Jung Jung (munjung@uchicago.edu)
+# 
+# to be used for the 2025 DNN ROI validation production
+# MUST be run after running "scrub_gaushit_data.fcl" on Reco1 files
+# 
+# runs gaushit, numberofhitsfilter, cluster3d, superadata on sptpc2d:dnnsp Wire products.
+
+#include "wcsp_data_sbnd.fcl"
+#include "opdeconvolution_sbnd_data.fcl"
+#include "sbnd_ophitfinder_deco_data.fcl"
+#include "sbnd_flashfinder_deco_data.fcl"
+#include "crt_channel_map_service.fcl"
+#include "crt_calib_service.fcl"
+#include "standard_reco1_sbnd.fcl"
+
+process_name: Reco1onDNN
+
+services:
+{
+    @table::services
+    @table::sbnd_data_services
+    CRTChannelMapService: @local::crt_channel_map_standard
+    CRTCalibService:      @local::crt_calib_service
+}
+
+physics.producers:
+{
+    @table::physics.producers
+    sptpc2d:   @local::sbnd_wcls_sp_data
+    crtstrips: @local::crtstriphitproducer_data_sbnd
+    crtclustering:  @local::crtclusterproducer_data_sbnd
+    crtspacepoints: @local::crtspacepointproducer_data_sbnd
+    crttracks:      @local::crttrackproducer_data_sbnd
+    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
+    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
+    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
+    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
+}
+
+physics.reco1: [gaushit, numberofhitsfilter, cluster3d]
+physics.ana: [superadata]
+
+outputs.out1.SelectEvents: [ "reco1" ]
+
+# uncomment below line to run DNN ROI finding SP for reco
+physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/reco1_postscrub_data_dnnroi.fcl
@@ -6,37 +6,9 @@
 # 
 # runs gaushit, numberofhitsfilter, cluster3d, superadata on sptpc2d:dnnsp Wire products.
 
-#include "wcsp_data_sbnd.fcl"
-#include "opdeconvolution_sbnd_data.fcl"
-#include "sbnd_ophitfinder_deco_data.fcl"
-#include "sbnd_flashfinder_deco_data.fcl"
-#include "crt_channel_map_service.fcl"
-#include "crt_calib_service.fcl"
-#include "standard_reco1_sbnd.fcl"
+#include "reco1_data.fcl"
 
 process_name: Reco1onDNN
-
-services:
-{
-    @table::services
-    @table::sbnd_data_services
-    CRTChannelMapService: @local::crt_channel_map_standard
-    CRTCalibService:      @local::crt_calib_service
-}
-
-physics.producers:
-{
-    @table::physics.producers
-    sptpc2d:   @local::sbnd_wcls_sp_data
-    crtstrips: @local::crtstriphitproducer_data_sbnd
-    crtclustering:  @local::crtclusterproducer_data_sbnd
-    crtspacepoints: @local::crtspacepointproducer_data_sbnd
-    crttracks:      @local::crttrackproducer_data_sbnd
-    opdecopmt: @local::SBNDOpDeconvolutionPMT_data
-    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_data
-    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_data
-    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_data
-}
 
 physics.reco1: [gaushit, numberofhitsfilter, cluster3d]
 physics.ana: [superadata]

--- a/sbndcode/JobConfigurations/dnnroi/scrub_gaushit_data.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/scrub_gaushit_data.fcl
@@ -1,0 +1,34 @@
+# File: scrub_gaushit_data.fcl
+# Authors: Linyan Wan (lwan@fnal.gov) and Mun Jung Jung (munjung@uchicago.edu)
+# 
+# to be used for the 2025 DNN ROI validation production
+#
+# removes gaushit products made in Reco 1 for data
+# allows gaushitfinder to be run again on different choice of Wire products
+
+#include "rootoutput_sbnd.fcl"
+#include "sam_sbnd.fcl"
+
+process_name: Scrub
+
+source:
+{
+  module_type:   RootInput
+  inputCommands: [ "keep *_*_*_*",
+                   "drop *_gaushit_*_*"]
+}
+
+outputs:
+{
+  out1:
+  {
+    @table::sbnd_rootoutput
+    dataTier: "reconstructed"
+  }
+}
+
+physics:
+{
+  stream1:   [ out1 ]
+  end_paths: [ stream1 ]
+}

--- a/sbndcode/JobConfigurations/dnnroi/sp_data_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/sp_data_bothrois.fcl
@@ -1,0 +1,40 @@
+#include "services_sbnd.fcl"
+#include "messages_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "wcsp_data_sbnd.fcl"
+
+### fcl to run SP and save Wire products based on both the tradition ROI finding algorithm and the DNN-based ROI finding
+### munjung@uchicago.edu
+
+process_name: WCLS
+
+services:
+{
+    @table::services
+    @table::sbnd_data_services
+}
+
+source: {
+   module_type: RootInput
+}
+
+outputs:{
+  out1:
+  {
+   @table::sbnd_rootoutput # inherit shared settings
+   dataTier: "reconstructed"
+  }
+
+}
+
+physics : {
+    producers: {
+        sptpc2d:   @local::sbnd_wcls_sp_data_bothrois
+    }
+
+   sp : [ sptpc2d ]
+   trigger_paths : [ sp ]
+   
+   o1 : [ out1 ]
+   end_paths: [ o1 ]
+}

--- a/sbndcode/JobConfigurations/dnnroi/sp_data_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/sp_data_bothrois.fcl
@@ -1,10 +1,13 @@
+# File: sp_data_bothrois.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# runs WC 2D signal processing on data using both traditional and DNN-based ROI finding
+# create three Wire products: sptpc2d:gauss, sptpc2d:wiener (from traditional), sptc2d:dnnsp (from DNN)
+
 #include "services_sbnd.fcl"
 #include "messages_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 #include "wcsp_data_sbnd.fcl"
-
-### fcl to run SP and save Wire products based on both the tradition ROI finding algorithm and the DNN-based ROI finding
-### munjung@uchicago.edu
 
 process_name: WCLS
 

--- a/sbndcode/JobConfigurations/dnnroi/sp_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/sp_data_dnnroi.fcl
@@ -1,10 +1,13 @@
+# File: sp_data_dnnroi.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# runs WC 2D signal processing using only DNN-based ROI finding
+# create one Wire product: sptc2d:dnnsp
+
 #include "services_sbnd.fcl"
 #include "messages_sbnd.fcl"
 #include "rootoutput_sbnd.fcl"
 #include "wcsp_data_sbnd.fcl"
-
-### fcl to run the DNN-based ROI finding
-### munjung@uchicago.edu
 
 process_name: WCLS
 

--- a/sbndcode/JobConfigurations/dnnroi/sp_data_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/sp_data_dnnroi.fcl
@@ -1,0 +1,40 @@
+#include "services_sbnd.fcl"
+#include "messages_sbnd.fcl"
+#include "rootoutput_sbnd.fcl"
+#include "wcsp_data_sbnd.fcl"
+
+### fcl to run the DNN-based ROI finding
+### munjung@uchicago.edu
+
+process_name: WCLS
+
+services:
+{
+    @table::services
+    @table::sbnd_data_services
+}
+
+source: {
+   module_type: RootInput
+}
+
+outputs:{
+  out1:
+  {
+   @table::sbnd_rootoutput # inherit shared settings
+   dataTier: "reconstructed"
+  }
+
+}
+
+physics : {
+    producers: {
+        sptpc2d:   @local::sbnd_wcls_sp_data_dnnroi
+    }
+
+   sp : [ sptpc2d ]
+   trigger_paths : [ sp ]
+   
+   o1 : [ out1 ]
+   end_paths: [ o1 ]
+}

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
@@ -1,6 +1,9 @@
-#include "standard_detsim_sbnd.fcl"
+# File: standard_detsim_sbnd_bothrois.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
 
-### fcl to run SP and save Wire products based on both the tradition ROI finding algorithm and the DNN-based ROI finding
-### munjung@uchicago.edu
+# runs WC 2D signal processing during detsim using both traditional and DNN-based ROI finding
+# create three Wire products: simtpc2d:gauss, simtpc2d:wiener (from traditional), simtpc2d:dnnsp (from DNN)
+
+#include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_bothrois

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
@@ -1,0 +1,6 @@
+#include "standard_detsim_sbnd.fcl"
+
+### fcl to run SP and save Wire products based on both the tradition ROI finding algorithm and the DNN-based ROI finding
+### munjung@uchicago.edu
+
+physics.producers.simtpc2d: @local::sbnd_wcls_simsp_bothrois

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
@@ -1,0 +1,6 @@
+#include "standard_detsim_sbnd.fcl"
+
+### fcl to run SP and save Wire products based on the DNN-based ROI finding
+### munjung@uchicago.edu
+
+physics.producers.simtpc2d: @local::sbnd_wcls_simsp_dnnroi

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
@@ -1,6 +1,10 @@
-#include "standard_detsim_sbnd.fcl"
+# File: standard_detsim_sbnd_dnnroi.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
 
-### fcl to run SP and save Wire products based on the DNN-based ROI finding
-### munjung@uchicago.edu
+# runs WC 2D signal processing during detsim using only DNN-based ROI finding
+# create one Wire product: simtpc2d:dnnsp
+
+
+#include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_dnnroi

--- a/sbndcode/JobConfigurations/dnnroi/standard_reco1_sbnd_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_reco1_sbnd_dnnroi.fcl
@@ -1,0 +1,8 @@
+# File: standard_reco1_sbnd_dnnroi.fcl
+# Authors: Mun Jung Jung (munjung@uchicago.edu)
+
+# run MC reco1 on simtpc2d:dnnsp
+
+#include "standard_reco1_sbnd.fcl"
+
+physics.producers.gaushit.CalDataModuleLabel: "simtpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco1_data.fcl
@@ -35,12 +35,3 @@ physics.ana: [superadata]
 outputs.out1.SelectEvents: [ "reco1" ]
 
 physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:gauss"
-
-# uncomment below 4 lines to run DNN ROI finding SP
-#physics.producers.sptpc2d.wcls_main.outputers: ["wclsFrameSaver:spsaver" , "wclsFrameSaver:dnnsaver"]
-#physics.producers.sptpc2d.wcls_main.structs.use_dnnroi: true
-#physics.producers.sptpc2d.wcls_main.structs.nchunks: 2 # should match training config
-#physics.producers.sptpc2d.wcls_main.structs.tick_per_slice: 4 # should match training config
-
-# uncomment below line to run DNN ROI finding SP for reco
-#physics.producers.gaushit.CalDataModuleLabel: "sptpc2d:dnnsp"

--- a/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
@@ -92,9 +92,3 @@ outputs:
                     ]
   }
 }
-
-# uncomment below 4 lines to run DNN ROI finding SP
-# physics.producers.simtpc2d.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
-# physics.producers.simtpc2d.wcls_main.structs.use_dnnroi: true
-# physics.producers.simtpc2d.wcls_main.structs.nchunks: 2 # should match training config
-# physics.producers.simtpc2d.wcls_main.structs.tick_per_slice: 4 # should match training config

--- a/sbndcode/JobConfigurations/standard/standard_reco1_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_reco1_sbnd.fcl
@@ -35,6 +35,3 @@ physics.end_paths:      [ @sequence::physics.end_paths, ana ]
 #outputs table overrides
 outputs.out1.dataTier:       "reconstructed"
 outputs.out1.outputCommands:  [@sequence::outputs.out1.outputCommands, @sequence::sbnd_reco1_drops]
-
-# uncomment below line to run DNN ROI finding SP for reco -- must have run DNN ROI finding in detsim stage
-#physics.producers.gaushit.CalDataModuleLabel: "simtpc2d:dnnsp"

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
@@ -381,7 +381,7 @@ if roi == "dnn" then
  g.intern(
   innodes=[wcls_input.adc_digits],
   outnodes=[],
-  centernodes=nfsp_pipes+[fanout_apa, retag_dnnroi, fanin_apa_dnnroi, wcls_output.dnnsp_signals, sink_dnnroi],
+  centernodes=nfsp_pipes+[fanout_apa, retag_dnnroi, retag_sp, fanin_apa_dnnroi, fanin_apa_sp, wcls_output.dnnsp_signals, sink_dnnroi, sink_sp],
   edges=[
     g.edge(wcls_input.adc_digits, fanout_apa, 0, 0),
     g.edge(fanout_apa, nfsp_pipes[0], 0, 0),
@@ -391,6 +391,10 @@ if roi == "dnn" then
     g.edge(fanin_apa_dnnroi, retag_dnnroi, 0, 0),
     g.edge(retag_dnnroi, wcls_output.dnnsp_signals, 0, 0),
     g.edge(wcls_output.dnnsp_signals, sink_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_sp, 1, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_sp, 1, 1),
+    g.edge(fanin_apa_sp, retag_sp, 0, 0),
+    g.edge(retag_sp, sink_sp, 0, 0),
   ]
 )
 else if roi == "both" then

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -525,7 +525,7 @@ local graph_sp_dnn =
 g.intern(
   innodes=[retagger_sim],
   outnodes=[],
-  centernodes=nfsp_pipes+[wcls_output_sim.sim_digits, fanout_apa, retagger_dnnroi, fanin_apa_dnnroi, wcls_output_sp.dnnsp_signals, sink_dnnroi],
+  centernodes=nfsp_pipes+[wcls_output_sim.sim_digits, fanout_apa, retagger_dnnroi, retagger_sp, fanin_apa_dnnroi, fanin_apa_sp, wcls_output_sp.dnnsp_signals, sink_dnnroi, sink_sp],
   edges=[
     g.edge(retagger_sim, wcls_output_sim.sim_digits, 0, 0),
     g.edge(wcls_output_sim.sim_digits, fanout_apa, 0, 0),
@@ -536,6 +536,10 @@ g.intern(
     g.edge(fanin_apa_dnnroi, retagger_dnnroi, 0, 0),
     g.edge(retagger_dnnroi, wcls_output_sp.dnnsp_signals, 0, 0),
     g.edge(wcls_output_sp.dnnsp_signals, sink_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_sp, 1, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_sp, 1, 1),
+    g.edge(fanin_apa_sp, retagger_sp, 0, 0),
+    g.edge(retagger_sp, sink_sp, 0, 0),
   ]
 );
 

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -5,7 +5,7 @@
 local reality = std.extVar('reality');
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
 local savetid = std.extVar("save_track_id");
-local use_dnnroi = std.extVar('use_dnnroi');
+local roi = std.extVar('roi');
 local nchunks = std.extVar('nchunks');
 local tick_per_slice = std.extVar('tick_per_slice');
 local dnnroi_model_p0 = std.extVar('dnnroi_model_p0');
@@ -138,7 +138,9 @@ local wcls_depoflux_writer = g.pnode({
 }, nin=1, nout=1, uses=tools.anodes + [tools.field]);
 
 local sp_maker = import 'pgrapher/experiment/sbnd/sp.jsonnet';
-local sp_override = if use_dnnroi then {
+
+local sp_override = 
+if roi == "dnn" then {
     sparse: true,
     use_roi_debug_mode: true,
     save_negative_charge: false, // TODO: no negative charge in gauss, default is false
@@ -152,9 +154,31 @@ local sp_override = if use_dnnroi then {
     break_roi_loop2_tag: "",
     shrink_roi_tag: "",
     extend_roi_tag: "",
-} else {
+    // mp3_roi_tag: "",
+    // mp2_roi_tag: "",
+    decon_charge_tag: "",
+    gauss_tag: "",
+    wiener_tag: "",
+} 
+else if roi == "both" then {
+    sparse: true,
+    use_roi_debug_mode: true,
+    save_negative_charge: false, // TODO: no negative charge in gauss, default is false
+    use_multi_plane_protection: true,
+    do_not_mp_protect_traditional: false, // TODO: do_not_mp_protect_traditional to make a clear ref, defualt is false 
+    mp_tick_resolution:4,
+    tight_lf_tag: "",
+    // loose_lf_tag: "", // comment to use as input to dnnsp
+    cleanup_roi_tag: "",
+    break_roi_loop1_tag: "",
+    break_roi_loop2_tag: "",
+    shrink_roi_tag: "",
+    extend_roi_tag: "",
+} 
+else if roi == "trad" then {
     sparse: true,
 };
+
 local sp = sp_maker(params, tools, sp_override);
 local sp_pipes = [sp.make_sigproc(a) for a in tools.anodes];
 
@@ -340,7 +364,8 @@ local chsel_pipes = [
 ];
 
 
-local nfsp_pipes = if use_dnnroi then
+local nfsp_pipes = 
+if roi == "dnn" then
 // oports: 0: dnnroi, 1: traditional sp
 [
   g.intern(
@@ -359,7 +384,26 @@ local nfsp_pipes = if use_dnnroi then
   )
   for n in std.range(0, std.length(tools.anodes) - 1)
 ]
-else
+else if roi == "both" then
+// oports: 0: dnnroi, 1: traditional sp
+[
+  g.intern(
+    innodes=[chsel_pipes[n]],
+    outnodes=[dnnroi_pipes[n],sp_fans[n]],
+    centernodes=[nf_pipes[n], sp_pipes[n], sp_fans[n]],
+    edges=[
+      g.edge(chsel_pipes[n], nf_pipes[n], 0, 0),
+      g.edge(nf_pipes[n], sp_pipes[n], 0, 0),
+      g.edge(sp_pipes[n], sp_fans[n], 0, 0),
+      g.edge(sp_fans[n], dnnroi_pipes[n], 0, 0),
+    ],
+    iports=chsel_pipes[n].iports,
+    oports=dnnroi_pipes[n].oports+[sp_fans[n].oports[1]],
+    name='nfsp_pipe_%d' % n,
+  )
+  for n in std.range(0, std.length(tools.anodes) - 1)
+]
+else if roi == "trad" then
 [
   g.pipeline([
                chsel_pipes[n],
@@ -474,15 +518,32 @@ wcls_output_sp.sp_signals,      //sp
 sink_sp                         //sp
 ]);
 
-local graph_sim_dnn = g.pipeline([
+local graph_sim = g.pipeline([
 wcls_input_sim.deposet,         //sim
 setdrifter,                     //sim
 wcls_depoflux_writer,           //sim
 bi_manifold1,                   //sim
 ]);
 
-
 local graph_sp_dnn = 
+g.intern(
+  innodes=[retagger_sim],
+  outnodes=[],
+  centernodes=nfsp_pipes+[wcls_output_sim.sim_digits, fanout_apa, retagger_dnnroi, fanin_apa_dnnroi, wcls_output_sp.dnnsp_signals, sink_dnnroi],
+  edges=[
+    g.edge(retagger_sim, wcls_output_sim.sim_digits, 0, 0),
+    g.edge(wcls_output_sim.sim_digits, fanout_apa, 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[0], 0, 0),
+    g.edge(fanout_apa, nfsp_pipes[1], 1, 0),
+    g.edge(nfsp_pipes[0], fanin_apa_dnnroi, 0, 0),
+    g.edge(nfsp_pipes[1], fanin_apa_dnnroi, 0, 1),
+    g.edge(fanin_apa_dnnroi, retagger_dnnroi, 0, 0),
+    g.edge(retagger_dnnroi, wcls_output_sp.dnnsp_signals, 0, 0),
+    g.edge(wcls_output_sp.dnnsp_signals, sink_dnnroi, 0, 0),
+  ]
+);
+
+local graph_sp_both = 
 g.intern(
   innodes=[retagger_sim],
   outnodes=[],
@@ -506,13 +567,22 @@ g.intern(
 );
 
 local graph_dnn = g.pipeline([
-graph_sim_dnn,
+graph_sim,
 graph_sp_dnn,
+]);
+
+local graph_both = g.pipeline([
+graph_sim,
+graph_sp_both,
 ]);
 
 local save_simdigits = std.extVar('save_simdigits');
 
-local graph = if use_dnnroi then graph_dnn else if save_simdigits == "true" then graph1_trad else graph2_trad;
+local graph = 
+if roi == "dnn" then graph_dnn 
+else if roi == "both" then graph_both 
+else if save_simdigits == "true" then graph1_trad 
+else graph2_trad;
 
 local app = {
   type: 'TbbFlow',

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -148,14 +148,11 @@ if roi == "dnn" then {
     do_not_mp_protect_traditional: false, // TODO: do_not_mp_protect_traditional to make a clear ref, defualt is false 
     mp_tick_resolution:4,
     tight_lf_tag: "",
-    // loose_lf_tag: "", // comment to use as input to dnnsp
     cleanup_roi_tag: "",
     break_roi_loop1_tag: "",
     break_roi_loop2_tag: "",
     shrink_roi_tag: "",
     extend_roi_tag: "",
-    // mp3_roi_tag: "",
-    // mp2_roi_tag: "",
     decon_charge_tag: "",
     gauss_tag: "",
     wiener_tag: "",
@@ -168,7 +165,6 @@ else if roi == "both" then {
     do_not_mp_protect_traditional: false, // TODO: do_not_mp_protect_traditional to make a clear ref, defualt is false 
     mp_tick_resolution:4,
     tight_lf_tag: "",
-    // loose_lf_tag: "", // comment to use as input to dnnsp
     cleanup_roi_tag: "",
     break_roi_loop1_tag: "",
     break_roi_loop2_tag: "",

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -29,7 +29,7 @@ sbnd_wcls: {
 
 # ------------------------------------------------------------------------------------ #
 
-## Configuration for 2D Sim + Signal Processing 
+## Configuration for 2D Sim + Signal Processing -- default: run only traditional ROI finding
 sbnd_wcls_simsp: @local::sbnd_wcls
 sbnd_wcls_simsp.wcls_main.configs:  ["pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet"]
 sbnd_wcls_simsp.wcls_main.inputers: ["wclsSimDepoSetSource:"]
@@ -61,6 +61,7 @@ sbnd_wcls_simsp.wcls_main.params:   {
 
                                      dnnroi_model_p0: "DNN_ROI/plane0.ts"
                                      dnnroi_model_p1: "DNN_ROI/plane1.ts"
+                                     roi: "trad"
                                     }
                                     
 sbnd_wcls_simsp.wcls_main.structs:  {
@@ -75,10 +76,28 @@ sbnd_wcls_simsp.wcls_main.structs:  {
                                      ## simulated front porch size [us]
                                      tick0_time: @local::sbnd_detectorclocks.TriggerOffsetTPC
                                      nticks: 3427
-                                     use_dnnroi: false
                                      nchunks: 2
                                      tick_per_slice: 4
                                     }
+
+# ------------------------------------------------------------------------------------ #
+
+## Configuration for 2D Sim + Signal Processing -- run both traditional and DNN ROI finding
+sbnd_wcls_simsp_bothrois: @local::sbnd_wcls_simsp
+sbnd_wcls_simsp_bothrois.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+sbnd_wcls_simsp_bothrois.wcls_main.params.roi: "both"
+sbnd_wcls_simsp_bothrois.wcls_main.structs.nchunks: 2 # should match training config
+sbnd_wcls_simsp_bothrois.wcls_main.structs.tick_per_slice: 4 # should match training config
+
+# ------------------------------------------------------------------------------------ #
+## Configuration for 2D Sim + Signal Processing -- run DNN ROI finding only
+sbnd_wcls_simsp_dnnroi: @local::sbnd_wcls_simsp
+sbnd_wcls_simsp_dnnroi.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+sbnd_wcls_simsp_dnnroi.wcls_main.params.roi: "dnn"
+sbnd_wcls_simsp_dnnroi.wcls_main.structs.nchunks: 2 # should match training config
+sbnd_wcls_simsp_dnnroi.wcls_main.structs.tick_per_slice: 4 # should match training config
+
+
 
 # ------------------------------------------------------------------------------------ #
 

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -76,8 +76,8 @@ sbnd_wcls_simsp.wcls_main.structs:  {
                                      ## simulated front porch size [us]
                                      tick0_time: @local::sbnd_detectorclocks.TriggerOffsetTPC
                                      nticks: 3427
-                                     nchunks: 2
-                                     tick_per_slice: 4
+                                     nchunks: 2 # dummy for trad
+                                     tick_per_slice: 4 # dummy for trad
                                     }
 
 # ------------------------------------------------------------------------------------ #

--- a/sbndcode/WireCell/wcsp_data_sbnd.fcl
+++ b/sbndcode/WireCell/wcsp_data_sbnd.fcl
@@ -66,4 +66,14 @@ sbnd_wcls_sp_data.wcls_main.structs:   {
                                         tick_per_slice: 4
                                        }
 
+# ------------------------------------------------------------------------------------ #
+
+## Configuration for **Signal processing ONLY** for data -- run both traditional and DNN ROI finding
+
+sbnd_wcls_sp_data_bothrois: @local::sbnd_wcls_sp_data
+sbnd_wcls_sp_data_bothrois.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+sbnd_wcls_sp_data_bothrois.wcls_main.structs.use_dnnroi: true
+sbnd_wcls_sp_data_bothrois.wcls_main.structs.nchunks: 2 # should match training config
+sbnd_wcls_sp_data_bothrois.wcls_main.structs.tick_per_slice: 4 # should match training config
+
 END_PROLOG

--- a/sbndcode/WireCell/wcsp_data_sbnd.fcl
+++ b/sbndcode/WireCell/wcsp_data_sbnd.fcl
@@ -56,14 +56,14 @@ sbnd_wcls_sp_data.wcls_main.params :   {
 
                                         dnnroi_model_p0: "DNN_ROI/plane0.ts"
                                         dnnroi_model_p1: "DNN_ROI/plane1.ts"
+                                        roi: "trad"
                                        }
 
 sbnd_wcls_sp_data.wcls_main.structs:   { 
                                         # Set the waveform sample length, eg, 6000, 15000, "auto"
                                         nticks: 3427
-                                        use_dnnroi: false
-                                        nchunks: 2
-                                        tick_per_slice: 4
+                                        nchunks: 2 # dummy for trad
+                                        tick_per_slice: 4 # dummy for trad
                                        }
 
 # ------------------------------------------------------------------------------------ #
@@ -71,9 +71,19 @@ sbnd_wcls_sp_data.wcls_main.structs:   {
 ## Configuration for **Signal processing ONLY** for data -- run both traditional and DNN ROI finding
 
 sbnd_wcls_sp_data_bothrois: @local::sbnd_wcls_sp_data
-sbnd_wcls_sp_data_bothrois.wcls_main.outputers: ["wclsDepoFluxWriter:postdrift", "wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
-sbnd_wcls_sp_data_bothrois.wcls_main.structs.use_dnnroi: true
+sbnd_wcls_sp_data_bothrois.wcls_main.outputers: ["wclsFrameSaver:spsaver", "wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+sbnd_wcls_sp_data_bothrois.wcls_main.params.roi: "both"
 sbnd_wcls_sp_data_bothrois.wcls_main.structs.nchunks: 2 # should match training config
 sbnd_wcls_sp_data_bothrois.wcls_main.structs.tick_per_slice: 4 # should match training config
+
+# ------------------------------------------------------------------------------------ #
+
+## Configuration for **Signal processing ONLY** for data -- run DNN ROI finding only
+
+sbnd_wcls_sp_data_dnnroi: @local::sbnd_wcls_sp_data
+sbnd_wcls_sp_data_dnnroi.wcls_main.outputers: ["wclsFrameSaver:dnnsaver"] # "wclsFrameSaver:simdigits" <- by default, do not save RawDigits. Uncomment this line to save RawDigits and set
+sbnd_wcls_sp_data_dnnroi.wcls_main.params.roi: "dnn"
+sbnd_wcls_sp_data_dnnroi.wcls_main.structs.nchunks: 2 # should match training config
+sbnd_wcls_sp_data_dnnroi.wcls_main.structs.tick_per_slice: 4 # should match training config
 
 END_PROLOG


### PR DESCRIPTION
## Description 

This PR updates and refactors fcls for running DNN-base ROI finding. 
Previously, the `JobConfigurations/standard` fcls had commented lines that could be uncommented to enable DNN ROI. With this PR, all relevant fcls are stored in `JobConfigurations/dnnroi` and `JobConfigurations/standard` fcls run only the traditional workflow. 
For the complete transition to DNN ROI for the upcoming fall production, the `JobConfigurations/dnnroi/<standard_fcl_name>_dnnroi.fcl` should replace the `JobConfigurations/dnnroi/<standard_fcl_name>.fcl` files.

Summary of changes in workflow:
- Updates on jsonnets and addition of fcls to run only DNN ROI finding 
- `structs:use_dnnroi` knob to switch between running only traditional ROI and running traditional+DNN ROI in parallel is replaced with `params:roi` knob to choose between `trad`, `dnn`, `both` options.
- for each option, dedicated SP tables are configured in `wcsimsp_sbnd.fcl` and `wcsp_data_sbnd.fcl` files, instead of overwriting each configuration from detsim/reco fcls

new fcls relevant for DNN ROI validation production: 
- MC:
    - `standard_detsim_sbnd_bothrois.fcl`: runs both ROIs during detsim-simtpc2d
    - `standard_reco1_sbnd_dnnroi.fcl`: runs Reco1 on simtpc2d:dnnsp Wire product
- Data:
    - `reco1_data_bothrois.fcl`: runs both ROIs during reco1-sptpc2d, run downstream reco1 on sptpc2d:gauss
    - `scrub_gaushit_data.fcl`: scrubs gaushit from the output of the above fcl
    - `reco1_postscrub_data_dnnroi.fcl`: run downstream reco1 again on the output of the above fcl, this time on sptpc2d:dnnsp


$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
