### PR TITLE
Feature/acastill lightpropagationfixes

### DIFF
--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrectionAna_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrectionAna_module.cc
@@ -53,9 +53,9 @@ private:
   TTree* fTree; ///< The TTree for storing event information
 
   double fOpFlashT0;
-  double fUpstreamTime_lightonly;
-  double fUpstreamTime_tpczcorr;
-  double fUpstreamTime_propcorr_tpczcorr;
+  double fNuToFLight;
+  double fNuToFCharge;
+  double fOpFlashT0Corrected;
 
   unsigned int _eventID;
   unsigned int _runID;
@@ -73,9 +73,9 @@ LightPropagationCorrectionAna::LightPropagationCorrectionAna(fhicl::ParameterSet
 void LightPropagationCorrectionAna::analyze(art::Event const& e)
 {
   fOpFlashT0=-99999.;
-  fUpstreamTime_lightonly=-99999.;
-  fUpstreamTime_tpczcorr=-99999.;
-  fUpstreamTime_propcorr_tpczcorr=-99999.;
+  fNuToFLight=-99999.;
+  fNuToFCharge=-99999.;
+  fOpFlashT0Corrected=-99999.;
 
   _eventID = -1;
   _runID = -1;
@@ -118,14 +118,14 @@ void LightPropagationCorrectionAna::analyze(art::Event const& e)
     
     std::cout << " Corrected flash time is " << correctedopflash->OpFlashT0 << std::endl;
     std::cout << " Associated with slice id " << slice_v[0]->ID() << std::endl;
-    std::cout << "Corrected flash time light only  " << correctedopflash->UpstreamTime_lightonly << std::endl;
-    std::cout << "Corrected flash time tpc z corr " << correctedopflash->UpstreamTime_tpczcorr << std::endl;
-    std::cout << "Corrected flash time prop corr tpc z corr " << correctedopflash->UpstreamTime_propcorr_tpczcorr << std::endl;
+    std::cout << "Corrected flash time light only  " << correctedopflash->NuToFLight << std::endl;
+    std::cout << "Corrected flash time tpc z corr " << correctedopflash->NuToFCharge << std::endl;
+    std::cout << "Corrected flash time prop corr tpc z corr " << correctedopflash->OpFlashT0Corrected << std::endl;
 
     fOpFlashT0 = correctedopflash->OpFlashT0;
-    fUpstreamTime_lightonly = correctedopflash->UpstreamTime_lightonly;
-    fUpstreamTime_tpczcorr = correctedopflash->UpstreamTime_tpczcorr;
-    fUpstreamTime_propcorr_tpczcorr = correctedopflash->UpstreamTime_propcorr_tpczcorr;
+    fNuToFLight = correctedopflash->NuToFLight;
+    fNuToFCharge = correctedopflash->NuToFCharge;
+    fOpFlashT0Corrected = correctedopflash->OpFlashT0Corrected;
     fTree->Fill();
   }
 }
@@ -141,9 +141,9 @@ void LightPropagationCorrectionAna::beginJob()
   fTree->Branch("subrunID", &_subrunID, "subrunID/i");
 
   fTree->Branch("fOpFlashT0", &fOpFlashT0, "OpFlashT0/d");
-  fTree->Branch("fUpstreamTime_lightonly", &fUpstreamTime_lightonly, "UpstreamTime_lightonly/d");
-  fTree->Branch("fUpstreamTime_tpczcorr", &fUpstreamTime_tpczcorr, "UpstreamTime_tpczcorr/d");
-  fTree->Branch("fUpstreamTime_propcorr_tpczcorr", &fUpstreamTime_propcorr_tpczcorr, "UpstreamTime_propcorr_tpczcorr/d");
+  fTree->Branch("fNuToFLight", &fNuToFLight, "NuToFLight/d");
+  fTree->Branch("fNuToFCharge", &fNuToFCharge, "NuToFCharge/d");
+  fTree->Branch("fOpFlashT0Corrected", &fOpFlashT0Corrected, "OpFlashT0Corrected/d");
 
 }
 

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -74,6 +74,7 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
     fEvent = e.id().event();
     fRun = e.id().run();
     fSubrun = e.id().subRun();
+    _flashgeo->InitializeFlashGeoAlgo();
 
     std::unique_ptr< std::vector<sbn::CorrectedOpFlashTiming> > correctedOpFlashTimes (new std::vector<sbn::CorrectedOpFlashTiming>);
     art::PtrMaker<sbn::CorrectedOpFlashTiming> make_correctedopflashtime_ptr{e};
@@ -128,9 +129,6 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
         ResetSliceInfo();
         // --- Get the slice
         auto & slice = sliceVect[ix];
-
-        // --- Get the slice nu score and check whether we want to correct for it
-
         // Now I need to get all the hits associated to this flash and get the timing for all of them
         // Get the slices PFPs
         double _sliceMaxNuScore = -9999.;
@@ -150,11 +148,7 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
                 fRecoVx= xyz_vertex.X();
                 fRecoVy= xyz_vertex.Y();
                 fRecoVz= xyz_vertex.Z();
-            }            
-            // If correct light propagation time
-
-
-            // Get the SP associated to the PFP and then get the hits associated to the SP. ---> Hits associated to the PFP
+            }
             //Get the spacepoints associated to the PFParticle
             std::vector<art::Ptr<recob::SpacePoint>> PFPSpacePointsVect = pfp_sp_assns.at(pfp.key());
             //Get the SP Hit assns    
@@ -170,7 +164,6 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
                     fSpacePointY.push_back(SP->position().Y());
                     fSpacePointZ.push_back(SP->position().Z());
                     fSpacePointIntegral.push_back(SPHit.at(0)->Integral());
-
                     //Fill Bayrcenter Position
                     if(SP->position().X() < 0){
                         fChargeWeightX[0] += SP->position().X() * SPHit.at(0)->Integral();

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -137,7 +137,7 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
         pfpVect = slice_pfp_assns.at(slice.key());
         for(const art::Ptr<recob::PFParticle> &pfp : pfpVect){
             if(pfp->IsPrimary() &&( std::abs(pfp->PdgCode())==12 || std::abs(pfp->PdgCode())==14 ) ){
-                const std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> pfpMetaVec = pfp_to_metadata.at(pfp->Self());
+                const std::vector<art::Ptr<larpandoraobj::PFParticleMetadata>> pfpMetaVec = pfp_to_metadata.at(pfp.key());
                 for (auto const pfpMeta : pfpMetaVec) {
                     larpandoraobj::PFParticleMetadata::PropertiesMap propertiesMap = pfpMeta->GetPropertiesMap();
                     if (propertiesMap.count("NuScore")) _fNuScore = propertiesMap.at("NuScore");

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -299,11 +299,9 @@ void sbnd::LightPropagationCorrection::produce(art::Event & e)
             newFlashTime = flasht0;
             sbn::CorrectedOpFlashTiming correctedOpFlashTiming;
             correctedOpFlashTiming.OpFlashT0 = originalFlashTime + fEventTriggerTime/1000 - fRWMTime/1000;
-            correctedOpFlashTiming.UpstreamTime_lightonly = originalFlashTime + fEventTriggerTime/1000 - fRWMTime/1000 - (Zcenter/fSpeedOfLight)/1000;
-            correctedOpFlashTiming.UpstreamTime_tpczcorr = originalFlashTime + fEventTriggerTime/1000 - fRWMTime/1000 - (fRecoVz/fSpeedOfLight)/1000;
-            correctedOpFlashTiming.UpstreamTime_propcorr_tpczcorr = newFlashTime + fEventTriggerTime/1000 - fRWMTime/1000 - (fRecoVz/fSpeedOfLight)/1000;
-            correctedOpFlashTiming.FMScore = _fFMScore;
-            correctedOpFlashTiming.SliceNuScore = _sliceMaxNuScore;
+            correctedOpFlashTiming.NuToFLight = (Zcenter/fSpeedOfLight)/1000;
+            correctedOpFlashTiming.NuToFCharge = (fRecoVz/fSpeedOfLight)/1000;
+            correctedOpFlashTiming.OpFlashT0Corrected = newFlashTime + fEventTriggerTime/1000 - fRWMTime/1000;
             correctedOpFlashTimes->emplace_back(std::move(correctedOpFlashTiming));
         }
 


### PR DESCRIPTION
## Description 

Remove CorrectedOpFlash attributes that can be found via slice-correctedopflash assns. It also changes the attributes to reflect each of the corrections separately.

This PR is to be merged with 
https://github.com/SBNSoftware/sbnanaobj/pull/162
https://github.com/SBNSoftware/sbncode/pull/584
https://github.com/SBNSoftware/sbnobj/pull/147

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
