### PR TITLE
Bugifx/acastill realistic pmt

### DIFF
--- a/sbndcode/OpDetReco/OpDeconvolution/job/run_decohitfinder.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/run_decohitfinder.fcl
@@ -50,19 +50,18 @@ physics:
     ophitxarapuca:  @local::SBNDDecoOpHitFinderXArapuca
     opflashdecotpc0arapuca:   @local::SBNDDecoSimpleFlashTPC0Arapuca
     opflashdecotpc1arapuca:   @local::SBNDDecoSimpleFlashTPC1Arapuca
-
   }
 
   reco: [
     opdecopmt,
     ophitpmt,
     opflashtpc0,
-    opflashtpc1,
+    opflashtpc1
 
-    opdecoxarapuca,
-    ophitxarapuca,
-    opflashdecotpc0arapuca,
-    opflashdecotpc1arapuca
+    #opdecoxarapuca,
+    #ophitxarapuca,
+    #opflashdecotpc0arapuca,
+    #opflashdecotpc1arapuca
   ]
 
 

--- a/sbndcode/OpDetReco/OpDeconvolution/job/run_decohitfinder.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/run_decohitfinder.fcl
@@ -41,10 +41,10 @@ physics:
 {
   producers:
   {
-    opdecopmt:     @local::SBNDOpDeconvolutionPMT
-    ophitpmt:  @local::SBNDDecoOpHitFinderPMT
-    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0
-    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1
+    opdecopmt:     @local::SBNDOpDeconvolutionPMT_realisticMC
+    ophitpmt:  @local::SBNDDecoOpHitFinderPMT_realisticMC
+    opflashtpc0:   @local::SBNDDecoSimpleFlashTPC0_realisticMC
+    opflashtpc1:   @local::SBNDDecoSimpleFlashTPC1_realisticMC
 
     opdecoxarapuca:     @local::SBNDOpDeconvolutionXARAPUCA
     ophitxarapuca:  @local::SBNDDecoOpHitFinderXArapuca

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -62,6 +62,7 @@ SBNDDecoSimpleFlashTPC0_realisticMC.OpHitInputTime: "RiseTime"
 SBNDDecoSimpleFlashTPC0_realisticMC.UseT0Tool: true
 SBNDDecoSimpleFlashTPC0_realisticMC.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC0_realisticMC.CorrectLightPropagation: true
+SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC2.root"
 
 #TPC1
 SBNDDecoSimpleFlashTPC1_realisticMC: @local::SBNDSimpleFlashTPC1
@@ -73,7 +74,7 @@ SBNDDecoSimpleFlashTPC1_realisticMC.OpHitInputTime: "RiseTime"
 SBNDDecoSimpleFlashTPC1_realisticMC.UseT0Tool: true
 SBNDDecoSimpleFlashTPC1_realisticMC.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC1_realisticMC.CorrectLightPropagation: true
-SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
+SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC2.root"
 
 
 ###### XA IDEAL MC ######

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_ophitfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_ophitfinder_deco.fcl
@@ -103,7 +103,5 @@ SBNDDecoOpHitFinderPMT_data.PedAlgoPset.Method:2
 
 #####OpHit finder for PMT deconvolved waveforms#####
 SBNDDecoOpHitFinderPMT_realisticMC: @local::SBNDDecoOpHitFinderPMT_data
-####SPE area must be 1./DecoWaveformPrecision
-SBNDDecoOpHitFinderPMT_realisticMC.InputModule: "pmtpulseoscillation"
 
 END_PROLOG

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -23,8 +23,8 @@ sbnd_digipmt_alg:
   CableTime:             135        #time delay of the 30 m long readout cable in ns
 
   # Digitizer simulation
-  PMTADCDynamicRange:    14745      #in ADC values
-  PMTBaseline:           14745      #in ADC
+  PMTADCDynamicRange:    14250      #in ADC values
+  PMTBaseline:           14250      #in ADC
   PMTBaselineRMS:        2.6        #in ADC
   
   #Sample noise from data

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -35,12 +35,12 @@ sbnd_digipmt_alg:
   PMTDarkNoiseRate:      1000.0     #in Hz
   
   # Detection efficiencies
-  PMTCoatedVUVEff_tpc0:       0.0315      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff_tpc0:       0.03493    #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff_tpc0:        0.03382   #PMT uncoated detection efficiency
+  PMTCoatedVUVEff_tpc0:       0.0385      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc0:       0.026    #PMT coated detection efficiency for reflected (VIS) light
+  PMTUncoatedEff_tpc0:        0.0357   #PMT uncoated detection efficiency
 
-  PMTCoatedVUVEff_tpc1:       0.027      #PMT coated detection efficiency for direct (VUV) light
-  PMTCoatedVISEff_tpc1:       0.03493      #PMT coated detection efficiency for reflected (VIS) light
+  PMTCoatedVUVEff_tpc1:       0.0392      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVISEff_tpc1:       0.026      #PMT coated detection efficiency for reflected (VIS) light
   PMTUncoatedEff_tpc1:        0.03382      #PMT uncoated detection efficiency
 
   # Simulate gain fluctuations

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -41,7 +41,7 @@ sbnd_digipmt_alg:
 
   PMTCoatedVUVEff_tpc1:       0.0392      #PMT coated detection efficiency for direct (VUV) light
   PMTCoatedVISEff_tpc1:       0.026      #PMT coated detection efficiency for reflected (VIS) light
-  PMTUncoatedEff_tpc1:        0.03382      #PMT uncoated detection efficiency
+  PMTUncoatedEff_tpc1:        0.0357      #PMT uncoated detection efficiency
 
   # Simulate gain fluctuations
   # (comment-out to skip gain fluctuations simulation)

--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -35,7 +35,7 @@ sbnd_digipmt_alg:
   PMTDarkNoiseRate:      1000.0     #in Hz
   
   # Detection efficiencies
-  PMTCoatedVUVEff_tpc0:       0.0385      #PMT coated detection efficiency for direct (VUV) light
+  PMTCoatedVUVEff_tpc0:       0.0392      #PMT coated detection efficiency for direct (VUV) light
   PMTCoatedVISEff_tpc0:       0.026    #PMT coated detection efficiency for reflected (VIS) light
   PMTUncoatedEff_tpc0:        0.0357   #PMT uncoated detection efficiency
 


### PR DESCRIPTION
## Description 
After (https://github.com/SBNSoftware/sbndcode/pull/876), the `OpHitFinder` algorithm for realistic MC workflow was missconfigured. The OpHitFinder module was taking raw waveforms coming from the `pmtpulseoscillation` module instead of `deconvolved` waveforms coming from `opdecopmt` module. This PR corrects the label for the `OpHitFinder` algorithm to use deconvolved waveforms.

It does also: 
- Remove XA reconstruction for light-only reconstruction fcl.
- Uses the correct drift estimation curve for realistic MC.
- Updates PMT detection efficiencies for better data/MC agreement


Please provide a detailed description of the changes this pull request introduces. 

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [x] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
