### PR TITLE
adding TrackHitFillRRStartCut: 1000 and TrackHitFillRREndCut: 1000 to cafmakerjob_sbnd_sce.fcl

### DIFF
--- a/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
+++ b/sbndcode/JobConfigurations/standard/caf/cafmakerjob_sbnd_sce.fcl
@@ -24,6 +24,8 @@ physics.producers.pandoraTrackRange.TrackLabel: "pandoraSCETrack"
 
 physics.producers.cafmaker.FlashMatchOpDetSuffixes: ["", "op", "ara", "opara"]
 physics.producers.cafmaker.FlashMatchSCECryoSuffixes: ["SCE"]
+physics.producers.cafmaker.TrackHitFillRRStartCut: 1000
+physics.producers.cafmaker.TrackHitFillRREndCut: 1000
 
 physics.producers.pandoraShowerSelectionVars.PandoraLabel: "pandoraSCE"
 physics.producers.pandoraShowerSelectionVars.ShowerLabel:  "pandoraSCEShowerSBN"


### PR DESCRIPTION
Update TrackHitFillRRStartCut and TrackHitFillRREndCut to 1000 cm for MC.
This is for
- Consistency between data and MC CAF
- The default TrackHitFillRREndCut  = 25 cm is not long enough to reproduce chi2 pid (26 cm is needed...)

## Description 
Please provide a detailed description of the changes this pull request introduces. 

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
