### PR TITLE
Add RecoUtils to the call stack

### DIFF
--- a/sbndcode/WireMod/CMakeLists.txt
+++ b/sbndcode/WireMod/CMakeLists.txt
@@ -6,6 +6,7 @@ cet_build_plugin(WireModifier art::EDProducer
     LIBRARIES PRIVATE
     sbncode_CAFMaker
     sbncode::WireMod_Utility
+    sbncode::caf_RecoUtils
     sbnobj::Common_SBNEventWeight
     larsim::MCCheater_BackTrackerService_service
     sbnanaobj::StandardRecord


### PR DESCRIPTION
## Description 
Adds RecoUtils from sbncode to the call stack to Wiremod

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 
(Note that WireMod is not in develop)

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
