### PR TITLE
Fix: correction to MonThreshold fcl parameter for data and MC

### DIFF
--- a/sbndcode/Decoders/PMT/pmtdecoder.fcl
+++ b/sbndcode/Decoders/PMT/pmtdecoder.fcl
@@ -48,7 +48,7 @@ pmtdecoder:
     hist_evt:        1  # the # of the event used to generate the histograms, 1st event by default 
 
     # trigger configurable
-    mon_threshold:   15 # ADC channel value threshold to add 1 to the trigger response MON pulse
+    mon_threshold:   50 # ADC channel value threshold to add 1 to the trigger response MON pulse
 
     # for when the fragIDs are mapped to the old configuration or you need to hardcode fragids...
     ## to use this, must set `fragid_offset` to 0!!!

--- a/sbndcode/OpDetSim/BeamRatesCalib_Defaults.fcl
+++ b/sbndcode/OpDetSim/BeamRatesCalib_Defaults.fcl
@@ -19,7 +19,7 @@ BeamRatesCalib:
     # Save some example trigger pulses for each flash (TH1D similar to wvfana)
     SaveAllMon: true
     # The MON threshold used in the saved TH1D examples
-    FCLthreshold: 25 
+    FCLthreshold: 50 
     # PMT index corresponding to the opening of the beam acceptance BeamWindowEnd
     # Note that BeamWindowStart should not account for MTC/A wire+processing delays
     # Those are handled by CAENOffset

--- a/sbndcode/OpDetSim/BeamRatesCalib_module.cc
+++ b/sbndcode/OpDetSim/BeamRatesCalib_module.cc
@@ -200,7 +200,7 @@ namespace opdet { //OpDet means optical detector
     fBeamWindowEnd = p.get<int>("BeamWindowEnd", 1688+680);
     fSaveAllMON = p.get<bool>("SaveAllMon", false);
     fCheckTriggers = p.get<bool>("CheckHardwareTriggers", false); //Needs MTCA LLT to be digitized which is unusual (run 15670)
-    fFCLthreshold        = p.get<int>("FCLthreshold", 15);
+    fFCLthreshold        = p.get<int>("FCLthreshold", 50);
     fOpDetsToPlot    = p.get<std::vector<std::string> >("OpDetsToPlot");
     fCheckSoftTrig = p.get<bool>("CheckSoftTrig", false);
     fSoftTrigLabel = p.get<std::string>("SoftTrigLabel", "pmtmetricproducer:");

--- a/sbndcode/OpDetSim/opdetdigitizer_sbnd.fcl
+++ b/sbndcode/OpDetSim/opdetdigitizer_sbnd.fcl
@@ -14,7 +14,7 @@ sbnd_opdetdigitizer:
   ApplyTriggers:             true  #optional
   ticksPerSlice:             5000 # corresponds to 10us
   PercentTicksBeforeCross:             0.2
-  MonThreshold:             15
+  MonThreshold:             50
   PairMultiplicityThreshold:             4 
 
   @table::sbnd_digipmt_alg


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [x] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer. 
Does not affect CAFs.
- [x] Does this affect the standard workflow? No
- [x] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
Documented on the Bug Tracker for the SBND Hack-a-thon ([slides](https://docs.google.com/presentation/d/1ru-3PjII875arrPLl-oSbMaQ-EFj5KQnRM_ppDTxVrI/edit?usp=sharing) and slack #sbnd-validation-hackathon)