### PR TITLE
Move frameshift to bnb streams only

### DIFF
--- a/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
+++ b/sbndcode/JobConfigurations/base/cafmakerjob_sbnd_data_base.fcl
@@ -177,5 +177,3 @@ physics.producers.cafmaker.FlashMatchSCECryoSuffixes: [""]
 # input art file.
 physics.producers.cafmaker.SystWeightLabels: []
 
-physics.producers.cafmaker.SBNDFrameShiftInfoLabel: "frameshift"
-physics.producers.cafmaker.SBNDTimingInfoLabel: "frameshift"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnblight.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnblight.fcl
@@ -1,3 +1,6 @@
 #include "cafmakerjob_sbnd_data_sce.fcl"
 
 physics.producers.cafmaker.BNBPOTDataLabel: "bnbinfo"
+
+physics.producers.cafmaker.SBNDFrameShiftInfoLabel: "frameshift"
+physics.producers.cafmaker.SBNDTimingInfoLabel: "frameshift"

--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnbzerobias.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_data_sce_bnbzerobias.fcl
@@ -1,3 +1,6 @@
 #include "cafmakerjob_sbnd_data_sce.fcl"
 
 physics.producers.cafmaker.BNBPOTDataLabel: "sbndbnbzerobiasinfo"
+
+physics.producers.cafmaker.SBNDFrameShiftInfoLabel: "frameshift"
+physics.producers.cafmaker.SBNDTimingInfoLabel: "frameshift"


### PR DESCRIPTION
## Description 
Fixing the the [initialization issue here](https://github.com/SBNSoftware/sbndcode/pull/804#issuecomment-3277231767) mentioned in the [subissue](https://github.com/SBNSoftware/sbncode/issues/568) by moving frameshift to bnb stream caf fcls only.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 
