### PR TITLE
Add wc_device jsonnet parameter and gpu_fcls

### DIFF
--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois.fcl
@@ -7,4 +7,3 @@
 #include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_bothrois
-physics.producers.simtpc2d.wcls_main.params.wc_device: "cpu"

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois_gpu.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_bothrois_gpu.fcl
@@ -7,4 +7,5 @@
 #include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_bothrois
-physics.producers.simtpc2d.wcls_main.params.wc_device: "cpu"
+physics.producers.simtpc2d.wcls_main.params.wc_device: "gpu"
+physics.producers.simtpc2d.wcls_main.plugins: [@sequence::sbnd_wcls_simsp_dnnroi.wcls_main.plugins, "WireCellCuda"]

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi.fcl
@@ -8,4 +8,3 @@
 #include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_dnnroi
-physics.producers.simtpc2d.wcls_main.params.wc_device: "cpu"

--- a/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi_gpu.fcl
+++ b/sbndcode/JobConfigurations/dnnroi/standard_detsim_sbnd_dnnroi_gpu.fcl
@@ -8,4 +8,5 @@
 #include "standard_detsim_sbnd.fcl"
 
 physics.producers.simtpc2d: @local::sbnd_wcls_simsp_dnnroi
-physics.producers.simtpc2d.wcls_main.params.wc_device: "cpu"
+physics.producers.simtpc2d.wcls_main.params.wc_device: "gpu" 
+physics.producers.simtpc2d.wcls_main.plugins: [@sequence::sbnd_wcls_simsp_dnnroi.wcls_main.plugins, "WireCellCuda"]

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp-data.jsonnet
@@ -22,6 +22,7 @@
 
 //local epoch = std.extVar('epoch');  // eg "dynamic", "after", "before", "perfect"
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
+local wc_device = std.extVar('wc_device');
 local raw_input_label = std.extVar('raw_input_label');  // eg "daq"
 local use_paramresp = std.extVar('use_paramresp');  // eg "true" or "false"
 local roi = std.extVar('roi');
@@ -49,9 +50,9 @@ local params = data_params {
     },
 };
 
-
-local tools = tools_maker(params);
-
+local default_tools = tools_maker(params);
+local tools = if wc_device == 'gpu' then std.mergePatch(default_tools,
+    {dft: {type: "TorchDFT", data: {device: wc_device}}}) else default_tools;
 
 local mega_anode = {
   type: 'MegaAnodePlane',
@@ -217,7 +218,7 @@ local ts_p0 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p0,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };
@@ -228,7 +229,7 @@ local ts_p1 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p1,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
@@ -33,14 +33,15 @@ local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
-local default_tools = tools_maker(params);
-local tools = if wc_device == 'gpu' then std.mergePatch(default_tools,
-    {dft: {type: "TorchDFT", data: {device: wc_device}}}) else default_tools;
+local tools_maker = import 'pgrapher/common/tools.jsonnet';
 
 local simu_params = import 'simparams.jsonnet';
 local params = simu_params;
 
-local tools = tools_maker(params);
+local default_tools = tools_maker(params);
+local tools = if wc_device == 'gpu' then std.mergePatch(default_tools,
+    {dft: {type: "TorchDFT", data: {device: wc_device}}}) else default_tools;
+
 
 local mega_anode = {
   type: 'MegaAnodePlane',

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
@@ -21,6 +21,7 @@
 
 
 local epoch = std.extVar('epoch');  // eg "dynamic", "after", "before", "perfect"
+local wc_device = std.extVar('wc_device');
 local sigoutform = std.extVar('signal_output_form');  // eg "sparse" or "dense"
 local raw_input_label = std.extVar('raw_input_label');  // eg "daq"
 local use_dnnroi = std.extVar('use_dnnroi');
@@ -32,7 +33,9 @@ local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
-local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local default_tools = tools_maker(params);
+local tools = if wc_device == 'gpu' then std.mergePatch(default_tools,
+    {dft: {type: "TorchDFT", data: {device: wc_device}}}) else default_tools;
 
 local simu_params = import 'simparams.jsonnet';
 local params = simu_params;
@@ -180,7 +183,7 @@ local ts_p0 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p0,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };
@@ -191,7 +194,7 @@ local ts_p1 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p1,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-nf-sp.jsonnet
@@ -33,7 +33,7 @@ local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/experiment/sbnd/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
-local tools_maker = import 'pgrapher/common/tools.jsonnet';
+local tools_maker = import 'pgrapher/common/tools.jsonnet';'
 
 local simu_params = import 'simparams.jsonnet';
 local params = simu_params;

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/wcls-sim-drift-depoflux-nf-sp.jsonnet
@@ -14,6 +14,7 @@ local dnnroi_model_p1 = std.extVar('dnnroi_model_p1');
 local g = import 'pgraph.jsonnet';
 local f = import 'pgrapher/common/funcs.jsonnet';
 local wc = import 'wirecell.jsonnet';
+local wc_device = std.extVar('wc_device');
 local io = import 'pgrapher/common/fileio.jsonnet';
 local tools_maker = import 'pgrapher/common/tools.jsonnet';
 
@@ -39,7 +40,9 @@ local params = base {
   }
 };
 
-local tools = tools_maker(params);
+local default_tools = tools_maker(params);
+local tools = if wc_device == 'gpu' then std.mergePatch(default_tools,
+    {dft: {type: "TorchDFT", data: {device: wc_device}}}) else default_tools;
 local sim_maker = import 'pgrapher/experiment/sbnd/sim.jsonnet';
 local sim = sim_maker(params, tools);
 local nanodes = std.length(tools.anodes);
@@ -317,7 +320,7 @@ local ts_p0 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p0,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };
@@ -328,7 +331,7 @@ local ts_p1 = {
     tick_per_slice: tick_per_slice, 
     data: {
         model: dnnroi_model_p1,
-        device: "cpu",
+        device: wc_device,
         concurrency: 1,
     },
 };

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -43,7 +43,10 @@ sbnd_wcls_simsp.wcls_main.params:   {
              
                                      ## Set "data" vs. "sim".  The epoch below probably should follow suit.
                                      reality: "sim"
-             
+
+                                     ## if using dnnroi, use this device 
+                                     wc_device: "cpu" 
+
                                      ## if epoch is "dynamic" you MUST add
                                      ## "wclsMultiChannelNoiseDB" to "inputers" and must NOT
                                      ## add it if not "dynamic"
@@ -156,7 +159,6 @@ sbnd_wcls_samples_rec.wcls_main.params:   {
              
                                      ## Set "data" vs. "sim".  The epoch below probably should follow suit.
                                      reality: "sim"
-             
                                      ## if epoch is "dynamic" you MUST add
                                      ## "wclsMultiChannelNoiseDB" to "inputers" and must NOT
                                      ## add it if not "dynamic"
@@ -199,7 +201,7 @@ sbnd_wcls_samples_tru.wcls_main.params:   {
              
                                      ## Set "data" vs. "sim".  The epoch below probably should follow suit.
                                      reality: "sim"
-             
+           
                                      ## if epoch is "dynamic" you MUST add
                                      ## "wclsMultiChannelNoiseDB" to "inputers" and must NOT
                                      ## add it if not "dynamic"

--- a/sbndcode/WireCell/wcsimsp_sbnd.fcl
+++ b/sbndcode/WireCell/wcsimsp_sbnd.fcl
@@ -116,6 +116,9 @@ sbnd_wcls_sp.wcls_main.params :   {
                                    # This locates the input raw::RawDigit collection in the art::Event 
                                    raw_input_label: "daq"   
 
+                                   # if dnnroi is used, this device will be used
+                                   wc_device: "cpu"   
+
                                    # Set "data" vs. "sim".  The epoch below probably should follow suit.
                                    reality: "sim"   
 

--- a/sbndcode/WireCell/wcsp_data_sbnd.fcl
+++ b/sbndcode/WireCell/wcsp_data_sbnd.fcl
@@ -41,6 +41,8 @@ sbnd_wcls_sp_data.wcls_main.outputers: ["wclsFrameSaver:spsaver"]
 sbnd_wcls_sp_data.wcls_main.params :   {
                                         # This locates the input raw::RawDigit collection in the art::Event 
                                         raw_input_label: "daq"   
+                                        # if dnnroi is used, this device will be used
+                                        wc_device: "cpu"   
 
                                         # if epoch is "dynamic" you MUST add
                                         # "wclsMultiChannelNoiseDB" to "inputers" and must NOT


### PR DESCRIPTION
Just wanted to add this to Mun's feature branch to avoid merge conflicts from trying to merge both into develop at the same time. This enables variable device selection in the DFT and ts model loading. Set using the same methods as was done in icaruscode. 

Have confirmed that standard_detsim_sbnd.fcl still works and the GPU activity is non-zero when running the appropriate fcls. If there is any other kind of validation requested, let me know!

<img width="811" height="582" alt="Screenshot from 2025-07-21 15-50-19" src="https://github.com/user-attachments/assets/4c64cbc5-7782-4770-a3db-f16dfb72e738" />

