### PR TITLE
Overlay modules updated under sbndcode/Overlays

### DIFF
--- a/sbndcode/Overlays/OverlayAna_module.cc
+++ b/sbndcode/Overlays/OverlayAna_module.cc
@@ -123,9 +123,24 @@ void OverlayAna::analyze(art::Event const& e)
     {
 
       unsigned int ch  = rawdigit->Channel();
-      // float        ped = rawdigit->GetPedestal();
+      float        ped = rawdigit->GetPedestal();
+
+      geo::WireID w_id = wr_geom.ChannelToWire(ch)[0];
+      unsigned int wire = w_id.Wire;
+      unsigned int plane = w_id.Plane;
+      unsigned int tpc = w_id.TPC;
+      unsigned int cryo = w_id.Cryostat;
+      std::cout << "RawDigit ch " << ch << ", wire " << wire << ", plane " << plane << ", tpc " << tpc << ", cryo " << cryo << std::endl;
 
       auto adcs = rawdigit->ADCs();
+      
+      // Add pedestal subtraction for MC data (i == 1)
+      if (i == 1) { 
+        for (auto &a : adcs) {
+          a -= ped;
+        }
+      }
+      
       if(i == 0) _tpc_waveforms_data[ch].assign(adcs.begin(), adcs.end());
       if(i == 1) _tpc_waveforms_mc[ch].assign(adcs.begin(), adcs.end());
       if(i == 2) _tpc_waveforms_overlay[ch].assign(adcs.begin(), adcs.end());

--- a/sbndcode/Overlays/overlay_waveforms.fcl
+++ b/sbndcode/Overlays/overlay_waveforms.fcl
@@ -17,6 +17,7 @@ physics.producers: {
     PMTOverlayHits: false
     CRTOverlayHits: false
     TPCRawInputLabels: ["daq", "simtpc2d:daq"]
+    SubtractPedestal:  [false, true]
   }
 
   overlayOpWaveforms:

--- a/sbndcode/Overlays/standard_detsim_overlay_sbnd.fcl
+++ b/sbndcode/Overlays/standard_detsim_overlay_sbnd.fcl
@@ -2,3 +2,4 @@
 
 # get WireCell sim-only module instead
 physics.producers.simtpc2d: @local::sbnd_wcls_sim
+#physics.producers.simtpc2d: @local::sbnd_wcls


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

**Preliminary implementation of Overlay integrated from `icaruscode` to `sbndcode`. The waveform has been tested: the pedestal was subtracted when we summed up data+MC to create the overlay waveform, and then the MC pedestal has been removed.** 

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
