### PR TITLE
Update diffusion fcls to be consistent with detvar workflows

### DIFF
--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_diffusion.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_diffusion.fcl
@@ -1,4 +1,4 @@
-#include "standard_detsim_sbnd.fcl"
+#include "detsim_detvar.fcl"
 
 #remove diffusion
 physics.producers.simtpc2d.wcls_main.structs.DL: 0

--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_longitudinal_diffusion_detvar.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_longitudinal_diffusion_detvar.fcl
@@ -1,6 +1,4 @@
-#include "standard_detsim_sbnd.fcl"
-
-process_name: DetsimVar
+#include "detsim_detvar.fcl"
 
 #remove diffusion
 physics.producers.simtpc2d.wcls_main.structs.DL: 0

--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_transverse_diffusion_detvar.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/standard_detsim_sbnd_no_transverse_diffusion_detvar.fcl
@@ -1,6 +1,4 @@
-#include "standard_detsim_sbnd.fcl"
-
-process_name: DetsimVar
+#include "detsim_detvar.fcl"
 
 #remove diffusion
 physics.producers.simtpc2d.wcls_main.structs.DT: 0


### PR DESCRIPTION
## Description 
Quick fix to the diffusion detector variation fcls: Update to add a unique product label as used in the other detector variation fcls. This also fixes a bug with the "no_diffusion" variation, where workflows with scrub stage as input will fail with a message like "The process name DetSim was previously used on these products."

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?