### PR TITLE
initialize gate counter for both LLT & HLT with no metadata

### DIFF
--- a/sbndcode/Decoders/PTB/SBNDPTBDecoder_module.cc
+++ b/sbndcode/Decoders/PTB/SBNDPTBDecoder_module.cc
@@ -195,6 +195,8 @@ void SBNDPTBDecoder::_process_PTB_AUX(const artdaq::Fragment& frag, ptbsv_t &sou
 	  wt = tstruct.word_type;
 	  tstruct.trigger_word = ctbfrag.Trigger(iword)->trigger_word;
 	  tstruct.timestamp = ctbfrag.Trigger(iword)->timestamp;
+ 	  tstruct.prev_timestamp = 0;
+	  tstruct.gate_counter = 0;
 	  if (ctbfrag.Trigger(iword)->IsHLT()) 
 	    {
 	      
@@ -202,10 +204,6 @@ void SBNDPTBDecoder::_process_PTB_AUX(const artdaq::Fragment& frag, ptbsv_t &sou
 		tstruct.prev_timestamp = ctbfrag.PTBWord(iword)->prevTS;
 		tstruct.gate_counter = ctbfrag.Trigger(iword)->gate_counter;
               }
-              else if ( frag.hasMetadata() == false ){ //If data is taken with 128b PTB words
-		tstruct.prev_timestamp = 0;
-		tstruct.gate_counter = 0;
-	      }
 
 
 	      ix = sout.HLTrigs.size();


### PR DESCRIPTION
## Description 
Quick PR to initialize some values written by the PTB decoder to default values. Without initialization, the LLT gate_counter value written by the decoder will give different results for the same input file each time it is run, making it more difficult to validate production workflows.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
First discovered here: https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=43576

Attached image shows the output of the gate_counter value for two output files made using the same input file run through the PTB decoder.
<img width="1226" height="588" alt="image (2)" src="https://github.com/user-attachments/assets/bd67125c-8618-4a59-9c5c-687092afa6f3" />
