### PR TITLE
Add detvar fcls to avoid the error for same process being run twice

### DIFF
--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/detsim_detvar_PDSonly_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/detsim_detvar_PDSonly_sbnd.fcl
@@ -1,0 +1,23 @@
+#include "standard_detsim_sbnd.fcl"
+
+process_name: DetSimVar
+
+physics:
+{
+
+producers:
+	{
+rns:       { module_type: "RandomNumberSaver" }
+opdaq:     @local::sbnd_opdetdigitizer
+	}
+
+#define the producer and filter modules for this path, order matters,
+simulate: [rns, opdaq]
+
+#define the output stream, there could be more than one if using filters
+				 stream1:   [ out1 ]
+
+#ie analyzers and output streams.  these all run simultaneously
+				 end_paths: [stream1]
+}
+

--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/detsim_detvar_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/detsim_detvar_sbnd.fcl
@@ -1,0 +1,3 @@
+#include "standard_detsim_sbnd.fcl"
+
+process_name: DetSimVar

--- a/sbndcode/JobConfigurations/standard/g4/g4_detvar_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/g4/g4_detvar_sbnd.fcl
@@ -1,0 +1,3 @@
+#include "standard_g4_sbnd.fcl"
+
+process_name: G4Var

--- a/sbndcode/JobConfigurations/standard/reco/detector_variations/reco1_detvar_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/detector_variations/reco1_detvar_sbnd.fcl
@@ -1,0 +1,3 @@
+#include "standard_reco1_sbnd.fcl"
+
+process_name: Reco1Var

--- a/sbndcode/JobConfigurations/standard/scrubs/scrub_PDS_detsim_reco1.fcl
+++ b/sbndcode/JobConfigurations/standard/scrubs/scrub_PDS_detsim_reco1.fcl
@@ -1,0 +1,33 @@
+# This fcl purely removes products made in opdaq & Reco1 processes.
+# This allows for keeping the identical simulated event on the file and running
+# a variation of PDS.
+#
+# Author Linyan Wan (lwan@fnal.gov)
+
+#include "rootoutput_sbnd.fcl"
+#include "sam_sbnd.fcl"
+
+process_name: Scrub
+
+source:
+{
+module_type:   RootInput
+						inputCommands: [ "keep *_*_*_*",
+						"drop *_opdaq_*_*",
+						"drop *_*_*_Reco1" ]
+}
+
+outputs:
+{
+out1:
+	{
+		@table::sbnd_rootoutput
+			dataTier: "simulated"
+	}
+}
+
+physics:
+{
+stream1:   [ out1 ]
+				  end_paths: [ stream1 ]
+}


### PR DESCRIPTION
## Description 
Adding detvar fcls to avoid the error of "The process name ABC was previously used on these products." when producing detvar samples.
In our setup, ABC can be G4 (recombination & SCE), detsim (PDS, etc), reco1. Reco2 is not relevant since we save reco1 files to run detvar samples on.

This PR is preventive and meant to merge only into develop (not production). Production has a different separate PR.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

This PR does not rely on any other repos.
