### PR TITLE
Fix nonstandard reco1 output to save filtered events

### DIFF
--- a/sbndcode/JobConfigurations/standard/reco/reco1_data_lowthreshold_dnn.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/reco1_data_lowthreshold_dnn.fcl
@@ -1,4 +1,4 @@
-#include "reco1_data.fcl"
+#include "reco1_data_storefilteredevents.fcl"
 #override the wirecell settings with the top include
 physics.producers.sptpc2d:   @local::sbnd_wcls_sp_data_low
 physics.producers.sptpc2d.wcls_main.structs.enableLowROIThresholds: true


### PR DESCRIPTION
## Description 
The production workflow requires out2 (filtered events) from reco1 stage. 
reco1_data_storefilteredevents.fcl does that, but most of the nonstandard reco1 (DNN ROI, LE DNN ROI, etc) does not. Changing the include file solves it.
Up for discussion how to fix for a longer term.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
No

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
No