### PR TITLE
Functionalise

### DIFF
--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -36,12 +36,12 @@
 
 #include <bitset>
 
-namespace sbnd {
+namespace sbnd::timing {
   class FrameShift;
 }
 
 
-class sbnd::FrameShift : public art::EDProducer {
+class sbnd::timing::FrameShift : public art::EDProducer {
 public:
   explicit FrameShift(fhicl::ParameterSet const& p);
   // The compiler-generated destructor is fine for non-base
@@ -60,10 +60,6 @@ public:
   void beginJob() override;
   void ResetEventVars();
     
-  static constexpr uint64_t InvalidTimestamp = std::numeric_limits<uint64_t>::max(); ///< Invalid frame.    
-  static constexpr uint16_t InvalidTimingChannel = std::numeric_limits<uint16_t>::max(); ///< Invalid frame.    
-  static constexpr uint16_t InvalidTimingType = std::numeric_limits<uint16_t>::max(); ///< Invalid frame.    
-
 private:
 
   // Declare member data here.
@@ -168,7 +164,7 @@ private:
 };
 
 
-sbnd::FrameShift::FrameShift(fhicl::ParameterSet const& p)
+sbnd::timing::FrameShift::FrameShift(fhicl::ParameterSet const& p)
   : EDProducer{p}  // ,
   // More initializers here.
 {
@@ -205,11 +201,11 @@ sbnd::FrameShift::FrameShift(fhicl::ParameterSet const& p)
   fShiftRWM2Gate = p.get<uint64_t>("ShiftRWM2Gate"); 
   fShiftTDC2PTB = p.get<uint64_t>("ShiftTDC2PTB");
   
-  produces< sbnd::timing::FrameShiftInfo >();
-  produces< sbnd::timing::TimingInfo >();
+  produces< FrameShiftInfo >();
+  produces< TimingInfo >();
 }
 
-void sbnd::FrameShift::produce(art::Event& e)
+void sbnd::timing::FrameShift::produce(art::Event& e)
 {
 
   ResetEventVars();
@@ -241,15 +237,15 @@ void sbnd::FrameShift::produce(art::Event& e)
   }
 
   //---------------------------TDC-----------------------------//
-  art::Handle<std::vector<sbnd::timing::DAQTimestamp>> tdcHandle;
+  art::Handle<std::vector<DAQTimestamp>> tdcHandle;
   e.getByLabel(fTdcDecodeLabel, tdcHandle);
 
   if (!tdcHandle.isValid() || tdcHandle->size() == 0){
-    mf::LogInfo("FrameShift") << "No sbnd::timing::DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!\n";
-    //throw cet::exception("FrameShift") << "No sbnd::timing::DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!";
+    mf::LogInfo("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!\n";
+    //throw cet::exception("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!";
   }
   else{
-    std::vector<sbnd::timing::DAQTimestamp> tdc_v(*tdcHandle);
+    std::vector<DAQTimestamp> tdc_v(*tdcHandle);
     for (size_t i=0; i<tdc_v.size(); i++){
       auto tdc = tdc_v[i];
       const uint32_t  ch = tdc.Channel();
@@ -404,17 +400,17 @@ void sbnd::FrameShift::produce(art::Event& e)
   }
 
   //Decide which global frame to use as reference 
-  uint64_t _global_frame = InvalidTimestamp;
-  if (_tdc_etrig_ts != InvalidTimestamp){ _global_frame = _tdc_etrig_ts; }
-  else if (_hlt_etrig_ts != InvalidTimestamp){ _global_frame = _hlt_etrig_ts; }
+  uint64_t _global_frame = kInvalidTimestamp;
+  if (_tdc_etrig_ts != kInvalidTimestamp){ _global_frame = _tdc_etrig_ts; }
+  else if (_hlt_etrig_ts != kInvalidTimestamp){ _global_frame = _hlt_etrig_ts; }
   else { _global_frame = _raw_ts;}
 
   if (fDebugFrame){
     std::cout << "----------------------------------------------------" << std::endl;
-    if (_tdc_etrig_ts != InvalidTimestamp){
+    if (_tdc_etrig_ts != kInvalidTimestamp){
       std::cout << "Using TDC ETRIG as Global Frame Reference" << std::endl;
     }
-    else if (_hlt_etrig_ts != InvalidTimestamp){
+    else if (_hlt_etrig_ts != kInvalidTimestamp){
       std::cout << "Using PTB HLT ETRIG as Global Frame Reference" << std::endl;
     }
     else {
@@ -587,53 +583,53 @@ void sbnd::FrameShift::produce(art::Event& e)
   if (_isBeam){
 
     //Frame CRT T1
-    if(_tdc_crtt1_ts != InvalidTimestamp){
+    if(_tdc_crtt1_ts != kInvalidTimestamp){
       _frame_crtt1 = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
       _timing_type_crtt1 = 0; //SPECTDC
       _timing_channel_crtt1 = 0;
     }
-    else if(_hlt_crtt1_ts != InvalidTimestamp) {
+    else if(_hlt_crtt1_ts != kInvalidTimestamp) {
       _frame_crtt1 = _hlt_crtt1_ts;
       _timing_type_crtt1 = 1; //PTB HLT
       _timing_channel_crtt1 = _hlt_crtt1;
     }
     else{
-      _frame_crtt1 = InvalidTimestamp;
+      _frame_crtt1 = kInvalidTimestamp;
       _timing_type_crtt1 = 2;
-      _timing_channel_crtt1 = InvalidTimingChannel;
+      _timing_channel_crtt1 = kInvalidChannel;
     }
 
     //Frame Beam Gate
-    if(_tdc_rwm_ts != InvalidTimestamp){
+    if(_tdc_rwm_ts != kInvalidTimestamp){
       _frame_gate = _tdc_rwm_ts + fShiftRWM2Gate; //TODO: + fShiftData2MC;
       _timing_type_gate = 0; //SPECTDC
       _timing_channel_gate = 2;
     }
-    else if(_hlt_gate_ts != InvalidTimestamp){
+    else if(_hlt_gate_ts != kInvalidTimestamp){
       _frame_gate = _hlt_gate_ts;
       _timing_type_gate = 1; //PTB HLT
       _timing_channel_gate = _hlt_gate;
     }else{
-      _frame_gate = InvalidTimestamp;
+      _frame_gate = kInvalidTimestamp;
       _timing_type_gate = 2;
-      _timing_channel_gate = InvalidTimingChannel;
+      _timing_channel_gate = kInvalidChannel;
     }
 
     //Frame ETRIG
-    if(_tdc_etrig_ts != InvalidTimestamp){
+    if(_tdc_etrig_ts != kInvalidTimestamp){
       _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
       _timing_type_etrig = 0; //SPECTDC
       _timing_channel_etrig = 4;
     }
-    else if(_hlt_etrig_ts != InvalidTimestamp){
+    else if(_hlt_etrig_ts != kInvalidTimestamp){
       _frame_etrig = _hlt_etrig_ts;
       _timing_type_etrig = 1; //PTB HLT
       _timing_channel_etrig = _hlt_etrig;
     }
     else {
-      _frame_etrig = InvalidTimestamp;
+      _frame_etrig = kInvalidTimestamp;
       _timing_type_etrig = 2;
-      _timing_channel_etrig = InvalidTimingChannel;
+      _timing_channel_etrig = kInvalidChannel;
     }
 
     //Pick default stream -- beam gate
@@ -644,36 +640,36 @@ void sbnd::FrameShift::produce(art::Event& e)
   else if (_isOffbeam){
 
     //Frame CRT T1
-    if(_tdc_crtt1_ts != InvalidTimestamp){
+    if(_tdc_crtt1_ts != kInvalidTimestamp){
       _frame_crtt1 = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
       _timing_type_crtt1 = 0; //SPECTDC
       _timing_channel_crtt1 = 0;
     }
-    else if(_hlt_crtt1_ts != InvalidTimestamp) {
+    else if(_hlt_crtt1_ts != kInvalidTimestamp) {
       _frame_crtt1 = _hlt_crtt1_ts;
       _timing_type_crtt1 = 1; //PTB HLT
       _timing_channel_crtt1 = _hlt_crtt1;
     }
     else{
-      _frame_crtt1 = InvalidTimestamp;
+      _frame_crtt1 = kInvalidTimestamp;
       _timing_type_crtt1 = 2;
-      _timing_channel_crtt1 = InvalidTimingChannel;
+      _timing_channel_crtt1 = kInvalidChannel;
     }
 
     //Frame Gate -- TODO: I think HLT Gate is recorded in TDC as FTRIG and can be found
-    if(_hlt_gate_ts != InvalidTimestamp) {
+    if(_hlt_gate_ts != kInvalidTimestamp) {
       _frame_gate = _hlt_gate_ts; // TODO: + fShiftData2MC;
       _timing_type_gate = 1; //PTB HLT
       _timing_channel_gate = _hlt_gate;
     }
     else {
-      _frame_gate = InvalidTimestamp;
+      _frame_gate = kInvalidTimestamp;
       _timing_type_gate = 2;
-      _timing_channel_gate = InvalidTimingChannel;
+      _timing_channel_gate = kInvalidChannel;
     }
 
     //Frame ETRIG
-    if(_tdc_etrig_ts != InvalidTimestamp) {
+    if(_tdc_etrig_ts != kInvalidTimestamp) {
       _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
       _timing_type_etrig = 0; //SPECTDC
       _timing_channel_etrig = 4;
@@ -684,9 +680,9 @@ void sbnd::FrameShift::produce(art::Event& e)
       _timing_channel_etrig = _hlt_etrig;
     }
     else {
-      _frame_etrig = InvalidTimestamp;
+      _frame_etrig = kInvalidTimestamp;
       _timing_type_etrig = 2;
-      _timing_channel_etrig = InvalidTimingChannel;
+      _timing_channel_etrig = kInvalidChannel;
     }
 
     //Pick default stream -- beam gate
@@ -697,20 +693,20 @@ void sbnd::FrameShift::produce(art::Event& e)
   else if (_isXmuon){
 
     //Frame ETRIG
-    if(_tdc_etrig_ts != InvalidTimestamp) {
+    if(_tdc_etrig_ts != kInvalidTimestamp) {
       _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
       _timing_type_etrig = 0; //SPECTDC
       _timing_channel_etrig = 4;
     }
-    else if(_hlt_etrig_ts != InvalidTimestamp) {
+    else if(_hlt_etrig_ts != kInvalidTimestamp) {
       _frame_etrig = _hlt_etrig_ts;
       _timing_type_etrig = 1; //PTB HLT
       _timing_channel_etrig = _hlt_etrig;
     }
     else {
-      _frame_etrig = InvalidTimestamp;
+      _frame_etrig = kInvalidTimestamp;
       _timing_type_etrig = 2;
-      _timing_channel_etrig = InvalidTimingChannel;
+      _timing_channel_etrig = kInvalidChannel;
     }
 
     //Pick default stream -- ETRIG
@@ -747,12 +743,12 @@ void sbnd::FrameShift::produce(art::Event& e)
   
 
   //Put product in event
-  std::unique_ptr< sbnd::timing::FrameShiftInfo > newFrameShiftInfo(new sbnd::timing::FrameShiftInfo(_frame_crtt1, _timing_type_crtt1, _timing_channel_crtt1,
+  std::unique_ptr< FrameShiftInfo > newFrameShiftInfo(new FrameShiftInfo(_frame_crtt1, _timing_type_crtt1, _timing_channel_crtt1,
                                                                                       _frame_gate, _timing_type_gate, _timing_channel_gate,
                                                                                       _frame_etrig, _timing_type_etrig,_timing_channel_etrig,
                                                                                       _frame_default, _timing_type_default, _timing_channel_default));
 
-  std::unique_ptr< sbnd::timing::TimingInfo > newTimingInfo(new sbnd::timing::TimingInfo(_raw_ts, _tdc_crtt1_ts, _tdc_bes_ts, _tdc_rwm_ts, _tdc_etrig_ts, _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
+  std::unique_ptr< TimingInfo > newTimingInfo(new TimingInfo(_raw_ts, _tdc_crtt1_ts, _tdc_bes_ts, _tdc_rwm_ts, _tdc_etrig_ts, _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
 
   e.put(std::move(newTimingInfo));
   e.put(std::move(newFrameShiftInfo));
@@ -761,7 +757,7 @@ void sbnd::FrameShift::produce(art::Event& e)
   fTree->Fill();
 }
 
-void sbnd::FrameShift::beginJob()
+void sbnd::timing::FrameShift::beginJob()
 {
   // Implementation of optional member function here.
   //Event Tree
@@ -811,23 +807,23 @@ void sbnd::FrameShift::beginJob()
   fTree->Branch("timing_channel_default", &_timing_channel_default);
 }
 
-void sbnd::FrameShift::ResetEventVars()
+void sbnd::timing::FrameShift::ResetEventVars()
 {
   _run = -1;
   _subrun = -1;
   _event = -1;
 
-  _raw_ts = InvalidTimestamp;
+  _raw_ts = kInvalidTimestamp;
 
   _tdc_ch0.clear();
   _tdc_ch1.clear();
   _tdc_ch2.clear();
   _tdc_ch4.clear();
 
-  _tdc_crtt1_ts = InvalidTimestamp;
-  _tdc_bes_ts = InvalidTimestamp;
-  _tdc_rwm_ts = InvalidTimestamp;
-  _tdc_etrig_ts = InvalidTimestamp;
+  _tdc_crtt1_ts = kInvalidTimestamp;
+  _tdc_bes_ts = kInvalidTimestamp;
+  _tdc_rwm_ts = kInvalidTimestamp;
+  _tdc_etrig_ts = kInvalidTimestamp;
 
   _ptb_hlt_trigger.clear();
   _ptb_hlt_timestamp.clear();
@@ -842,27 +838,27 @@ void sbnd::FrameShift::ResetEventVars()
   _isXmuon = false;  
 
   _hlt_etrig = std::numeric_limits<int>::max();
-  _hlt_etrig_ts = InvalidTimestamp;
+  _hlt_etrig_ts = kInvalidTimestamp;
   _hlt_gate = std::numeric_limits<int>::max();
-  _hlt_gate_ts = InvalidTimestamp;
+  _hlt_gate_ts = kInvalidTimestamp;
   _hlt_crtt1= std::numeric_limits<int>::max();
-  _hlt_crtt1_ts = InvalidTimestamp;
+  _hlt_crtt1_ts = kInvalidTimestamp;
   
-  _frame_crtt1 = InvalidTimestamp;
-  _timing_type_crtt1 = InvalidTimingType;
-  _timing_channel_crtt1 = InvalidTimingChannel;
+  _frame_crtt1 = kInvalidTimestamp;
+  _timing_type_crtt1 = kInvalidType;
+  _timing_channel_crtt1 = kInvalidChannel;
   
-  _frame_gate = InvalidTimestamp;
-  _timing_type_gate = InvalidTimingType;
-  _timing_channel_gate = InvalidTimingChannel;
+  _frame_gate = kInvalidTimestamp;
+  _timing_type_gate = kInvalidType;
+  _timing_channel_gate = kInvalidChannel;
   
-  _frame_etrig = InvalidTimestamp;
-  _timing_type_etrig = InvalidTimingType;
-  _timing_channel_etrig = InvalidTimingChannel;
+  _frame_etrig = kInvalidTimestamp;
+  _timing_type_etrig = kInvalidType;
+  _timing_channel_etrig = kInvalidChannel;
 
-  _frame_default = InvalidTimestamp;
-  _timing_type_default = InvalidTimingType;
-  _timing_channel_default = InvalidTimingChannel;
+  _frame_default = kInvalidTimestamp;
+  _timing_type_default = kInvalidType;
+  _timing_channel_default = kInvalidChannel;
 }
 
-DEFINE_ART_MODULE(sbnd::FrameShift)
+DEFINE_ART_MODULE(sbnd::timing::FrameShift)

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -169,6 +169,8 @@ private:
   TTree *fTree;
   art::ServiceHandle<art::TFileService> tfs;
   int _run, _subrun, _event;
+
+  static constexpr uint64_t kSecondInNanoseconds = static_cast<uint64_t>(1e9);
 };
 
 
@@ -229,38 +231,38 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   GetPTBTimestamps(e);
   FindETRIGs();
 
-  uint64_t global_frame = DecideGlobalFrame();
+  uint64_t global_frame_ts = DecideGlobalFrame();
 
   //---------------------------TDC Frame-----------------------------//
   // ch0: CRT T1
   if (_tdc_ch0.size() != 0)
-    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame);
+    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame_ts);
 
   // ch1: BES
   if (_tdc_ch1.size() != 0)
-    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame);
+    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame_ts);
 
   // ch2: RWM
   if (_tdc_ch2.size() != 0)
-    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame);
+    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame_ts);
 
   if (fDebugTdc){
     std::cout << "----------------------------------------------------" << std::endl;
     std::cout << "TDC Channel 0 (CRTT1) Timestamp: " 
-                      << " (s) = " << _tdc_crtt1_ts/uint64_t(1e9)
-                      << ", (ns) = " << _tdc_crtt1_ts%uint64_t(1e9) 
+                      << " (s) = " << _tdc_crtt1_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _tdc_crtt1_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "TDC Channel 1 (BES) Timestamp: "
-                      << " (s) = " << _tdc_bes_ts/uint64_t(1e9)
-                      << ", (ns) = " << _tdc_bes_ts%uint64_t(1e9) 
+                      << " (s) = " << _tdc_bes_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _tdc_bes_ts%kSecondInNanoseconds
                       << std::endl;       
     std::cout << "TDC Channel 2 (RWM) Timestamp: "
-                      << " (s) = " << _tdc_rwm_ts/uint64_t(1e9)
-                      << ", (ns) = " << _tdc_rwm_ts%uint64_t(1e9) 
+                      << " (s) = " << _tdc_rwm_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _tdc_rwm_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "TDC Channel 4 (ETRIG) Timestamp: "
-                      << " (s) = " << _tdc_etrig_ts/uint64_t(1e9)
-                      << ", (ns) = " << _tdc_etrig_ts%uint64_t(1e9)
+                      << " (s) = " << _tdc_etrig_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _tdc_etrig_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "----------------------------------------------------" << std::endl;
   } 
@@ -318,18 +320,18 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
     if (_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl; 
     std::cout << "HLT ETRIG = " << _hlt_etrig
                       << ", Timestamp: "
-                      << " (s) = " << _hlt_etrig_ts/uint64_t(1e9)
-                      << ", (ns) = " << _hlt_etrig_ts%uint64_t(1e9) 
+                      << " (s) = " << _hlt_etrig_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _hlt_etrig_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "HLT Gate = " << _hlt_gate
                       << ", Timestamp: "
-                      << " (s) = " << _hlt_gate_ts/uint64_t(1e9)
-                      << ", (ns) = " << _hlt_gate_ts%uint64_t(1e9) 
+                      << " (s) = " << _hlt_gate_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _hlt_gate_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "HLT CRT T1 = " << _hlt_crtt1
                       << ", Timestamp: "
-                      << " (s) = " << _hlt_crtt1_ts/uint64_t(1e9)
-                      << ", (ns) = " << _hlt_crtt1_ts%uint64_t(1e9) 
+                      << " (s) = " << _hlt_crtt1_ts/kSecondInNanoseconds
+                      << ", (ns) = " << _hlt_crtt1_ts%kSecondInNanoseconds
                       << std::endl;
     std::cout << "----------------------------------------------------" << std::endl;
   }
@@ -490,23 +492,23 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
     std::cout << "Frame Shift Results:" << std::endl;
     std::cout << "Frame CRT T1 type " << _timing_type_crtt1
                       <<", channel " << _timing_channel_crtt1
-                      << ": (s) = " << _frame_crtt1/uint64_t(1e9) 
-                      << ", (ns) = " << _frame_crtt1%uint64_t(1e9) 
+                      << ": (s) = " << _frame_crtt1/kSecondInNanoseconds
+                      << ", (ns) = " << _frame_crtt1%kSecondInNanoseconds
                       << std::endl;
     std::cout << "Frame Beam Gate  type " << _timing_type_gate
                       <<", channel " << _timing_channel_gate
-                      << ": (s) = " << _frame_gate/uint64_t(1e9) 
-                      << ", (ns) = " << _frame_gate%uint64_t(1e9) 
+                      << ": (s) = " << _frame_gate/kSecondInNanoseconds
+                      << ", (ns) = " << _frame_gate%kSecondInNanoseconds
                       << std::endl;
     std::cout << "Frame ETRIG type " << _timing_type_etrig
                       <<", channel " << _timing_channel_etrig
-                      << ": (s) = " << _frame_etrig/uint64_t(1e9) 
-                      << ", (ns) = " << _frame_etrig%uint64_t(1e9) 
+                      << ": (s) = " << _frame_etrig/kSecondInNanoseconds
+                      << ", (ns) = " << _frame_etrig%kSecondInNanoseconds
                       << std::endl;
     std::cout << "Default Frame type " << _timing_type_default
                       <<", channel " << _timing_channel_default
-                      << " : (s) = " << _frame_default/uint64_t(1e9) 
-                      << ", (ns) = " << _frame_default%uint64_t(1e9) 
+                      << " : (s) = " << _frame_default/kSecondInNanoseconds
+                      << ", (ns) = " << _frame_default%kSecondInNanoseconds
                       << std::endl;
     std::cout << "--------------------------------------" << std::endl;
   }
@@ -563,8 +565,8 @@ void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
     {
       std::cout << "----------------------------------------------------" << std::endl;
       std::cout << "DAQ Header Timestamp: "
-		<< " (s) = " << _raw_ts/uint64_t(1e9)
-		<< ", (ns) = " << _raw_ts%uint64_t(1e9) 
+		<< " (s) = " << _raw_ts/kSecondInNanoseconds
+		<< ", (ns) = " << _raw_ts%kSecondInNanoseconds
 		<< std::endl;
     }
 }
@@ -682,8 +684,8 @@ void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
 	{
 	  std::cout << "----------------------------------------------------" << std::endl;
 	  std::cout << "HLT " << _ptb_hlt_trunmask[i] 
-		    << " sec (s) = " << _ptb_hlt_unmask_timestamp[i]/uint64_t(1e9)
-		    << ", ts (ns) = " << _ptb_hlt_unmask_timestamp[i]%uint64_t(1e9)
+		    << " sec (s) = " << _ptb_hlt_unmask_timestamp[i]/kSecondInNanoseconds
+		    << ", ts (ns) = " << _ptb_hlt_unmask_timestamp[i]%kSecondInNanoseconds
 		    << std::endl;
 	}
     }
@@ -732,14 +734,14 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
 {
   //Decide which global frame to use as reference
   // Prioritise TDC ETRIG then PTB ETRIG then the raw header.
-  uint64_t global_frame = kInvalidTimestamp;
+  uint64_t global_frame_ts = kInvalidTimestamp;
 
   if (_tdc_etrig_ts != kInvalidTimestamp)
-    global_frame = _tdc_etrig_ts;
+    global_frame_ts = _tdc_etrig_ts;
   else if (_hlt_etrig_ts != kInvalidTimestamp)
-    global_frame = _hlt_etrig_ts;
+    global_frame_ts = _hlt_etrig_ts;
   else
-    global_frame = _raw_ts;
+    global_frame_ts = _raw_ts;
 
   if (fDebugFrame)
     {
@@ -752,12 +754,12 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
 	std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
 
       std::cout << "Global Frame Timestamp: "
-		<< " (s) = " << global_frame/uint64_t(1e9)
-		<< ", (ns) = " << global_frame%uint64_t(1e9) 
+		<< " (s) = " << global_frame_ts/kSecondInNanoseconds
+		<< ", (ns) = " << global_frame_ts%kSecondInNanoseconds
 		<< std::endl;
     }
 
-  return global_frame;
+  return global_frame_ts;
 }
 
 void sbnd::timing::FrameShift::beginJob()

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -67,6 +67,7 @@ public:
   void GetTDCTimestamps(const art::Event &e);
   void GetPTBTimestamps(const art::Event &e);
   void FindETRIGs();
+
   uint64_t DecideGlobalEtrigTimestamp();
   void DecideRelevantTDCTimestamps(const uint64_t &global_etrig_ts);
   void DecideRelevantPTBTimestamps(const uint64_t &global_etrig_ts);
@@ -179,7 +180,7 @@ private:
 
 sbnd::timing::FrameShift::FrameShift(fhicl::ParameterSet const& p)
   : EDProducer{p}  // ,
-  // More initializers here.
+    // More initializers here.
 {
   fDAQHeaderInstanceLabel = p.get<std::string>("DAQHeaderInstanceLabel");
   fDAQHeaderModuleLabel = p.get<std::string>("DAQHeaderModuleLabel");
@@ -226,8 +227,8 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   _subrun = e.id().subRun();
   _event  =  e.id().event();
 
-  if (fDebugTdc | fDebugPtb | fDebugFrame)
-        std::cout <<"#----------RUN " << _run << " SUBRUN " << _subrun << " EVENT " << _event <<"----------#\n";
+  if(fDebugTdc | fDebugPtb | fDebugFrame)
+    std::cout <<"#----------RUN " << _run << " SUBRUN " << _subrun << " EVENT " << _event <<"----------#\n";
 
   GetRawTimestamp(e);
   GetTDCTimestamps(e);
@@ -258,43 +259,43 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   if(_isBeam || _isOffbeam)
     {
       if(_tdc_crtt1_ts != kInvalidTimestamp)
-	{
-	  _frame_crtt1          = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
-	  _timing_type_crtt1    = kSPECTDCType;
-	  _timing_channel_crtt1 = 0;
-	}
+        {
+          _frame_crtt1          = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
+          _timing_type_crtt1    = kSPECTDCType;
+          _timing_channel_crtt1 = 0;
+        }
       else if(_hlt_crtt1_ts != kInvalidTimestamp)
-	{
-	  _frame_crtt1          = _hlt_crtt1_ts;
-	  _timing_type_crtt1    = kPTBHLTType;
-	  _timing_channel_crtt1 = _hlt_crtt1;
-	}
+        {
+          _frame_crtt1          = _hlt_crtt1_ts;
+          _timing_type_crtt1    = kPTBHLTType;
+          _timing_channel_crtt1 = _hlt_crtt1;
+        }
       else
-	{
-	  _frame_crtt1          = 0;
-	  _timing_type_crtt1    = kNoShiftType;
-	  _timing_channel_crtt1 = kInvalidChannel;
-	}
+        {
+          _frame_crtt1          = 0;
+          _timing_type_crtt1    = kNoShiftType;
+          _timing_channel_crtt1 = kInvalidChannel;
+        }
 
       //Frame Beam Gate
       if(_isBeam && _tdc_rwm_ts != kInvalidTimestamp) // TODO: For Offbeam, I think HLT Gate is recorded in TDC as FTRIG and can be found
-	{
-	  _frame_gate          = _tdc_rwm_ts + fShiftRWM2Gate; //TODO: + fShiftData2MC;
-	  _timing_type_gate    = kSPECTDCType;
-	  _timing_channel_gate = 2;
-	}
+        {
+          _frame_gate          = _tdc_rwm_ts + fShiftRWM2Gate; //TODO: + fShiftData2MC;
+          _timing_type_gate    = kSPECTDCType;
+          _timing_channel_gate = 2;
+        }
       else if(_hlt_gate_ts != kInvalidTimestamp)
-	{
-	  _frame_gate          = _hlt_gate_ts;
-	  _timing_type_gate    = kPTBHLTType;
-	  _timing_channel_gate = _hlt_gate;
-	}
+        {
+          _frame_gate          = _hlt_gate_ts;
+          _timing_type_gate    = kPTBHLTType;
+          _timing_channel_gate = _hlt_gate;
+        }
       else
-	{
-	  _frame_gate          = 0;
-	  _timing_type_gate    = kNoShiftType;
-	  _timing_channel_gate = kInvalidChannel;
-	}
+        {
+          _frame_gate          = 0;
+          _timing_type_gate    = kNoShiftType;
+          _timing_channel_gate = kInvalidChannel;
+        }
     }
 
   //Frame ETRIG
@@ -324,7 +325,7 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
       _timing_type_default    = _timing_type_gate;
       _timing_channel_default = _timing_channel_gate;
     }
-  else if (_isXmuon)
+  else if(_isXmuon)
     {
       //Pick default stream -- ETRIG
       _frame_default        = _frame_etrig;
@@ -332,29 +333,29 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
       _timing_channel_etrig = _timing_channel_etrig;
     }
 
-  if (fDebugFrame)
+  if(fDebugFrame)
     {
       std::cout << "--------------------------------------" << std::endl;
       std::cout << "Frame Shift Results:" << std::endl;
       std::cout << "Frame CRT T1 type " << _timing_type_crtt1 <<", channel " << _timing_channel_crtt1 << ": "
-		<< PrintFormatTimestamp(_frame_crtt1) << std::endl;
+                << PrintFormatTimestamp(_frame_crtt1) << std::endl;
       std::cout << "Frame Beam Gate  type " << _timing_type_gate <<", channel " << _timing_channel_gate << ": "
-		<< PrintFormatTimestamp(_frame_gate) << std::endl;
+                << PrintFormatTimestamp(_frame_gate) << std::endl;
       std::cout << "Frame ETRIG type " << _timing_type_etrig <<", channel " << _timing_channel_etrig << ": "
-		<< PrintFormatTimestamp(_frame_etrig) << std::endl;
+                << PrintFormatTimestamp(_frame_etrig) << std::endl;
       std::cout << "Default Frame type " << _timing_type_default <<", channel " << _timing_channel_default << ": "
-		<< PrintFormatTimestamp(_frame_default) << std::endl;
+                << PrintFormatTimestamp(_frame_default) << std::endl;
       std::cout << "--------------------------------------" << std::endl;
     }
 
   //Put product in event
   std::unique_ptr<FrameShiftInfo> newFrameShiftInfo(new FrameShiftInfo(_frame_crtt1, _timing_type_crtt1, _timing_channel_crtt1,
-								       _frame_gate, _timing_type_gate, _timing_channel_gate,
-								       _frame_etrig, _timing_type_etrig,_timing_channel_etrig,
-								       _frame_default, _timing_type_default, _timing_channel_default));
+                                                                       _frame_gate, _timing_type_gate, _timing_channel_gate,
+                                                                       _frame_etrig, _timing_type_etrig,_timing_channel_etrig,
+                                                                       _frame_default, _timing_type_default, _timing_channel_default));
 
   std::unique_ptr<TimingInfo> newTimingInfo(new TimingInfo(_raw_ts, _tdc_crtt1_ts, _tdc_bes_ts, _tdc_rwm_ts, _tdc_etrig_ts,
-							   _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
+                                                           _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
 
   e.put(std::move(newTimingInfo));
   e.put(std::move(newFrameShiftInfo));
@@ -373,10 +374,10 @@ uint64_t sbnd::timing::FrameShift::FindClosest(const std::vector<uint64_t> &time
       uint64_t diff = reference > timestamp ? reference - timestamp : timestamp - reference;
 
       if(diff < min_diff)
-      {
-        min_diff = diff;
-	closest  = timestamp;
-      }
+        {
+          min_diff = diff;
+          closest  = timestamp;
+        }
     }
 
   return closest;
@@ -395,7 +396,7 @@ void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
   art::Handle<artdaq::detail::RawEventHeader> DAQHeaderHandle;
   e.getByLabel(fDAQHeaderModuleLabel, fDAQHeaderInstanceLabel, DAQHeaderHandle);
 
-  if (!DAQHeaderHandle.isValid())
+  if(!DAQHeaderHandle.isValid())
     throw cet::exception("FrameShift") << "No artdaq::detail::RawEventHeader found w/ tag " << fDAQHeaderModuleLabel << ". Check data quality!";
   else
     {
@@ -403,7 +404,7 @@ void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
       _raw_ts = rawHeaderEvent.timestamp() - fRawTSCorrection;
     }
 
-  if (fDebugDAQHeader)
+  if(fDebugDAQHeader)
     {
       std::cout << "----------------------------------------------------" << std::endl;
       std::cout << "DAQ Header Timestamp: " << PrintFormatTimestamp(_raw_ts) << std::endl;
@@ -415,33 +416,33 @@ void sbnd::timing::FrameShift::GetTDCTimestamps(const art::Event &e)
   art::Handle<std::vector<DAQTimestamp>> tdcHandle;
   e.getByLabel(fTdcDecodeLabel, tdcHandle);
   
-  if (!tdcHandle.isValid() || tdcHandle->size() == 0)
+  if(!tdcHandle.isValid() || tdcHandle->size() == 0)
     mf::LogInfo("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!\n";
   else
     {
       for(auto const& tdc : *tdcHandle)
-	{
-	  const uint32_t  ch = tdc.Channel();
-	  const uint64_t  ts = tdc.Timestamp();
-	  //Also TODO: Make use of picosecond timestamps
-	  //const uint64_t  ts_ps = tdc.TimestampPs();
+        {
+          const uint32_t  ch = tdc.Channel();
+          const uint64_t  ts = tdc.Timestamp();
+          //Also TODO: Make use of picosecond timestamps
+          //const uint64_t  ts_ps = tdc.TimestampPs();
 
-	  switch(ch)
-	    {
-	    case 0:
-	      _tdc_ch0.push_back(ts);
-	      break;
-	    case 1:
-	      _tdc_ch1.push_back(ts);
-	      break;
-	    case 2:
-	      _tdc_ch2.push_back(ts);
-	      break;
-	    case 4:
-	      _tdc_ch4.push_back(ts);
-	      break;
-	    }
-	}
+          switch(ch)
+            {
+            case 0:
+              _tdc_ch0.push_back(ts);
+              break;
+            case 1:
+              _tdc_ch1.push_back(ts);
+              break;
+            case 2:
+              _tdc_ch2.push_back(ts);
+              break;
+            case 4:
+              _tdc_ch4.push_back(ts);
+              break;
+            }
+        }
     }
 }
 
@@ -450,7 +451,7 @@ void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
   art::Handle<std::vector<raw::ptb::sbndptb>> ptbHandle;
   e.getByLabel(fPtbDecodeLabel, ptbHandle);
   
-  if ((!ptbHandle.isValid() || ptbHandle->size() == 0))
+  if((!ptbHandle.isValid() || ptbHandle->size() == 0))
     throw cet::exception("FrameShift") << "No raw::ptb::sbndptb found w/ tag " << fPtbDecodeLabel << ". Check data quality!";
   else
     {
@@ -458,7 +459,7 @@ void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
       unsigned nHLTs = 0;
 
       for(auto const& ptb : *ptbHandle)
-	nHLTs += ptb.GetNHLTriggers();
+        nHLTs += ptb.GetNHLTriggers();
   
       _ptb_hlt_trigger.resize(nHLTs);
       _ptb_hlt_timestamp.resize(nHLTs);
@@ -469,100 +470,100 @@ void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
       unsigned h_i = 0; //For trigger with bitmask
 
       for(auto const& ptb : *ptbHandle)
-	{
-	  for(unsigned i = 0; i < ptb.GetNHLTriggers(); ++i)
-	    {
-	      _ptb_hlt_trigger[h_i]   = ptb.GetHLTrigger(i).trigger_word;
-	      _ptb_hlt_timestamp[h_i] = ptb.GetHLTrigger(i).timestamp * uint64_t(20); //Units can be found in the Decoder Module 
-	      h_i++;
+        {
+          for(unsigned i = 0; i < ptb.GetNHLTriggers(); ++i)
+            {
+              _ptb_hlt_trigger[h_i]   = ptb.GetHLTrigger(i).trigger_word;
+              _ptb_hlt_timestamp[h_i] = ptb.GetHLTrigger(i).timestamp * uint64_t(20); //Units can be found in the Decoder Module 
+              h_i++;
   
-	      int val = ptb.GetHLTrigger(i).trigger_word;
-	      int upBit[32];
+              int val = ptb.GetHLTrigger(i).trigger_word;
+              int upBit[32];
     
-	      for(int u=0; u<32; u++)
-		upBit[u] = -1; //setting default values for maximum of 32 bits
+              for(int u=0; u<32; u++)
+                upBit[u] = -1; //setting default values for maximum of 32 bits
   
-	      int numOfTrig = 0;
-	      for(int b=0; b<32; b++)
-		{
-		  if((val & 0x01) == 1)
-		    {
-		      upBit[numOfTrig] = b;
-		      numOfTrig++;
-		    }
+              int numOfTrig = 0;
+              for(int b=0; b<32; b++)
+                {
+                  if((val & 0x01) == 1)
+                    {
+                      upBit[numOfTrig] = b;
+                      numOfTrig++;
+                    }
 
-		  val = val >> 1;
-		}
+                  val = val >> 1;
+                }
     
-	      if (numOfTrig == 1)
-		{
-		  _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
-		  _ptb_hlt_trunmask[hlt_i]         = upBit[0];
-		  hlt_i++;
-		}
-	      else if (numOfTrig > 1)
-		{
-		  nHLTs += (numOfTrig - 1);
-		  _ptb_hlt_unmask_timestamp.resize(nHLTs);
-		  _ptb_hlt_trunmask.resize(nHLTs);
+              if(numOfTrig == 1)
+                {
+                  _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
+                  _ptb_hlt_trunmask[hlt_i]         = upBit[0];
+                  hlt_i++;
+                }
+              else if(numOfTrig > 1)
+                {
+                  nHLTs += (numOfTrig - 1);
+                  _ptb_hlt_unmask_timestamp.resize(nHLTs);
+                  _ptb_hlt_trunmask.resize(nHLTs);
   
-		  for (int mult = 0; mult < numOfTrig; mult++)
-		    {
-		      _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
-		      _ptb_hlt_trunmask[hlt_i]         = upBit[mult];
-		      hlt_i++;
-		    }
-		}
-	    } //End of loop over nHLTriggers
-	} //End of loop over ptb in ptb_v
+                  for(int mult = 0; mult < numOfTrig; mult++)
+                    {
+                      _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
+                      _ptb_hlt_trunmask[hlt_i]         = upBit[mult];
+                      hlt_i++;
+                    }
+                }
+            } //End of loop over nHLTriggers
+        } //End of loop over ptb in ptb_v
     }
 
   if(fDebugPtb)
     {
       for(size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
-	{
-	  std::cout << "----------------------------------------------------" << std::endl;
-	  std::cout << "HLT " << _ptb_hlt_trunmask[i] << ": " << PrintFormatTimestamp(_ptb_hlt_unmask_timestamp[i]) << std::endl;
-	}
+        {
+          std::cout << "----------------------------------------------------" << std::endl;
+          std::cout << "HLT " << _ptb_hlt_trunmask[i] << ": " << PrintFormatTimestamp(_ptb_hlt_unmask_timestamp[i]) << std::endl;
+        }
     }
 }
 
 void sbnd::timing::FrameShift::FindETRIGs()
 {
-  if (_tdc_ch4.size() == 0)
+  if(_tdc_ch4.size() == 0)
     throw cet::exception("FrameShift") << "No TDC ETRIG timestamps found! Check data quality!";
   else
     _tdc_etrig_ts = FindClosest(_tdc_ch4, _raw_ts);
 
   //Grab all the ETRIG HLTS -- there might be more than 1
-  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
+  for(size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
     {
-      for (size_t j = 0; j < fPtbEtrigHlts.size(); j++)
-	{
-	  if (_ptb_hlt_trunmask[i] == fPtbEtrigHlts[j])
-	    {
-	      _ptb_hlt_etrig.push_back(_ptb_hlt_trunmask[i]);
-	      _ptb_hlt_etrig_ts.push_back(_ptb_hlt_unmask_timestamp[i]);
-	    }
-	}
+      for(size_t j = 0; j < fPtbEtrigHlts.size(); j++)
+        {
+          if(_ptb_hlt_trunmask[i] == fPtbEtrigHlts[j])
+            {
+              _ptb_hlt_etrig.push_back(_ptb_hlt_trunmask[i]);
+              _ptb_hlt_etrig_ts.push_back(_ptb_hlt_unmask_timestamp[i]);
+            }
+        }
     }
 
-  if (_ptb_hlt_etrig.size() == 0)
+  if(_ptb_hlt_etrig.size() == 0)
     throw cet::exception("FrameShift") << "No HLT ETRIG timestamps found! Check data quality!";
   else
     {
       uint64_t min_diff = std::numeric_limits<uint64_t>::max();
       for(size_t i = 0; i < _ptb_hlt_etrig.size(); i++)
-	{
-	  uint64_t diff = _raw_ts > _ptb_hlt_etrig_ts[i] ? _raw_ts - _ptb_hlt_etrig_ts[i] : _ptb_hlt_etrig_ts[i] - _raw_ts;
+        {
+          uint64_t diff = _raw_ts > _ptb_hlt_etrig_ts[i] ? _raw_ts - _ptb_hlt_etrig_ts[i] : _ptb_hlt_etrig_ts[i] - _raw_ts;
 
-	  if(diff < min_diff)
-	    {
-	      min_diff      = diff;
-	      _hlt_etrig    = _ptb_hlt_etrig[i];
-	      _hlt_etrig_ts = _ptb_hlt_etrig_ts[i];
-	    }
-	}
+          if(diff < min_diff)
+            {
+              min_diff      = diff;
+              _hlt_etrig    = _ptb_hlt_etrig[i];
+              _hlt_etrig_ts = _ptb_hlt_etrig_ts[i];
+            }
+        }
     }
 }
 
@@ -572,22 +573,22 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalEtrigTimestamp()
   // Prioritise TDC ETRIG then PTB ETRIG then the raw header.
   uint64_t global_etrig_ts = kInvalidTimestamp;
 
-  if (_tdc_etrig_ts != kInvalidTimestamp)
+  if(_tdc_etrig_ts != kInvalidTimestamp)
     global_etrig_ts = _tdc_etrig_ts;
-  else if (_hlt_etrig_ts != kInvalidTimestamp)
+  else if(_hlt_etrig_ts != kInvalidTimestamp)
     global_etrig_ts = _hlt_etrig_ts;
   else
     global_etrig_ts = _raw_ts;
 
-  if (fDebugFrame)
+  if(fDebugFrame)
     {
       std::cout << "----------------------------------------------------" << std::endl;
-      if (_tdc_etrig_ts != kInvalidTimestamp)
-	std::cout << "Using TDC ETRIG as Global Frame Reference" << std::endl;
-      else if (_hlt_etrig_ts != kInvalidTimestamp)
-	std::cout << "Using PTB HLT ETRIG as Global Frame Reference" << std::endl;
+      if(_tdc_etrig_ts != kInvalidTimestamp)
+        std::cout << "Using TDC ETRIG as Global Frame Reference" << std::endl;
+      else if(_hlt_etrig_ts != kInvalidTimestamp)
+        std::cout << "Using PTB HLT ETRIG as Global Frame Reference" << std::endl;
       else
-	std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
+        std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
 
       std::cout << "Global Frame Timestamp: " << PrintFormatTimestamp(global_etrig_ts) << std::endl;
     }
@@ -598,18 +599,18 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalEtrigTimestamp()
 void sbnd::timing::FrameShift::DecideRelevantTDCTimestamps(const uint64_t &global_etrig_ts)
 {
   // ch0: CRT T1
-  if (_tdc_ch0.size() != 0)
+  if(_tdc_ch0.size() != 0)
     _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_etrig_ts);
 
   // ch1: BES
-  if (_tdc_ch1.size() != 0)
+  if(_tdc_ch1.size() != 0)
     _tdc_bes_ts = FindClosest(_tdc_ch1, global_etrig_ts);
 
   // ch2: RWM
-  if (_tdc_ch2.size() != 0)
+  if(_tdc_ch2.size() != 0)
     _tdc_rwm_ts = FindClosest(_tdc_ch2, global_etrig_ts);
 
-  if (fDebugTdc)
+  if(fDebugTdc)
     {
       std::cout << "----------------------------------------------------" << std::endl;
       std::cout << "TDC Channel 0 (CRTT1) Timestamp: " << PrintFormatTimestamp(_tdc_crtt1_ts) << std::endl;
@@ -627,39 +628,39 @@ void sbnd::timing::FrameShift::DecideRelevantPTBTimestamps(const uint64_t &globa
 
   for(const int &beam_etrig_hlt : fBeamEtrigHlt)
     {
-      if (_hlt_etrig == beam_etrig_hlt)
-	{
-	  _hlt_gate  = fBeamGateHlt;
-	  _hlt_crtt1 = fBeamCrtT1Hlt;
-	  _isBeam    = true;
-	  break;
-	}
+      if(_hlt_etrig == beam_etrig_hlt)
+        {
+          _hlt_gate  = fBeamGateHlt;
+          _hlt_crtt1 = fBeamCrtT1Hlt;
+          _isBeam    = true;
+          break;
+        }
     }
 
-  if (!_isBeam)
+  if(!_isBeam)
     {
       for(const int &offbeam_etrig_hlt : fOffbeamEtrigHlt)
-	{
-	  if (_hlt_etrig == offbeam_etrig_hlt)
-	    {
-	      _hlt_gate  = fOffbeamGateHlt;
-	      _hlt_crtt1 = fOffbeamCrtT1Hlt;
-	      _isOffbeam = true;
-	      break;
-	    }
-	}
+        {
+          if(_hlt_etrig == offbeam_etrig_hlt)
+            {
+              _hlt_gate  = fOffbeamGateHlt;
+              _hlt_crtt1 = fOffbeamCrtT1Hlt;
+              _isOffbeam = true;
+              break;
+            }
+        }
     }
 
-  if (!_isBeam & !_isOffbeam)
+  if(!_isBeam & !_isOffbeam)
     {
-      for (const int &xmuon_etrig_hlt : fXmuonEtrigHlt)
-	{
-	  if (_hlt_etrig == xmuon_etrig_hlt)
-	    {
-	      _isXmuon = true;
-	      break;
-	    }
-	}
+      for(const int &xmuon_etrig_hlt : fXmuonEtrigHlt)
+        {
+          if(_hlt_etrig == xmuon_etrig_hlt)
+            {
+              _isXmuon = true;
+              break;
+            }
+        }
     }
 
   if( !_isBeam & !_isOffbeam & !_isXmuon)
@@ -667,20 +668,20 @@ void sbnd::timing::FrameShift::DecideRelevantPTBTimestamps(const uint64_t &globa
 
   //Get Gate and CRT T1 HLT timestamps
   //TODO: What if there is no Gate or CRT T1 HLT?
-  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
+  for(size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
     {
       if(_ptb_hlt_trunmask[i] == _hlt_gate)
-	_hlt_gate_ts = _ptb_hlt_unmask_timestamp[i];
+        _hlt_gate_ts = _ptb_hlt_unmask_timestamp[i];
       if(_ptb_hlt_trunmask[i] == _hlt_crtt1)
-	_hlt_crtt1_ts = _ptb_hlt_unmask_timestamp[i];
+        _hlt_crtt1_ts = _ptb_hlt_unmask_timestamp[i];
     }
 
-  if (fDebugPtb)
+  if(fDebugPtb)
     {
       std::cout << "----------------------------------------------------" << std::endl;
-      if (_isBeam) std::cout << "This is Beam Stream!" << std::endl;
-      if (_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl;
-      if (_isXmuon) std::cout << "This is Crossing Muon Stream!" << std::endl;
+      if(_isBeam) std::cout << "This is Beam Stream!" << std::endl;
+      if(_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl;
+      if(_isXmuon) std::cout << "This is Crossing Muon Stream!" << std::endl;
       std::cout << "HLT ETRIG = " << _hlt_etrig << ", Timestamp: " << PrintFormatTimestamp(_hlt_etrig_ts) << std::endl;
       std::cout << "HLT Gate = " << _hlt_gate << ", Timestamp: " << PrintFormatTimestamp(_hlt_gate_ts) << std::endl;
       std::cout << "HLT CRT T1 = " << _hlt_crtt1 << ", Timestamp: " << PrintFormatTimestamp(_hlt_crtt1_ts) << std::endl;

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -61,6 +61,7 @@ public:
   void ResetEventVars();
 
   uint64_t FindClosest(const std::vector<uint64_t> &timestamps, const uint64_t &reference);
+  std::string PrintFormatTimestamp(const uint64_t &timestamp);
 
   void GetRawTimestamp(const art::Event &e);
   void GetTDCTimestamps(const art::Event &e);
@@ -248,22 +249,10 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
 
   if (fDebugTdc){
     std::cout << "----------------------------------------------------" << std::endl;
-    std::cout << "TDC Channel 0 (CRTT1) Timestamp: " 
-                      << " (s) = " << _tdc_crtt1_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _tdc_crtt1_ts%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "TDC Channel 1 (BES) Timestamp: "
-                      << " (s) = " << _tdc_bes_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _tdc_bes_ts%kSecondInNanoseconds
-                      << std::endl;       
-    std::cout << "TDC Channel 2 (RWM) Timestamp: "
-                      << " (s) = " << _tdc_rwm_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _tdc_rwm_ts%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "TDC Channel 4 (ETRIG) Timestamp: "
-                      << " (s) = " << _tdc_etrig_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _tdc_etrig_ts%kSecondInNanoseconds
-                      << std::endl;
+    std::cout << "TDC Channel 0 (CRTT1) Timestamp: " << PrintFormatTimestamp(_tdc_crtt1_ts) << std::endl;
+    std::cout << "TDC Channel 1 (BES) Timestamp: " << PrintFormatTimestamp(_tdc_bes_ts) << std::endl;
+    std::cout << "TDC Channel 2 (RWM) Timestamp: "<< PrintFormatTimestamp(_tdc_rwm_ts) << std::endl;
+    std::cout << "TDC Channel 4 (ETRIG) Timestamp: "<< PrintFormatTimestamp(_tdc_etrig_ts) << std::endl;
     std::cout << "----------------------------------------------------" << std::endl;
   } 
   
@@ -318,21 +307,9 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
     std::cout << "----------------------------------------------------" << std::endl;
     if (_isBeam) std::cout << "This is Beam Stream!" << std::endl; 
     if (_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl; 
-    std::cout << "HLT ETRIG = " << _hlt_etrig
-                      << ", Timestamp: "
-                      << " (s) = " << _hlt_etrig_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _hlt_etrig_ts%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "HLT Gate = " << _hlt_gate
-                      << ", Timestamp: "
-                      << " (s) = " << _hlt_gate_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _hlt_gate_ts%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "HLT CRT T1 = " << _hlt_crtt1
-                      << ", Timestamp: "
-                      << " (s) = " << _hlt_crtt1_ts/kSecondInNanoseconds
-                      << ", (ns) = " << _hlt_crtt1_ts%kSecondInNanoseconds
-                      << std::endl;
+    std::cout << "HLT ETRIG = " << _hlt_etrig << ", Timestamp: " << PrintFormatTimestamp(_hlt_etrig_ts) << std::endl;
+    std::cout << "HLT Gate = " << _hlt_gate << ", Timestamp: " << PrintFormatTimestamp(_hlt_gate_ts) << std::endl;
+    std::cout << "HLT CRT T1 = " << _hlt_crtt1 << ", Timestamp: " << PrintFormatTimestamp(_hlt_crtt1_ts) << std::endl;
     std::cout << "----------------------------------------------------" << std::endl;
   }
 
@@ -490,26 +467,14 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   if (fDebugFrame){
     std::cout << "--------------------------------------" << std::endl;
     std::cout << "Frame Shift Results:" << std::endl;
-    std::cout << "Frame CRT T1 type " << _timing_type_crtt1
-                      <<", channel " << _timing_channel_crtt1
-                      << ": (s) = " << _frame_crtt1/kSecondInNanoseconds
-                      << ", (ns) = " << _frame_crtt1%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "Frame Beam Gate  type " << _timing_type_gate
-                      <<", channel " << _timing_channel_gate
-                      << ": (s) = " << _frame_gate/kSecondInNanoseconds
-                      << ", (ns) = " << _frame_gate%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "Frame ETRIG type " << _timing_type_etrig
-                      <<", channel " << _timing_channel_etrig
-                      << ": (s) = " << _frame_etrig/kSecondInNanoseconds
-                      << ", (ns) = " << _frame_etrig%kSecondInNanoseconds
-                      << std::endl;
-    std::cout << "Default Frame type " << _timing_type_default
-                      <<", channel " << _timing_channel_default
-                      << " : (s) = " << _frame_default/kSecondInNanoseconds
-                      << ", (ns) = " << _frame_default%kSecondInNanoseconds
-                      << std::endl;
+    std::cout << "Frame CRT T1 type " << _timing_type_crtt1 <<", channel " << _timing_channel_crtt1 << ": "
+	      << PrintFormatTimestamp(_frame_crtt1) << std::endl;
+    std::cout << "Frame Beam Gate  type " << _timing_type_gate <<", channel " << _timing_channel_gate << ": "
+	      << PrintFormatTimestamp(_frame_gate) << std::endl;
+    std::cout << "Frame ETRIG type " << _timing_type_etrig <<", channel " << _timing_channel_etrig << ": "
+	      << PrintFormatTimestamp(_frame_etrig) << std::endl;
+    std::cout << "Default Frame type " << _timing_type_default <<", channel " << _timing_channel_default << ": "
+	      << PrintFormatTimestamp(_frame_default) << std::endl;
     std::cout << "--------------------------------------" << std::endl;
   }
   
@@ -548,6 +513,14 @@ uint64_t sbnd::timing::FrameShift::FindClosest(const std::vector<uint64_t> &time
   return closest;
 }
 
+std::string sbnd::timing::FrameShift::PrintFormatTimestamp(const uint64_t &timestamp)
+{
+  std::stringstream ss;
+  ss << "(s) = " <<  timestamp / kSecondInNanoseconds << ", (ns) = " << timestamp % kSecondInNanoseconds;
+
+  return ss.str();
+}
+
 void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
 {
   art::Handle<artdaq::detail::RawEventHeader> DAQHeaderHandle;
@@ -564,10 +537,7 @@ void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
   if (fDebugDAQHeader)
     {
       std::cout << "----------------------------------------------------" << std::endl;
-      std::cout << "DAQ Header Timestamp: "
-		<< " (s) = " << _raw_ts/kSecondInNanoseconds
-		<< ", (ns) = " << _raw_ts%kSecondInNanoseconds
-		<< std::endl;
+      std::cout << "DAQ Header Timestamp: " << PrintFormatTimestamp(_raw_ts) << std::endl;
     }
 }
 
@@ -683,10 +653,7 @@ void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
       for(size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
 	{
 	  std::cout << "----------------------------------------------------" << std::endl;
-	  std::cout << "HLT " << _ptb_hlt_trunmask[i] 
-		    << " sec (s) = " << _ptb_hlt_unmask_timestamp[i]/kSecondInNanoseconds
-		    << ", ts (ns) = " << _ptb_hlt_unmask_timestamp[i]%kSecondInNanoseconds
-		    << std::endl;
+	  std::cout << "HLT " << _ptb_hlt_trunmask[i] << ": " << PrintFormatTimestamp(_ptb_hlt_unmask_timestamp[i]) << std::endl;
 	}
     }
 }
@@ -753,10 +720,7 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
       else
 	std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
 
-      std::cout << "Global Frame Timestamp: "
-		<< " (s) = " << global_frame_ts/kSecondInNanoseconds
-		<< ", (ns) = " << global_frame_ts%kSecondInNanoseconds
-		<< std::endl;
+      std::cout << "Global Frame Timestamp: " << PrintFormatTimestamp(global_frame_ts) << std::endl;
     }
 
   return global_frame_ts;

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -67,9 +67,9 @@ public:
   void GetTDCTimestamps(const art::Event &e);
   void GetPTBTimestamps(const art::Event &e);
   void FindETRIGs();
-  uint64_t DecideGlobalFrame();
-  void DefineTDCFrame(const uint64_t &global_frame_ts);
-  void DefinePTBFrame(const uint64_t &global_frame_ts);
+  uint64_t DecideGlobalEtrigTimestamp();
+  void DecideRelevantTDCTimestamps(const uint64_t &global_etrig_ts);
+  void DecideRelevantPTBTimestamps(const uint64_t &global_etrig_ts);
 
 private:
 
@@ -234,9 +234,9 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   GetPTBTimestamps(e);
   FindETRIGs();
 
-  uint64_t global_frame_ts = DecideGlobalFrame();
-  DefineTDCFrame(global_frame_ts);
-  DefinePTBFrame(global_frame_ts);
+  uint64_t global_etrig_ts = DecideGlobalEtrigTimestamp();
+  DecideRelevantTDCTimestamps(global_etrig_ts);
+  DecideRelevantPTBTimestamps(global_etrig_ts);
 
   //-----------------------Pick default frame-----------------------//
   // The follow picks which frame to apply at downstream stage and store it as frame_default, based on the stream
@@ -254,163 +254,107 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   //    + MC: t = 0 = first proton in spill
   //    + Data: t = 0 = abitrary. All subsystem electronics time is reference to the last PPS
     
-  if (_isBeam){
+  //Frame CRT T1
+  if(_isBeam || _isOffbeam)
+    {
+      if(_tdc_crtt1_ts != kInvalidTimestamp)
+	{
+	  _frame_crtt1          = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
+	  _timing_type_crtt1    = kSPECTDCType;
+	  _timing_channel_crtt1 = 0;
+	}
+      else if(_hlt_crtt1_ts != kInvalidTimestamp)
+	{
+	  _frame_crtt1          = _hlt_crtt1_ts;
+	  _timing_type_crtt1    = kPTBHLTType;
+	  _timing_channel_crtt1 = _hlt_crtt1;
+	}
+      else
+	{
+	  _frame_crtt1          = 0;
+	  _timing_type_crtt1    = kNoShiftType;
+	  _timing_channel_crtt1 = kInvalidChannel;
+	}
 
-    //Frame CRT T1
-    if(_tdc_crtt1_ts != kInvalidTimestamp){
-      _frame_crtt1 = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
-      _timing_type_crtt1 = 0; //SPECTDC
-      _timing_channel_crtt1 = 0;
-    }
-    else if(_hlt_crtt1_ts != kInvalidTimestamp) {
-      _frame_crtt1 = _hlt_crtt1_ts;
-      _timing_type_crtt1 = 1; //PTB HLT
-      _timing_channel_crtt1 = _hlt_crtt1;
-    }
-    else{
-      _frame_crtt1 = kInvalidTimestamp;
-      _timing_type_crtt1 = 2;
-      _timing_channel_crtt1 = kInvalidChannel;
-    }
-
-    //Frame Beam Gate
-    if(_tdc_rwm_ts != kInvalidTimestamp){
-      _frame_gate = _tdc_rwm_ts + fShiftRWM2Gate; //TODO: + fShiftData2MC;
-      _timing_type_gate = 0; //SPECTDC
-      _timing_channel_gate = 2;
-    }
-    else if(_hlt_gate_ts != kInvalidTimestamp){
-      _frame_gate = _hlt_gate_ts;
-      _timing_type_gate = 1; //PTB HLT
-      _timing_channel_gate = _hlt_gate;
-    }else{
-      _frame_gate = kInvalidTimestamp;
-      _timing_type_gate = 2;
-      _timing_channel_gate = kInvalidChannel;
+      //Frame Beam Gate
+      if(_isBeam && _tdc_rwm_ts != kInvalidTimestamp) // TODO: For Offbeam, I think HLT Gate is recorded in TDC as FTRIG and can be found
+	{
+	  _frame_gate          = _tdc_rwm_ts + fShiftRWM2Gate; //TODO: + fShiftData2MC;
+	  _timing_type_gate    = kSPECTDCType;
+	  _timing_channel_gate = 2;
+	}
+      else if(_hlt_gate_ts != kInvalidTimestamp)
+	{
+	  _frame_gate          = _hlt_gate_ts;
+	  _timing_type_gate    = kPTBHLTType;
+	  _timing_channel_gate = _hlt_gate;
+	}
+      else
+	{
+	  _frame_gate          = 0;
+	  _timing_type_gate    = kNoShiftType;
+	  _timing_channel_gate = kInvalidChannel;
+	}
     }
 
-    //Frame ETRIG
-    if(_tdc_etrig_ts != kInvalidTimestamp){
-      _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
-      _timing_type_etrig = 0; //SPECTDC
+  //Frame ETRIG
+  if(_tdc_etrig_ts != kInvalidTimestamp)
+    {
+      _frame_etrig          = _tdc_etrig_ts + fShiftTDC2PTB;
+      _timing_type_etrig    = kSPECTDCType;
       _timing_channel_etrig = 4;
     }
-    else if(_hlt_etrig_ts != kInvalidTimestamp){
-      _frame_etrig = _hlt_etrig_ts;
-      _timing_type_etrig = 1; //PTB HLT
+  else if(_hlt_etrig_ts != kInvalidTimestamp)
+    {
+      _frame_etrig          = _hlt_etrig_ts;
+      _timing_type_etrig    = kPTBHLTType;
       _timing_channel_etrig = _hlt_etrig;
     }
-    else {
-      _frame_etrig = kInvalidTimestamp;
-      _timing_type_etrig = 2;
+  else
+    {
+      _frame_etrig          = 0;
+      _timing_type_etrig    = kNoShiftType;
       _timing_channel_etrig = kInvalidChannel;
     }
 
-    //Pick default stream -- beam gate
-    _frame_default = _frame_gate;
-    _timing_type_default = _timing_type_gate;
-    _timing_channel_default = _timing_channel_gate;
-  }
-  else if (_isOffbeam){
-
-    //Frame CRT T1
-    if(_tdc_crtt1_ts != kInvalidTimestamp){
-      _frame_crtt1 = _tdc_crtt1_ts; //TODO: Add shift from TDC to PTB
-      _timing_type_crtt1 = 0; //SPECTDC
-      _timing_channel_crtt1 = 0;
+  if(_isBeam || _isOffbeam)
+    {
+      //Pick default stream -- beam gate
+      _frame_default          = _frame_gate;
+      _timing_type_default    = _timing_type_gate;
+      _timing_channel_default = _timing_channel_gate;
     }
-    else if(_hlt_crtt1_ts != kInvalidTimestamp) {
-      _frame_crtt1 = _hlt_crtt1_ts;
-      _timing_type_crtt1 = 1; //PTB HLT
-      _timing_channel_crtt1 = _hlt_crtt1;
-    }
-    else{
-      _frame_crtt1 = kInvalidTimestamp;
-      _timing_type_crtt1 = 2;
-      _timing_channel_crtt1 = kInvalidChannel;
+  else if (_isXmuon)
+    {
+      //Pick default stream -- ETRIG
+      _frame_default        = _frame_etrig;
+      _timing_type_default  = _timing_type_etrig;
+      _timing_channel_etrig = _timing_channel_etrig;
     }
 
-    //Frame Gate -- TODO: I think HLT Gate is recorded in TDC as FTRIG and can be found
-    if(_hlt_gate_ts != kInvalidTimestamp) {
-      _frame_gate = _hlt_gate_ts; // TODO: + fShiftData2MC;
-      _timing_type_gate = 1; //PTB HLT
-      _timing_channel_gate = _hlt_gate;
+  if (fDebugFrame)
+    {
+      std::cout << "--------------------------------------" << std::endl;
+      std::cout << "Frame Shift Results:" << std::endl;
+      std::cout << "Frame CRT T1 type " << _timing_type_crtt1 <<", channel " << _timing_channel_crtt1 << ": "
+		<< PrintFormatTimestamp(_frame_crtt1) << std::endl;
+      std::cout << "Frame Beam Gate  type " << _timing_type_gate <<", channel " << _timing_channel_gate << ": "
+		<< PrintFormatTimestamp(_frame_gate) << std::endl;
+      std::cout << "Frame ETRIG type " << _timing_type_etrig <<", channel " << _timing_channel_etrig << ": "
+		<< PrintFormatTimestamp(_frame_etrig) << std::endl;
+      std::cout << "Default Frame type " << _timing_type_default <<", channel " << _timing_channel_default << ": "
+		<< PrintFormatTimestamp(_frame_default) << std::endl;
+      std::cout << "--------------------------------------" << std::endl;
     }
-    else {
-      _frame_gate = kInvalidTimestamp;
-      _timing_type_gate = 2;
-      _timing_channel_gate = kInvalidChannel;
-    }
-
-    //Frame ETRIG
-    if(_tdc_etrig_ts != kInvalidTimestamp) {
-      _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
-      _timing_type_etrig = 0; //SPECTDC
-      _timing_channel_etrig = 4;
-    }
-    else if(_hlt_etrig_ts !=0) {
-      _frame_etrig = _hlt_etrig_ts;
-      _timing_type_etrig = 1; //PTB HLT
-      _timing_channel_etrig = _hlt_etrig;
-    }
-    else {
-      _frame_etrig = kInvalidTimestamp;
-      _timing_type_etrig = 2;
-      _timing_channel_etrig = kInvalidChannel;
-    }
-
-    //Pick default stream -- beam gate
-    _frame_default = _frame_gate;
-    _timing_type_default = _timing_type_gate;
-    _timing_channel_default = _timing_channel_gate;
-  }
-  else if (_isXmuon){
-
-    //Frame ETRIG
-    if(_tdc_etrig_ts != kInvalidTimestamp) {
-      _frame_etrig = _tdc_etrig_ts + fShiftTDC2PTB;
-      _timing_type_etrig = 0; //SPECTDC
-      _timing_channel_etrig = 4;
-    }
-    else if(_hlt_etrig_ts != kInvalidTimestamp) {
-      _frame_etrig = _hlt_etrig_ts;
-      _timing_type_etrig = 1; //PTB HLT
-      _timing_channel_etrig = _hlt_etrig;
-    }
-    else {
-      _frame_etrig = kInvalidTimestamp;
-      _timing_type_etrig = 2;
-      _timing_channel_etrig = kInvalidChannel;
-    }
-
-    //Pick default stream -- ETRIG
-    _frame_default = _frame_etrig;
-    _timing_type_default = _timing_type_etrig;
-    _timing_channel_etrig = _timing_channel_etrig;
-  }
-
-  if (fDebugFrame){
-    std::cout << "--------------------------------------" << std::endl;
-    std::cout << "Frame Shift Results:" << std::endl;
-    std::cout << "Frame CRT T1 type " << _timing_type_crtt1 <<", channel " << _timing_channel_crtt1 << ": "
-	      << PrintFormatTimestamp(_frame_crtt1) << std::endl;
-    std::cout << "Frame Beam Gate  type " << _timing_type_gate <<", channel " << _timing_channel_gate << ": "
-	      << PrintFormatTimestamp(_frame_gate) << std::endl;
-    std::cout << "Frame ETRIG type " << _timing_type_etrig <<", channel " << _timing_channel_etrig << ": "
-	      << PrintFormatTimestamp(_frame_etrig) << std::endl;
-    std::cout << "Default Frame type " << _timing_type_default <<", channel " << _timing_channel_default << ": "
-	      << PrintFormatTimestamp(_frame_default) << std::endl;
-    std::cout << "--------------------------------------" << std::endl;
-  }
-  
 
   //Put product in event
-  std::unique_ptr< FrameShiftInfo > newFrameShiftInfo(new FrameShiftInfo(_frame_crtt1, _timing_type_crtt1, _timing_channel_crtt1,
-                                                                                      _frame_gate, _timing_type_gate, _timing_channel_gate,
-                                                                                      _frame_etrig, _timing_type_etrig,_timing_channel_etrig,
-                                                                                      _frame_default, _timing_type_default, _timing_channel_default));
+  std::unique_ptr<FrameShiftInfo> newFrameShiftInfo(new FrameShiftInfo(_frame_crtt1, _timing_type_crtt1, _timing_channel_crtt1,
+								       _frame_gate, _timing_type_gate, _timing_channel_gate,
+								       _frame_etrig, _timing_type_etrig,_timing_channel_etrig,
+								       _frame_default, _timing_type_default, _timing_channel_default));
 
-  std::unique_ptr< TimingInfo > newTimingInfo(new TimingInfo(_raw_ts, _tdc_crtt1_ts, _tdc_bes_ts, _tdc_rwm_ts, _tdc_etrig_ts, _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
+  std::unique_ptr<TimingInfo> newTimingInfo(new TimingInfo(_raw_ts, _tdc_crtt1_ts, _tdc_bes_ts, _tdc_rwm_ts, _tdc_etrig_ts,
+							   _hlt_crtt1_ts, _hlt_etrig_ts, _hlt_gate_ts));
 
   e.put(std::move(newTimingInfo));
   e.put(std::move(newFrameShiftInfo));
@@ -622,18 +566,18 @@ void sbnd::timing::FrameShift::FindETRIGs()
     }
 }
 
-uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
+uint64_t sbnd::timing::FrameShift::DecideGlobalEtrigTimestamp()
 {
   //Decide which global frame to use as reference
   // Prioritise TDC ETRIG then PTB ETRIG then the raw header.
-  uint64_t global_frame_ts = kInvalidTimestamp;
+  uint64_t global_etrig_ts = kInvalidTimestamp;
 
   if (_tdc_etrig_ts != kInvalidTimestamp)
-    global_frame_ts = _tdc_etrig_ts;
+    global_etrig_ts = _tdc_etrig_ts;
   else if (_hlt_etrig_ts != kInvalidTimestamp)
-    global_frame_ts = _hlt_etrig_ts;
+    global_etrig_ts = _hlt_etrig_ts;
   else
-    global_frame_ts = _raw_ts;
+    global_etrig_ts = _raw_ts;
 
   if (fDebugFrame)
     {
@@ -645,25 +589,25 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
       else
 	std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
 
-      std::cout << "Global Frame Timestamp: " << PrintFormatTimestamp(global_frame_ts) << std::endl;
+      std::cout << "Global Frame Timestamp: " << PrintFormatTimestamp(global_etrig_ts) << std::endl;
     }
 
-  return global_frame_ts;
+  return global_etrig_ts;
 }
 
-void sbnd::timing::FrameShift::DefineTDCFrame(const uint64_t &global_frame_ts)
+void sbnd::timing::FrameShift::DecideRelevantTDCTimestamps(const uint64_t &global_etrig_ts)
 {
   // ch0: CRT T1
   if (_tdc_ch0.size() != 0)
-    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame_ts);
+    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_etrig_ts);
 
   // ch1: BES
   if (_tdc_ch1.size() != 0)
-    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame_ts);
+    _tdc_bes_ts = FindClosest(_tdc_ch1, global_etrig_ts);
 
   // ch2: RWM
   if (_tdc_ch2.size() != 0)
-    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame_ts);
+    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_etrig_ts);
 
   if (fDebugTdc)
     {
@@ -676,7 +620,7 @@ void sbnd::timing::FrameShift::DefineTDCFrame(const uint64_t &global_frame_ts)
     }
 }
 
-void sbnd::timing::FrameShift::DefinePTBFrame(const uint64_t &global_frame_ts)
+void sbnd::timing::FrameShift::DecideRelevantPTBTimestamps(const uint64_t &global_etrig_ts)
 {
   //Check which Gate/CRT T1 HLT to use based on ETRIG HLT
   //Order to check: Beam -> Offbeam -> Xmuon

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -68,6 +68,8 @@ public:
   void GetPTBTimestamps(const art::Event &e);
   void FindETRIGs();
   uint64_t DecideGlobalFrame();
+  void DefineTDCFrame(const uint64_t &global_frame_ts);
+  void DefinePTBFrame(const uint64_t &global_frame_ts);
 
 private:
 
@@ -233,85 +235,8 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   FindETRIGs();
 
   uint64_t global_frame_ts = DecideGlobalFrame();
-
-  //---------------------------TDC Frame-----------------------------//
-  // ch0: CRT T1
-  if (_tdc_ch0.size() != 0)
-    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame_ts);
-
-  // ch1: BES
-  if (_tdc_ch1.size() != 0)
-    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame_ts);
-
-  // ch2: RWM
-  if (_tdc_ch2.size() != 0)
-    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame_ts);
-
-  if (fDebugTdc){
-    std::cout << "----------------------------------------------------" << std::endl;
-    std::cout << "TDC Channel 0 (CRTT1) Timestamp: " << PrintFormatTimestamp(_tdc_crtt1_ts) << std::endl;
-    std::cout << "TDC Channel 1 (BES) Timestamp: " << PrintFormatTimestamp(_tdc_bes_ts) << std::endl;
-    std::cout << "TDC Channel 2 (RWM) Timestamp: "<< PrintFormatTimestamp(_tdc_rwm_ts) << std::endl;
-    std::cout << "TDC Channel 4 (ETRIG) Timestamp: "<< PrintFormatTimestamp(_tdc_etrig_ts) << std::endl;
-    std::cout << "----------------------------------------------------" << std::endl;
-  } 
-  
-  //---------------------------PTB Frame-----------------------------//
-
-  //Check which Gate/CRT T1 HLT to use based on ETRIG HLT
-  //Order to check: Beam -> Offbeam -> Xmuon
-  for (size_t i = 0; i < fBeamEtrigHlt.size(); i++){
-    if (_hlt_etrig == fBeamEtrigHlt[i]){
-      _hlt_gate = fBeamGateHlt;
-      _hlt_crtt1 = fBeamCrtT1Hlt;
-      _isBeam = true;
-      break;
-    }
-  }
-  if (!_isBeam){
-    for (size_t i = 0; i < fOffbeamEtrigHlt.size(); i++){
-      if (_hlt_etrig == fOffbeamEtrigHlt[i]){
-        _hlt_gate = fOffbeamGateHlt;
-        _hlt_crtt1 = fOffbeamCrtT1Hlt;
-        _isOffbeam = true;
-        break;
-      }
-    }
-  }
-  if (!_isBeam & !_isOffbeam){
-    for (size_t i = 0; i < fXmuonEtrigHlt.size(); i++){
-      if (_hlt_etrig == fXmuonEtrigHlt[i]){
-        _isXmuon = true;
-        break;
-      }
-    }
-  } 
-
-  if( !_isBeam & !_isOffbeam & !_isXmuon){
-    throw cet::exception("FrameShift") << "ETRIG HLT " << _hlt_etrig << " does not match any known Beam/Offbeam/Xmuon ETRIG HLT! Check data quality!";
-  }
-
-  //Get Gate and CRT T1 HLT timestamps 
-  //TODO: What if there is no Gate or CRT T1 HLT?
-  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++){
-    if(_ptb_hlt_trunmask[i] == _hlt_gate){
-      _hlt_gate_ts = _ptb_hlt_unmask_timestamp[i];
-    }
-    if(_ptb_hlt_trunmask[i] == _hlt_crtt1){
-      _hlt_crtt1_ts = _ptb_hlt_unmask_timestamp[i];
-    }
-  }
-
-  if (fDebugPtb){
-
-    std::cout << "----------------------------------------------------" << std::endl;
-    if (_isBeam) std::cout << "This is Beam Stream!" << std::endl; 
-    if (_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl; 
-    std::cout << "HLT ETRIG = " << _hlt_etrig << ", Timestamp: " << PrintFormatTimestamp(_hlt_etrig_ts) << std::endl;
-    std::cout << "HLT Gate = " << _hlt_gate << ", Timestamp: " << PrintFormatTimestamp(_hlt_gate_ts) << std::endl;
-    std::cout << "HLT CRT T1 = " << _hlt_crtt1 << ", Timestamp: " << PrintFormatTimestamp(_hlt_crtt1_ts) << std::endl;
-    std::cout << "----------------------------------------------------" << std::endl;
-  }
+  DefineTDCFrame(global_frame_ts);
+  DefinePTBFrame(global_frame_ts);
 
   //-----------------------Pick default frame-----------------------//
   // The follow picks which frame to apply at downstream stage and store it as frame_default, based on the stream
@@ -724,6 +649,99 @@ uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
     }
 
   return global_frame_ts;
+}
+
+void sbnd::timing::FrameShift::DefineTDCFrame(const uint64_t &global_frame_ts)
+{
+  // ch0: CRT T1
+  if (_tdc_ch0.size() != 0)
+    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame_ts);
+
+  // ch1: BES
+  if (_tdc_ch1.size() != 0)
+    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame_ts);
+
+  // ch2: RWM
+  if (_tdc_ch2.size() != 0)
+    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame_ts);
+
+  if (fDebugTdc)
+    {
+      std::cout << "----------------------------------------------------" << std::endl;
+      std::cout << "TDC Channel 0 (CRTT1) Timestamp: " << PrintFormatTimestamp(_tdc_crtt1_ts) << std::endl;
+      std::cout << "TDC Channel 1 (BES) Timestamp: " << PrintFormatTimestamp(_tdc_bes_ts) << std::endl;
+      std::cout << "TDC Channel 2 (RWM) Timestamp: "<< PrintFormatTimestamp(_tdc_rwm_ts) << std::endl;
+      std::cout << "TDC Channel 4 (ETRIG) Timestamp: "<< PrintFormatTimestamp(_tdc_etrig_ts) << std::endl;
+      std::cout << "----------------------------------------------------" << std::endl;
+    }
+}
+
+void sbnd::timing::FrameShift::DefinePTBFrame(const uint64_t &global_frame_ts)
+{
+  //Check which Gate/CRT T1 HLT to use based on ETRIG HLT
+  //Order to check: Beam -> Offbeam -> Xmuon
+
+  for(const int &beam_etrig_hlt : fBeamEtrigHlt)
+    {
+      if (_hlt_etrig == beam_etrig_hlt)
+	{
+	  _hlt_gate  = fBeamGateHlt;
+	  _hlt_crtt1 = fBeamCrtT1Hlt;
+	  _isBeam    = true;
+	  break;
+	}
+    }
+
+  if (!_isBeam)
+    {
+      for(const int &offbeam_etrig_hlt : fOffbeamEtrigHlt)
+	{
+	  if (_hlt_etrig == offbeam_etrig_hlt)
+	    {
+	      _hlt_gate  = fOffbeamGateHlt;
+	      _hlt_crtt1 = fOffbeamCrtT1Hlt;
+	      _isOffbeam = true;
+	      break;
+	    }
+	}
+    }
+
+  if (!_isBeam & !_isOffbeam)
+    {
+      for (const int &xmuon_etrig_hlt : fXmuonEtrigHlt)
+	{
+	  if (_hlt_etrig == xmuon_etrig_hlt)
+	    {
+	      _isXmuon = true;
+	      break;
+	    }
+	}
+    }
+
+  if( !_isBeam & !_isOffbeam & !_isXmuon)
+    throw cet::exception("FrameShift") << "ETRIG HLT " << _hlt_etrig << " does not match any known Beam/Offbeam/Xmuon ETRIG HLT! Check data quality!";
+
+  //Get Gate and CRT T1 HLT timestamps
+  //TODO: What if there is no Gate or CRT T1 HLT?
+  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
+    {
+      if(_ptb_hlt_trunmask[i] == _hlt_gate)
+	_hlt_gate_ts = _ptb_hlt_unmask_timestamp[i];
+      if(_ptb_hlt_trunmask[i] == _hlt_crtt1)
+	_hlt_crtt1_ts = _ptb_hlt_unmask_timestamp[i];
+    }
+
+  if (fDebugPtb)
+    {
+      std::cout << "----------------------------------------------------" << std::endl;
+      if (_isBeam) std::cout << "This is Beam Stream!" << std::endl;
+      if (_isOffbeam) std::cout << "This is Offbeam Stream!" << std::endl;
+      if (_isXmuon) std::cout << "This is Crossing Muon Stream!" << std::endl;
+      std::cout << "HLT ETRIG = " << _hlt_etrig << ", Timestamp: " << PrintFormatTimestamp(_hlt_etrig_ts) << std::endl;
+      std::cout << "HLT Gate = " << _hlt_gate << ", Timestamp: " << PrintFormatTimestamp(_hlt_gate_ts) << std::endl;
+      std::cout << "HLT CRT T1 = " << _hlt_crtt1 << ", Timestamp: " << PrintFormatTimestamp(_hlt_crtt1_ts) << std::endl;
+      std::cout << "----------------------------------------------------" << std::endl;
+    }
 }
 
 void sbnd::timing::FrameShift::beginJob()

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -59,7 +59,15 @@ public:
   // Selected optional functions.
   void beginJob() override;
   void ResetEventVars();
-    
+
+  uint64_t FindClosest(const std::vector<uint64_t> &timestamps, const uint64_t &reference);
+
+  void GetRawTimestamp(const art::Event &e);
+  void GetTDCTimestamps(const art::Event &e);
+  void GetPTBTimestamps(const art::Event &e);
+  void FindETRIGs();
+  uint64_t DecideGlobalFrame();
+
 private:
 
   // Declare member data here.
@@ -207,7 +215,6 @@ sbnd::timing::FrameShift::FrameShift(fhicl::ParameterSet const& p)
 
 void sbnd::timing::FrameShift::produce(art::Event& e)
 {
-
   ResetEventVars();
 
   _run    = e.id().run();
@@ -217,262 +224,25 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   if (fDebugTdc | fDebugPtb | fDebugFrame)
         std::cout <<"#----------RUN " << _run << " SUBRUN " << _subrun << " EVENT " << _event <<"----------#\n";
 
-  //----------------------------DAQ Header-----------------------------//
-  art::Handle<artdaq::detail::RawEventHeader> DAQHeaderHandle;
-  e.getByLabel(fDAQHeaderModuleLabel, fDAQHeaderInstanceLabel, DAQHeaderHandle);
+  GetRawTimestamp(e);
+  GetTDCTimestamps(e);
+  GetPTBTimestamps(e);
+  FindETRIGs();
 
-  if (!DAQHeaderHandle.isValid()){
-    throw cet::exception("FrameShift") << "No artdaq::detail::RawEventHeader found w/ tag " << fDAQHeaderModuleLabel << ". Check data quality!";
-  }
-  else{
-      artdaq::RawEvent rawHeaderEvent = artdaq::RawEvent(*DAQHeaderHandle);
-      _raw_ts = rawHeaderEvent.timestamp() - fRawTSCorrection;
-  }
-  if (fDebugDAQHeader){
-    std::cout << "----------------------------------------------------" << std::endl;
-    std::cout << "DAQ Header Timestamp: "
-                      << " (s) = " << _raw_ts/uint64_t(1e9)
-                      << ", (ns) = " << _raw_ts%uint64_t(1e9) 
-                      << std::endl;
-  }
-
-  //---------------------------TDC-----------------------------//
-  art::Handle<std::vector<DAQTimestamp>> tdcHandle;
-  e.getByLabel(fTdcDecodeLabel, tdcHandle);
-
-  if (!tdcHandle.isValid() || tdcHandle->size() == 0){
-    mf::LogInfo("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!\n";
-    //throw cet::exception("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!";
-  }
-  else{
-    std::vector<DAQTimestamp> tdc_v(*tdcHandle);
-    for (size_t i=0; i<tdc_v.size(); i++){
-      auto tdc = tdc_v[i];
-      const uint32_t  ch = tdc.Channel();
-      const uint64_t  ts = tdc.Timestamp();
-      //Also TODO: Make use of picosecond timestamps
-      //const uint64_t  ts_ps = tdc.TimestampPs();
-
-      if (ch == 0) {
-        _tdc_ch0.push_back(ts);
-      }
-      else if (ch == 1) {
-        _tdc_ch1.push_back(ts);
-      }
-      else if (ch == 2) {
-        _tdc_ch2.push_back(ts);
-      }
-      else if (ch == 4) {
-        _tdc_ch4.push_back(ts);
-      }
-    }
-  }
-  tdcHandle.removeProduct();
-
-  //---------------------------PTB-----------------------------//
-  art::Handle<std::vector<raw::ptb::sbndptb>> ptbHandle;
-  std::vector<art::Ptr<raw::ptb::sbndptb>> ptb_v;
-  e.getByLabel(fPtbDecodeLabel, ptbHandle);
-  
-  if ((!ptbHandle.isValid() || ptbHandle->size() == 0)){
-      throw cet::exception("FrameShift") << "No raw::ptb::sbndptb found w/ tag " << fPtbDecodeLabel << ". Check data quality!";
-  }
-  else{
-    art::fill_ptr_vector(ptb_v, ptbHandle);
-    // HLT Words
-    unsigned nHLTs = 0;
-
-    for(auto const& ptb : ptb_v)
-      nHLTs += ptb->GetNHLTriggers();
-  
-    _ptb_hlt_trigger.resize(nHLTs);
-    _ptb_hlt_timestamp.resize(nHLTs);
-    _ptb_hlt_trunmask.resize(nHLTs);
-    _ptb_hlt_unmask_timestamp.resize(nHLTs);
-
-    unsigned hlt_i = 0; //For multiple upbits in trigger words for unmasking
-    unsigned h_i = 0; //For trigger with bitmask
-
-    for(auto const& ptb : ptb_v){
-      for(unsigned i = 0; i < ptb->GetNHLTriggers(); ++i){
-        _ptb_hlt_trigger[h_i] = ptb->GetHLTrigger(i).trigger_word;
-        _ptb_hlt_timestamp[h_i] = ptb->GetHLTrigger(i).timestamp * uint64_t(20); //Units can be found in the Decoder Module 
-        h_i++;
-  
-        int val = ptb->GetHLTrigger(i).trigger_word;
-        int upBit[32];
-    
-        for (int u=0; u<32; u++){ //setting default values for maximum of 32 bits
-          upBit[u]=-1;
-        }
-  
-        int numOfTrig =0;
-        for(int b=0; b<32;b++){
-          if ((val & 0x01) ==1){
-            upBit[numOfTrig] = b;
-            numOfTrig++;
-          }
-          val = val >> 1;
-        }
-    
-        if (numOfTrig ==1){
-          _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
-          _ptb_hlt_trunmask[hlt_i] = upBit[0];
-          hlt_i++;
-        }//End of if statement for single upbit
-        else if (numOfTrig > 1){
-          nHLTs += (numOfTrig -1);
-          _ptb_hlt_unmask_timestamp.resize(nHLTs);
-          _ptb_hlt_trunmask.resize(nHLTs);
-  
-          for (int mult =0; mult < numOfTrig; mult++){ 
-            _ptb_hlt_trunmask[hlt_i] = upBit[mult];
-            _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
-            hlt_i++;
-          } //End of loop over multiple upbits
-        } //End of else statement for multiple triggers
-      } //End of loop over nHLTriggers
-    } //End of loop over ptb in ptb_v
-  }
-  ptbHandle.removeProduct();
-
-  if (fDebugPtb){
-    for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++){
-      std::cout << "----------------------------------------------------" << std::endl;
-      std::cout << "HLT " << _ptb_hlt_trunmask[i] 
-                          << " sec (s) = " << _ptb_hlt_unmask_timestamp[i]/uint64_t(1e9)
-                          << ", ts (ns) = " << _ptb_hlt_unmask_timestamp[i]%uint64_t(1e9)
-                          <<std::endl;
-    }
-  }
-
-  //---------------------------Get ETRIG From TDC and PTB-----------------------------//
-
-  // TDC ch4: ETRIG
-  if (_tdc_ch4.size() == 0){
-    throw cet::exception("FrameShift") << "No TDC ETRIG timestamps found! Check data quality!";
-  }
-  else if (_tdc_ch4.size() == 1){
-    _tdc_etrig_ts = _tdc_ch4[0];
-  }
-  else if(_tdc_ch4.size() > 1){
-    uint64_t min_diff = std::numeric_limits<uint64_t>::max();
-    for(auto ts : _tdc_ch4){
-      uint64_t diff = _raw_ts > ts ? _raw_ts - ts : ts - _raw_ts; //raw_ts must be found for every event else throw exception
-      if(diff < min_diff)
-      {
-        min_diff    = diff;
-        _tdc_etrig_ts = ts;
-      }
-    }
-  }
-
-  //HLT ETRIG 
-  //Grab all the ETRIG HLTS -- there might be more than 1
-  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++){
-    for (size_t j = 0; j < fPtbEtrigHlts.size(); j++){
-      if (_ptb_hlt_trunmask[i] == fPtbEtrigHlts[j]){
-        _ptb_hlt_etrig.push_back(_ptb_hlt_trunmask[i]);
-        _ptb_hlt_etrig_ts.push_back(_ptb_hlt_unmask_timestamp[i]);
-      }
-    }
-  }
-
-
-  if (_ptb_hlt_etrig.size() == 0){
-    throw cet::exception("FrameShift") << "No HLT ETRIG timestamps found! Check data quality!";
-  }
-  else if (_ptb_hlt_etrig.size() == 1){
-    _hlt_etrig = _ptb_hlt_etrig[0];
-    _hlt_etrig_ts = _ptb_hlt_etrig_ts[0];
-  }
-  else if(_ptb_hlt_etrig.size() > 1){
-    uint64_t min_diff = std::numeric_limits<uint64_t>::max();
-    for(size_t i = 0; i < _ptb_hlt_etrig.size(); i++){
-      uint64_t diff = _raw_ts > _ptb_hlt_etrig_ts[i] ? _raw_ts - _ptb_hlt_etrig_ts[i] : _ptb_hlt_etrig_ts[i] - _raw_ts;
-      if(diff < min_diff)
-      {
-        min_diff    = diff;
-        _hlt_etrig = _ptb_hlt_etrig[i];
-        _hlt_etrig_ts = _ptb_hlt_etrig_ts[i];
-      }
-    }
-  }
-
-  //Decide which global frame to use as reference 
-  uint64_t _global_frame = kInvalidTimestamp;
-  if (_tdc_etrig_ts != kInvalidTimestamp){ _global_frame = _tdc_etrig_ts; }
-  else if (_hlt_etrig_ts != kInvalidTimestamp){ _global_frame = _hlt_etrig_ts; }
-  else { _global_frame = _raw_ts;}
-
-  if (fDebugFrame){
-    std::cout << "----------------------------------------------------" << std::endl;
-    if (_tdc_etrig_ts != kInvalidTimestamp){
-      std::cout << "Using TDC ETRIG as Global Frame Reference" << std::endl;
-    }
-    else if (_hlt_etrig_ts != kInvalidTimestamp){
-      std::cout << "Using PTB HLT ETRIG as Global Frame Reference" << std::endl;
-    }
-    else {
-      std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
-    }
-    std::cout << "Global Frame Timestamp: "
-                      << " (s) = " << _global_frame/uint64_t(1e9)
-                      << ", (ns) = " << _global_frame%uint64_t(1e9) 
-                      << std::endl;
-  }
+  uint64_t global_frame = DecideGlobalFrame();
 
   //---------------------------TDC Frame-----------------------------//
   // ch0: CRT T1
-  if (_tdc_ch0.size() == 1){
-    _tdc_crtt1_ts = _tdc_ch0[0];
-  }
-  else if(_tdc_ch0.size() > 1){
-    //Get the one closest to the global frame
-    uint64_t min_diff = std::numeric_limits<uint64_t>::max();
-    for(auto ts : _tdc_ch0){
-      uint64_t diff = _global_frame > ts ? _global_frame - ts : ts - _global_frame;
-      if(diff < min_diff)
-      {
-        min_diff    = diff;
-        _tdc_crtt1_ts = ts;
-      }
-    }
-  }
+  if (_tdc_ch0.size() != 0)
+    _tdc_crtt1_ts = FindClosest(_tdc_ch0, global_frame);
 
   // ch1: BES
-  if (_tdc_ch1.size() == 1){
-    _tdc_bes_ts = _tdc_ch1[0];
-  }
-  else if(_tdc_ch1.size() > 1){
-    //Get the one closest to the global frame
-    uint64_t min_diff = std::numeric_limits<uint64_t>::max();
-    for(auto ts : _tdc_ch1){
-      uint64_t diff = _global_frame > ts ? _global_frame - ts : ts - _global_frame;
-      if(diff < min_diff)
-      {
-        min_diff    = diff;
-        _tdc_bes_ts = ts;
-      }
-    }
-  }
+  if (_tdc_ch1.size() != 0)
+    _tdc_bes_ts = FindClosest(_tdc_ch1, global_frame);
 
   // ch2: RWM
-  if (_tdc_ch2.size() == 1){
-    _tdc_rwm_ts = _tdc_ch2[0];
-  }
-  else if(_tdc_ch2.size() > 1){
-    //Get the one closest to the global frame
-    uint64_t min_diff = std::numeric_limits<uint64_t>::max();
-    for(auto ts : _tdc_ch2){
-      uint64_t diff = _global_frame > ts ? _global_frame - ts : ts - _global_frame;
-      if(diff < min_diff)
-      {
-        min_diff    = diff;
-        _tdc_rwm_ts = ts;
-      }
-    }
-  }
+  if (_tdc_ch2.size() != 0)
+    _tdc_rwm_ts = FindClosest(_tdc_ch2, global_frame);
 
   if (fDebugTdc){
     std::cout << "----------------------------------------------------" << std::endl;
@@ -755,6 +525,239 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
 
   //Fill the tree
   fTree->Fill();
+}
+
+uint64_t sbnd::timing::FrameShift::FindClosest(const std::vector<uint64_t> &timestamps, const uint64_t &reference)
+{
+  uint64_t min_diff = kInvalidTimestamp;
+  uint64_t closest  = kInvalidTimestamp;
+
+  for(const uint64_t &timestamp : timestamps)
+    {
+      uint64_t diff = reference > timestamp ? reference - timestamp : timestamp - reference;
+
+      if(diff < min_diff)
+      {
+        min_diff = diff;
+	closest  = timestamp;
+      }
+    }
+
+  return closest;
+}
+
+void sbnd::timing::FrameShift::GetRawTimestamp(const art::Event &e)
+{
+  art::Handle<artdaq::detail::RawEventHeader> DAQHeaderHandle;
+  e.getByLabel(fDAQHeaderModuleLabel, fDAQHeaderInstanceLabel, DAQHeaderHandle);
+
+  if (!DAQHeaderHandle.isValid())
+    throw cet::exception("FrameShift") << "No artdaq::detail::RawEventHeader found w/ tag " << fDAQHeaderModuleLabel << ". Check data quality!";
+  else
+    {
+      artdaq::RawEvent rawHeaderEvent = artdaq::RawEvent(*DAQHeaderHandle);
+      _raw_ts = rawHeaderEvent.timestamp() - fRawTSCorrection;
+    }
+
+  if (fDebugDAQHeader)
+    {
+      std::cout << "----------------------------------------------------" << std::endl;
+      std::cout << "DAQ Header Timestamp: "
+		<< " (s) = " << _raw_ts/uint64_t(1e9)
+		<< ", (ns) = " << _raw_ts%uint64_t(1e9) 
+		<< std::endl;
+    }
+}
+
+void sbnd::timing::FrameShift::GetTDCTimestamps(const art::Event &e)
+{
+  art::Handle<std::vector<DAQTimestamp>> tdcHandle;
+  e.getByLabel(fTdcDecodeLabel, tdcHandle);
+  
+  if (!tdcHandle.isValid() || tdcHandle->size() == 0)
+    mf::LogInfo("FrameShift") << "No DAQTimestamp found w/ tag " << fTdcDecodeLabel << ". Check data quality!\n";
+  else
+    {
+      for(auto const& tdc : *tdcHandle)
+	{
+	  const uint32_t  ch = tdc.Channel();
+	  const uint64_t  ts = tdc.Timestamp();
+	  //Also TODO: Make use of picosecond timestamps
+	  //const uint64_t  ts_ps = tdc.TimestampPs();
+
+	  switch(ch)
+	    {
+	    case 0:
+	      _tdc_ch0.push_back(ts);
+	      break;
+	    case 1:
+	      _tdc_ch1.push_back(ts);
+	      break;
+	    case 2:
+	      _tdc_ch2.push_back(ts);
+	      break;
+	    case 4:
+	      _tdc_ch4.push_back(ts);
+	      break;
+	    }
+	}
+    }
+}
+
+void sbnd::timing::FrameShift::GetPTBTimestamps(const art::Event &e)
+{
+  art::Handle<std::vector<raw::ptb::sbndptb>> ptbHandle;
+  e.getByLabel(fPtbDecodeLabel, ptbHandle);
+  
+  if ((!ptbHandle.isValid() || ptbHandle->size() == 0))
+    throw cet::exception("FrameShift") << "No raw::ptb::sbndptb found w/ tag " << fPtbDecodeLabel << ". Check data quality!";
+  else
+    {
+      // HLT Words
+      unsigned nHLTs = 0;
+
+      for(auto const& ptb : *ptbHandle)
+	nHLTs += ptb.GetNHLTriggers();
+  
+      _ptb_hlt_trigger.resize(nHLTs);
+      _ptb_hlt_timestamp.resize(nHLTs);
+      _ptb_hlt_trunmask.resize(nHLTs);
+      _ptb_hlt_unmask_timestamp.resize(nHLTs);
+
+      unsigned hlt_i = 0; //For multiple upbits in trigger words for unmasking
+      unsigned h_i = 0; //For trigger with bitmask
+
+      for(auto const& ptb : *ptbHandle)
+	{
+	  for(unsigned i = 0; i < ptb.GetNHLTriggers(); ++i)
+	    {
+	      _ptb_hlt_trigger[h_i]   = ptb.GetHLTrigger(i).trigger_word;
+	      _ptb_hlt_timestamp[h_i] = ptb.GetHLTrigger(i).timestamp * uint64_t(20); //Units can be found in the Decoder Module 
+	      h_i++;
+  
+	      int val = ptb.GetHLTrigger(i).trigger_word;
+	      int upBit[32];
+    
+	      for(int u=0; u<32; u++)
+		upBit[u] = -1; //setting default values for maximum of 32 bits
+  
+	      int numOfTrig = 0;
+	      for(int b=0; b<32; b++)
+		{
+		  if((val & 0x01) == 1)
+		    {
+		      upBit[numOfTrig] = b;
+		      numOfTrig++;
+		    }
+
+		  val = val >> 1;
+		}
+    
+	      if (numOfTrig == 1)
+		{
+		  _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
+		  _ptb_hlt_trunmask[hlt_i]         = upBit[0];
+		  hlt_i++;
+		}
+	      else if (numOfTrig > 1)
+		{
+		  nHLTs += (numOfTrig - 1);
+		  _ptb_hlt_unmask_timestamp.resize(nHLTs);
+		  _ptb_hlt_trunmask.resize(nHLTs);
+  
+		  for (int mult = 0; mult < numOfTrig; mult++)
+		    {
+		      _ptb_hlt_unmask_timestamp[hlt_i] = _ptb_hlt_timestamp[h_i-1];
+		      _ptb_hlt_trunmask[hlt_i]         = upBit[mult];
+		      hlt_i++;
+		    }
+		}
+	    } //End of loop over nHLTriggers
+	} //End of loop over ptb in ptb_v
+    }
+
+  if(fDebugPtb)
+    {
+      for(size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
+	{
+	  std::cout << "----------------------------------------------------" << std::endl;
+	  std::cout << "HLT " << _ptb_hlt_trunmask[i] 
+		    << " sec (s) = " << _ptb_hlt_unmask_timestamp[i]/uint64_t(1e9)
+		    << ", ts (ns) = " << _ptb_hlt_unmask_timestamp[i]%uint64_t(1e9)
+		    << std::endl;
+	}
+    }
+}
+
+void sbnd::timing::FrameShift::FindETRIGs()
+{
+  if (_tdc_ch4.size() == 0)
+    throw cet::exception("FrameShift") << "No TDC ETRIG timestamps found! Check data quality!";
+  else
+    _tdc_etrig_ts = FindClosest(_tdc_ch4, _raw_ts);
+
+  //Grab all the ETRIG HLTS -- there might be more than 1
+  for (size_t i = 0; i < _ptb_hlt_unmask_timestamp.size(); i++)
+    {
+      for (size_t j = 0; j < fPtbEtrigHlts.size(); j++)
+	{
+	  if (_ptb_hlt_trunmask[i] == fPtbEtrigHlts[j])
+	    {
+	      _ptb_hlt_etrig.push_back(_ptb_hlt_trunmask[i]);
+	      _ptb_hlt_etrig_ts.push_back(_ptb_hlt_unmask_timestamp[i]);
+	    }
+	}
+    }
+
+  if (_ptb_hlt_etrig.size() == 0)
+    throw cet::exception("FrameShift") << "No HLT ETRIG timestamps found! Check data quality!";
+  else
+    {
+      uint64_t min_diff = std::numeric_limits<uint64_t>::max();
+      for(size_t i = 0; i < _ptb_hlt_etrig.size(); i++)
+	{
+	  uint64_t diff = _raw_ts > _ptb_hlt_etrig_ts[i] ? _raw_ts - _ptb_hlt_etrig_ts[i] : _ptb_hlt_etrig_ts[i] - _raw_ts;
+
+	  if(diff < min_diff)
+	    {
+	      min_diff      = diff;
+	      _hlt_etrig    = _ptb_hlt_etrig[i];
+	      _hlt_etrig_ts = _ptb_hlt_etrig_ts[i];
+	    }
+	}
+    }
+}
+
+uint64_t sbnd::timing::FrameShift::DecideGlobalFrame()
+{
+  //Decide which global frame to use as reference
+  // Prioritise TDC ETRIG then PTB ETRIG then the raw header.
+  uint64_t global_frame = kInvalidTimestamp;
+
+  if (_tdc_etrig_ts != kInvalidTimestamp)
+    global_frame = _tdc_etrig_ts;
+  else if (_hlt_etrig_ts != kInvalidTimestamp)
+    global_frame = _hlt_etrig_ts;
+  else
+    global_frame = _raw_ts;
+
+  if (fDebugFrame)
+    {
+      std::cout << "----------------------------------------------------" << std::endl;
+      if (_tdc_etrig_ts != kInvalidTimestamp)
+	std::cout << "Using TDC ETRIG as Global Frame Reference" << std::endl;
+      else if (_hlt_etrig_ts != kInvalidTimestamp)
+	std::cout << "Using PTB HLT ETRIG as Global Frame Reference" << std::endl;
+      else
+	std::cout << "Using DAQ Header Timestamp as Global Frame Reference" << std::endl;
+
+      std::cout << "Global Frame Timestamp: "
+		<< " (s) = " << global_frame/uint64_t(1e9)
+		<< ", (ns) = " << global_frame%uint64_t(1e9) 
+		<< std::endl;
+    }
+
+  return global_frame;
 }
 
 void sbnd::timing::FrameShift::beginJob()

--- a/sbndcode/Timing/FrameShift/FrameShift_module.cc
+++ b/sbndcode/Timing/FrameShift/FrameShift_module.cc
@@ -74,149 +74,117 @@ public:
 
 private:
 
-  // Declare member data here.
-  //DAQ Header
-  std::string fDAQHeaderModuleLabel;
-  std::string fDAQHeaderInstanceLabel;
-  uint64_t fRawTSCorrection; //Correction for the Event timestamp to account for NTB
-  uint64_t fMaxAllowedRefTimeDiff;
-  uint64_t _raw_ts; //ns
-  
-  //Timing Reference
-  art::InputTag fTimingRefPmtLabel;
-  art::InputTag fTimingRefCrtLabel;
+  // FCL Parameters
+  std::string fDAQHeaderModuleLabel;   // Instance label for DAQ header product
+  std::string fDAQHeaderInstanceLabel; // Module label for DAQ header product
+  uint64_t fRawTSCorrection;           // Correction to the DAQ header timestamp to account for NTB offset
+  art::InputTag fPtbDecodeLabel;       // Module label for decoded PTB data
+  std::vector<int> fPtbEtrigHlts;      // All allowed PTB HLT codes for event triggers
+  std::vector<int> fBeamEtrigHlt;      // PTB HLT codes associated with beam trigger
+  std::vector<int> fOffbeamEtrigHlt;   // PTB HLT codes associated with offbeam trigger
+  std::vector<int> fXmuonEtrigHlt;     // PTB HLT codes associated with crossing muon trigger
+  int fBeamCrtT1Hlt;                   // PTB HLT code for beam CRT T1 reset
+  int fOffbeamCrtT1Hlt;                // PTB HLT code for offbeam CRT T1 reset
+  int fBeamGateHlt;                    // PTB HLT code for beam gate opening
+  int fOffbeamGateHlt;                 // PTB HLT code for offbeam gate opening
+  art::InputTag fTdcDecodeLabel;       // Module label for decoded TDC data
+  uint64_t fShiftData2MC;              // Value to shift Data to MC -- so that data agree with MC [ns]
+                                       // TODO: Derive this value and verify if it is consistent across pmt/crt
+                                       // TODO: Get this value from database instead of fhicl parameter
+  uint64_t fShiftRWM2Gate;             // Value to move RWM frame to agree with HLT Gate Frame
+                                       // This is derived by subtracting: TDC RWM - HLT Gate.
+                                       // Using the MC2025B dataset, this distribution has a mean of 1738 ns and std of 9 ns.
+                                       // TODO: Get this value from database instead of fhicl parameter
+  uint64_t fShiftTDC2PTB;              // Value to account for cable length between TDC and PTB
+  bool fMakeTree;                      // Whether to produce a TTree in the hist file
+  bool fDebugDAQHeader;                // Whether to print debug statements relevant to DAQ header
+  bool fDebugPtb;                      // Whether to print debug statements relevant to PTB
+  bool fDebugTdc;                      // Whether to print debug statements relevant to TDC
+  bool fDebugFrame;                    // Whether to print debug statements relevant to frame shifts
 
-  //PTB
-  art::InputTag fPtbDecodeLabel;
-  
-  std::vector<int> fPtbEtrigHlts; 
-  
-  std::vector<int> fBeamEtrigHlt;
-  std::vector<int> fOffbeamEtrigHlt;
-  std::vector<int> fXmuonEtrigHlt;
-  
-  int fBeamCrtT1Hlt;
-  int fOffbeamCrtT1Hlt;
-  
-  int fBeamGateHlt;
-  int fOffbeamGateHlt;
-  
-  std::vector<uint64_t> _ptb_hlt_trigger;
-  std::vector<uint64_t> _ptb_hlt_timestamp;
-  std::vector<uint64_t> _ptb_hlt_unmask_timestamp;
-  std::vector<int> _ptb_hlt_trunmask;
 
-  std::vector<int> _ptb_hlt_etrig;
-  std::vector<uint64_t> _ptb_hlt_etrig_ts;
+  // Global Variables, set in processing
+  int _run, _subrun, _event;                       // Stores the unique run, subrun, event number combination for this event
 
-  bool _isBeam;
-  bool _isOffbeam;
-  bool _isXmuon;  
+  uint64_t _raw_ts;                                // Stores DAQ header timestamp
+  std::vector<uint64_t> _ptb_hlt_trigger;          // Stores full trigger word from PTB HLT (indexed per HLT)
+  std::vector<uint64_t> _ptb_hlt_timestamp;        // Stores timestamp associated with PTB HLT (indexed per HLT)
+  std::vector<uint64_t> _ptb_hlt_unmask_timestamp; // Stores timestamp associated with PTB HLT for each element (indexed per HLT element once unmasked)
+  std::vector<int> _ptb_hlt_trunmask;              // Stores PTB HLT code for each element (indexed per HLT element once unmasked)
+  std::vector<int> _ptb_hlt_etrig;                 // Stores all PTB HLTs that are an 'allowed type' for this stream
+  std::vector<uint64_t> _ptb_hlt_etrig_ts;         // Stores the associated timestamps for the above HLTs
 
-  int _hlt_etrig;
-  uint64_t _hlt_etrig_ts;
-  int _hlt_gate;
-  uint64_t _hlt_gate_ts;
-  int _hlt_crtt1;
-  uint64_t _hlt_crtt1_ts;
+  bool _isBeam;                                    // Event is a beam trigger (BNB or BNBLight)
+  bool _isOffbeam;                                 // Event is an offbeam trigger (OffBeam or OffBeamLight)
+  bool _isXmuon;                                   // Event is a crossing muon trigger
+
+  int _hlt_etrig;                                  // Stores the HLT event trigger code, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _hlt_etrig_ts;                          // Stores the HLT timestamp, once we've decided which one was closest to the DAQ header timestamp
+  int _hlt_gate;                                   // Stores the HLT gate opening code, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _hlt_gate_ts;                           // Stores the HLT gate opening timestamp, once we've decided which one was closest to the DAQ header timestamp
+  int _hlt_crtt1;                                  // Stores the HLT CRT T1 code, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _hlt_crtt1_ts;                          // Stores the HLT CRT T1 timestamp, once we've decided which one was closest to the DAQ header timestamp
  
-  //TDC
-  art::InputTag fTdcDecodeLabel;
+  std::vector<uint64_t> _tdc_ch0;                  // Stores all the timestamps recorded in the TDC channel 0 (CRT T1)
+  std::vector<uint64_t> _tdc_ch1;                  // Stores all the timestamps recorded in the TDC channel 1 (BES)
+  std::vector<uint64_t> _tdc_ch2;                  // Stores all the timestamps recorded in the TDC channel 2 (RWM)
+  std::vector<uint64_t> _tdc_ch4;                  // Stores all the timestamps recorded in the TDC channel 4 (Event trigger)
 
-  std::vector<uint64_t> _tdc_ch0;
-  std::vector<uint64_t> _tdc_ch1;
-  std::vector<uint64_t> _tdc_ch2;
-  std::vector<uint64_t> _tdc_ch4;
+  uint64_t _tdc_crtt1_ts;                          // Stores the TDC CRT T1 timestamp, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _tdc_bes_ts;                            // Stores the TDC BES timestamp, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _tdc_rwm_ts;                            // Stores the TDC RWM timestamp, once we've decided which one was closest to the DAQ header timestamp
+  uint64_t _tdc_etrig_ts;                          // Stores the TDC event trigger timestamp, once we've decided which one was closest to the DAQ header timestamp
 
-  uint64_t _tdc_crtt1_ts;
-  uint64_t _tdc_bes_ts;
-  uint64_t _tdc_rwm_ts;
-  uint64_t _tdc_etrig_ts;
+  uint64_t _frame_crtt1;                           // Stores the shift required to move from the PPS frame to the CRT T1 frame
+  uint16_t _timing_type_crtt1;                     // Stores the type (TDC/PTB) used to produce the above shift
+  uint16_t _timing_channel_crtt1;                  // Stores the channel (TDC) / code (PTB) used to produce the above shift
+  uint64_t _frame_gate;                            // Stores the shift required to move from the PPS frame to the gate opening frame
+  uint16_t _timing_type_gate;                      // Stores the type (TDC/PTB) used to produce the above shift
+  uint16_t _timing_channel_gate;                   // Stores the channel (TDC) / code (PTB) used to produce the above shift
+  uint64_t _frame_etrig;                           // Stores the shift required to move from the PPS frame to the event trigger frame
+  uint16_t _timing_type_etrig;                     // Stores the type (TDC/PTB) used to produce the above shift
+  uint16_t _timing_channel_etrig;                  // Stores the channel (TDC) / code (PTB) used to produce the above shift
 
-  //Frame Shift
-  uint64_t _frame_crtt1; //ns
-  uint16_t _timing_type_crtt1;
-  uint16_t _timing_channel_crtt1;
-  uint64_t _frame_gate; //ns
-  uint16_t _timing_type_gate;
-  uint16_t _timing_channel_gate;
-  uint64_t _frame_etrig; //ns
-  uint16_t _timing_type_etrig;
-  uint16_t _timing_channel_etrig;
+  uint64_t _frame_default;                         // Stores the shift required to move from the PPS frame to the default frame for this stream
+  uint16_t _timing_type_default;                   // Stores the type (TDC/PTB) used to produce the above shift
+  uint16_t _timing_channel_default;                // Stores the channel (TDC) / code (PTB) used to produce the above shift
 
-  //Value to apply at downstream modules depending on which stream
-  uint64_t _frame_default;
-  uint16_t _timing_type_default;
-  uint16_t _timing_channel_default;
-
-  //Value to shift Data to MC -- so that data agree with MC [ns]
-  //TODO: Derive this value and verify if it is consistent across pmt/crt
-  //TODO: Get this value from database instead of fhicl parameter
-  uint64_t fShiftData2MC; //ns
-
-  //Value to move RWM frame to agree with HLT Gate Frame
-  //This is derived by subtracting: TDC RWM - HLT Gate.
-  //Using the MC2025B dataset, this distribution has a mean of 1738 ns and std of 9 ns.
-  //TODO: Get this value from database instead of fhicl parameter
-  uint64_t fShiftRWM2Gate; //ns
-
-  //Value to move TDC values to PTB HLT values
-  uint64_t fShiftTDC2PTB; //ns
-
-  //Debug
-  bool fDebugDAQHeader;
-  bool fDebugPtb;
-  bool fDebugTdc;
-  bool fDebugFrame;
-
-  //---TREE PARAMETERS
+  // Tree production
   TTree *fTree;
   art::ServiceHandle<art::TFileService> tfs;
-  int _run, _subrun, _event;
 
+  // Useful value
   static constexpr uint64_t kSecondInNanoseconds = static_cast<uint64_t>(1e9);
 };
 
 
 sbnd::timing::FrameShift::FrameShift(fhicl::ParameterSet const& p)
-  : EDProducer{p}  // ,
-    // More initializers here.
+  : EDProducer{p}
 {
   fDAQHeaderInstanceLabel = p.get<std::string>("DAQHeaderInstanceLabel");
   fDAQHeaderModuleLabel = p.get<std::string>("DAQHeaderModuleLabel");
   fRawTSCorrection = p.get<uint64_t>("RawTSCorrection");
-  fMaxAllowedRefTimeDiff = p.get<uint64_t>("MaxAllowedRefTimeDiff");
-  
-  fTimingRefPmtLabel = p.get<art::InputTag>("TimingRefPmtLabel");
-  fTimingRefCrtLabel = p.get<art::InputTag>("TimingRefCrtLabel");
-
-  fTdcDecodeLabel = p.get<art::InputTag>("TdcDecodeLabel");
   fPtbDecodeLabel = p.get<art::InputTag>("PtbDecodeLabel");
-
   fPtbEtrigHlts = p.get<std::vector<int>>("PtbEtrigHlts");
-  
   fBeamEtrigHlt = p.get<std::vector<int>>("BeamEtrigHlt");
   fOffbeamEtrigHlt = p.get<std::vector<int>>("OffbeamEtrigHlt");
   fXmuonEtrigHlt = p.get<std::vector<int>>("XmuonEtrigHlt");
-  
   fBeamCrtT1Hlt = p.get<int>("BeamCrtT1Hlt");
   fOffbeamCrtT1Hlt = p.get<int>("OffbeamCrtT1Hlt");
-
   fBeamGateHlt = p.get<int>("BeamGateHlt");
   fOffbeamGateHlt = p.get<int>("OffbeamGateHlt");
-
+  fTdcDecodeLabel = p.get<art::InputTag>("TdcDecodeLabel");
+  fShiftData2MC = p.get<uint64_t>("ShiftData2MC"); //TODO: Get from database instead of fhicl parameters
+  fShiftRWM2Gate = p.get<uint64_t>("ShiftRWM2Gate"); //TODO: Get from database instead of fhicl parameters
+  fShiftTDC2PTB = p.get<uint64_t>("ShiftTDC2PTB"); //TODO: Get from database instead of fhicl parameters
+  fMakeTree = p.get<bool>("MakeTree", false);
   fDebugDAQHeader = p.get<bool>("DebugDAQHeader", false);
   fDebugPtb = p.get<bool>("DebugPtb", false);
   fDebugTdc = p.get<bool>("DebugTdc", false);
   fDebugFrame = p.get<bool>("DebugFrame", false);
   
-  //TODO: Get from database instead of fhicl parameters
-  fShiftData2MC = p.get<uint64_t>("ShiftData2MC");
-  fShiftRWM2Gate = p.get<uint64_t>("ShiftRWM2Gate"); 
-  fShiftTDC2PTB = p.get<uint64_t>("ShiftTDC2PTB");
-  
-  produces< FrameShiftInfo >();
-  produces< TimingInfo >();
+  produces<FrameShiftInfo>();
+  produces<TimingInfo>();
 }
 
 void sbnd::timing::FrameShift::produce(art::Event& e)
@@ -361,7 +329,8 @@ void sbnd::timing::FrameShift::produce(art::Event& e)
   e.put(std::move(newFrameShiftInfo));
 
   //Fill the tree
-  fTree->Fill();
+  if(fMakeTree)
+    fTree->Fill();
 }
 
 uint64_t sbnd::timing::FrameShift::FindClosest(const std::vector<uint64_t> &timestamps, const uint64_t &reference)
@@ -691,52 +660,53 @@ void sbnd::timing::FrameShift::DecideRelevantPTBTimestamps(const uint64_t &globa
 
 void sbnd::timing::FrameShift::beginJob()
 {
-  // Implementation of optional member function here.
-  //Event Tree
-  fTree = tfs->make<TTree>("events", "");
+  if(fMakeTree)
+    {
+      fTree = tfs->make<TTree>("events", "");
   
-  fTree->Branch("run", &_run);
-  fTree->Branch("subrun", &_subrun);
-  fTree->Branch("event", &_event);
+      fTree->Branch("run", &_run);
+      fTree->Branch("subrun", &_subrun);
+      fTree->Branch("event", &_event);
   
-  //TDC
-  fTree->Branch("tdc_ch0", &_tdc_ch0);
-  fTree->Branch("tdc_ch1", &_tdc_ch1);
-  fTree->Branch("tdc_ch2", &_tdc_ch2);
-  fTree->Branch("tdc_ch4", &_tdc_ch4);
+      //TDC
+      fTree->Branch("tdc_ch0", &_tdc_ch0);
+      fTree->Branch("tdc_ch1", &_tdc_ch1);
+      fTree->Branch("tdc_ch2", &_tdc_ch2);
+      fTree->Branch("tdc_ch4", &_tdc_ch4);
 
-  fTree->Branch("tdc_crtt1_ts", &_tdc_crtt1_ts);
-  fTree->Branch("tdc_bes_ts", &_tdc_bes_ts);
-  fTree->Branch("tdc_rwm_ts", &_tdc_rwm_ts);
-  fTree->Branch("tdc_etrig_ts", &_tdc_etrig_ts);
+      fTree->Branch("tdc_crtt1_ts", &_tdc_crtt1_ts);
+      fTree->Branch("tdc_bes_ts", &_tdc_bes_ts);
+      fTree->Branch("tdc_rwm_ts", &_tdc_rwm_ts);
+      fTree->Branch("tdc_etrig_ts", &_tdc_etrig_ts);
 
-  //PTB
-  fTree->Branch("ptb_hlt_unmask_timestamp", &_ptb_hlt_unmask_timestamp);
-  fTree->Branch("ptb_hlt_trunmask", &_ptb_hlt_trunmask);
+      //PTB
+      fTree->Branch("ptb_hlt_unmask_timestamp", &_ptb_hlt_unmask_timestamp);
+      fTree->Branch("ptb_hlt_trunmask", &_ptb_hlt_trunmask);
 
-  fTree->Branch("hlt_etrig", &_hlt_etrig);
-  fTree->Branch("hlt_etrig_ts", &_hlt_etrig_ts);
-  fTree->Branch("hlt_gate", &_hlt_gate);
-  fTree->Branch("hlt_gate_ts", &_hlt_gate_ts);
-  fTree->Branch("hlt_crtt1", &_hlt_crtt1);
-  fTree->Branch("hlt_crtt1_ts", &_hlt_crtt1_ts);
+      fTree->Branch("hlt_etrig", &_hlt_etrig);
+      fTree->Branch("hlt_etrig_ts", &_hlt_etrig_ts);
+      fTree->Branch("hlt_gate", &_hlt_gate);
+      fTree->Branch("hlt_gate_ts", &_hlt_gate_ts);
+      fTree->Branch("hlt_crtt1", &_hlt_crtt1);
+      fTree->Branch("hlt_crtt1_ts", &_hlt_crtt1_ts);
 
-  //Frame Shift
-  fTree->Branch("frame_crtt1", &_frame_crtt1);
-  fTree->Branch("timing_type_crtt1", &_timing_type_crtt1);
-  fTree->Branch("timing_channel_crtt1", &_timing_channel_crtt1);
+      //Frame Shift
+      fTree->Branch("frame_crtt1", &_frame_crtt1);
+      fTree->Branch("timing_type_crtt1", &_timing_type_crtt1);
+      fTree->Branch("timing_channel_crtt1", &_timing_channel_crtt1);
 
-  fTree->Branch("frame_gate", &_frame_gate);
-  fTree->Branch("timing_type_gate", &_timing_type_gate);
-  fTree->Branch("timing_channel_gate", &_timing_channel_gate);
+      fTree->Branch("frame_gate", &_frame_gate);
+      fTree->Branch("timing_type_gate", &_timing_type_gate);
+      fTree->Branch("timing_channel_gate", &_timing_channel_gate);
 
-  fTree->Branch("frame_etrig", &_frame_etrig);  
-  fTree->Branch("timing_type_etrig", &_timing_type_etrig);
-  fTree->Branch("timing_channel_etrig", &_timing_channel_etrig);
+      fTree->Branch("frame_etrig", &_frame_etrig);  
+      fTree->Branch("timing_type_etrig", &_timing_type_etrig);
+      fTree->Branch("timing_channel_etrig", &_timing_channel_etrig);
 
-  fTree->Branch("frame_default", &_frame_default);
-  fTree->Branch("timing_type_default", &_timing_type_default);
-  fTree->Branch("timing_channel_default", &_timing_channel_default);
+      fTree->Branch("frame_default", &_frame_default);
+      fTree->Branch("timing_type_default", &_timing_type_default);
+      fTree->Branch("timing_channel_default", &_timing_channel_default);
+    }
 }
 
 void sbnd::timing::FrameShift::ResetEventVars()

--- a/sbndcode/Timing/FrameShift/frameshift_sbnd_data.fcl
+++ b/sbndcode/Timing/FrameShift/frameshift_sbnd_data.fcl
@@ -1,40 +1,36 @@
 BEGIN_PROLOG
+
 frameshift_data:
 {
-    module_type:  "FrameShift" 
-    
-    DAQHeaderInstanceLabel: "RawEventHeader"
-    DAQHeaderModuleLabel: "daq"
-    RawTSCorrection: 367000 //367 us
-    MaxAllowedRefTimeDiff: 3000000 //3 ms
+  module_type:  "FrameShift" 
   
-    TimingRefPmtLabel: "pmtdecoder"
-    TimingRefCrtLabel: "crtstrips"
+  DAQHeaderInstanceLabel: "RawEventHeader"
+  DAQHeaderModuleLabel: "daq"
+  RawTSCorrection: 367000 //367 us
+  
+  TdcDecodeLabel: "tdcdecoder"
+  PtbDecodeLabel: "ptbdecoder"
 
-    TdcDecodeLabel: "tdcdecoder"
-    PtbDecodeLabel: "ptbdecoder"
+  PtbEtrigHlts: [1, 2, 3, 4, 5, 14, 15]
+  
+  BeamEtrigHlt: [1,2]
+  OffbeamEtrigHlt: [3,4]
+  XmuonEtrigHlt: [5, 14, 15]
 
-    PtbEtrigHlts: [1, 2, 3, 4, 5, 14, 15]
-    
-    BeamEtrigHlt: [1,2]
-    OffbeamEtrigHlt: [3,4]
-    XmuonEtrigHlt: [5, 14, 15]
+  BeamCrtT1Hlt: 20
+  OffbeamCrtT1Hlt: 21
 
-    BeamCrtT1Hlt: 20
-    OffbeamCrtT1Hlt: 21
+  BeamGateHlt: 26
+  OffbeamGateHlt: 27
 
-    BeamGateHlt: 26
-    OffbeamGateHlt: 27
-
-    DebugDAQHeader: false
-    DebugPtb: false
-    DebugTdc: false
-    DebugFrame: false
-    
-    ShiftData2MC: 0
-    ShiftRWM2Gate: 1738 #ns
-    ShiftTDC2PTB: 257 #ns
+  DebugDAQHeader: false
+  DebugPtb: false
+  DebugTdc: false
+  DebugFrame: false
+  
+  ShiftData2MC: 0
+  ShiftRWM2Gate: 1738 //ns
+  ShiftTDC2PTB: 257 //ns
 }
-  
-  
+
 END_PROLOG


### PR DESCRIPTION
## Description 
**This is an internal PR within the team working on refactoring the timing reference frames for data, release managers can ignore. We will make a final PR once the main branch is ready.**

In this PR I've refactored the frame shift module a little:
- Moved everything into the `sbnd::timing` namespace so we don't have to specify it for all the objects etc.
- Added functions to split up most of the `produce()` function and make things a little more readable.
- Created helper function for finding the closest timestamp in a vector to provided reference timestamp, as this was being done many times.
- Created helper function for formatting a `uint64_t` timestamp into seconds and nanoseconds for print statements, as this was also being done many times.
- I've reduced the duplication in the final logic, a lot of it was the same for beam and offbeam.
- I've made the indentation consistent and removed unused fcl parameters.
- I've added a fcl parameter (that defaults to false) for whether to produce the TTree.
- I've made sure we are using pre-defined default values and enumerations provided in the relevant sbnobj files.

This goes with SBNSoftware/sbnobj#156