### PR TITLE
Bugifx/acastill realistic pmt

### DIFF
--- a/sbndcode/Calibration/configurations/calibration_database_PDS_TagSets_sbnd.fcl
+++ b/sbndcode/Calibration/configurations/calibration_database_PDS_TagSets_sbnd.fcl
@@ -10,8 +10,8 @@ BEGIN_PROLOG
 
 # For SBND 2025 Fall production
 PDS_CalibrationTags_Nov2025: {
-  PMTCalibrationDatabaseTag:    "v2r1"
-  DatabaseTimeStamp: 1763157679000000000
+  PMTCalibrationDatabaseTag:    "v3r1"
+  DatabaseTimeStamp: 1765487620000000000
 }
 
 END_PROLOG

--- a/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
+++ b/sbndcode/JobConfigurations/standard/reco/config/workflow_reco2.fcl
@@ -77,8 +77,8 @@ sbnd_reco2_producers:{
     fmatchoparaSCE:      @local::sbnd_simple_flashmatch_opara_sce
     opt0finder:          @local::sbnd_opt0_finder_one_to_many
     opt0finderSCE:       @local::sbnd_opt0_finder_one_to_many
-    tpcpmtbarycentermatching: @local::TPCPMTBarycenterMatchProducer
-    tpcpmtbarycentermatchingSCE: @local::TPCPMTBarycenterMatchProducerSCE
+    tpcpmtbarycentermatching: @local::TPCPMTBarycenterMatchProducerMC
+    tpcpmtbarycentermatchingSCE: @local::TPCPMTBarycenterMatchProducerSCEMC
 
     ### Uncalibrated calorimetry producer for calibration caloskimmer
     caloskimCalorimetry: @local::caloskim_calorimetry

--- a/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
+++ b/sbndcode/JobConfigurations/standard/standard_detsim_sbnd.fcl
@@ -68,12 +68,12 @@ physics:
     simtpc2d:  @local::sbnd_wcls_simsp_bothrois
     crtsim:    @local::sbnd_crtsim
     opdaq:     @local::sbnd_opdetdigitizer
-    pmtmetricmc: @local::sbnd_pmtmcmetricproducer
     pmtpulseoscillation: @local::sbnd_pmtpulseoscillation
+    pmtmetricmc: @local::sbnd_pmtmcmetricproducer
   }
 
   #define the producer and filter modules for this path, order matters,
-  simulate: [rns, simtpc2d, crtsim, opdaq, pmtmetricmc, pmtpulseoscillation]
+  simulate: [rns, simtpc2d, crtsim, opdaq, pmtpulseoscillation, pmtmetricmc]
 
   #define the output stream, there could be more than one if using filters
   stream1:   [ out1 ]

--- a/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
+++ b/sbndcode/LArSoftConfigurations/opticalproperties_sbnd.fcl
@@ -30,7 +30,7 @@ sbnd_opticalproperties: {
     # ScintPreScale MUST be equal/larger than the largest detection efficiency applied at DetSim stage
     # This corresponds to the coated PMTs detection efficiency (3.9% see docdb-40444)
     # See sbndcode/OpDetSim/digi_pmt_sbnd.fcl
-    ScintPreScale:  0.039
+    ScintPreScale:  0.0392
 
     EnableCerenkovLight: false # Cerenkov light OFF by default
 

--- a/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWienerData_tool.cc
+++ b/sbndcode/OpDetReco/OpDeconvolution/Alg/OpDeconvolutionAlgWienerData_tool.cc
@@ -51,7 +51,6 @@ private:
   std::vector<double> fSinglePEWave;
   std::vector<int> fSinglePEChannels;
   std::vector<double> fPeakAmplitude;
-  std::vector<int> fSkipChannelList;
   bool fPositivePolarity;
   bool fUseSaturated;
   int fADCSaturationValue;
@@ -129,7 +128,6 @@ opdet::OpDeconvolutionAlgWiener::OpDeconvolutionAlgWiener(fhicl::ParameterSet co
   fPMTChargeToADC = p.get< double >("PMTChargeToADC");
   fDecoWaveformPrecision = p.get< double >("DecoWaveformPrecision");
   fBaselineSample = p.get< short unsigned int >("BaselineSample");
-  fSkipChannelList = p.get< std::vector<int>>("SkipChannelList");
   fFilter = p.get< std::string >("Filter");
   fElectronics = p.get< std::string >("Electronics");
   fDaphne_Freq  = p.get< double >("DaphneFreq");
@@ -173,11 +171,9 @@ std::vector<raw::OpDetWaveform> opdet::OpDeconvolutionAlgWiener::RunDeconvolutio
 {
   std::vector<raw::OpDetWaveform> wfDeco;
   wfDeco.reserve(wfVector.size());
-  for(auto const& wf : wfVector)
-  {
+  for(auto const& wf : wfVector){
     int channelNumber = wf.ChannelNumber();
-    auto it = std::find(fSkipChannelList.begin(), fSkipChannelList.end(), channelNumber);
-    if (it == fSkipChannelList.end()) {
+    if(fPMTCalibrationDatabaseService->getReconstructChannel(channelNumber)) {
       fSinglePEWave = fPMTCalibrationDatabaseService->getSER(channelNumber);
       double SPEAmplitude =  fPMTCalibrationDatabaseService->getSPEAmplitude(channelNumber);
       double SPEPeakValue = *std::max_element(fSinglePEWave.begin(), fSinglePEWave.end(), [](double a, double b) {return std::abs(a) < std::abs(b);});

--- a/sbndcode/OpDetReco/OpDeconvolution/job/opdeconvolution_sbnd.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/opdeconvolution_sbnd.fcl
@@ -34,7 +34,6 @@ SBNDOpDeconvolutionPMT_data.Electronics: [""]
 SBNDOpDeconvolutionPMT_data.OpDecoAlg.OpDetDataFile: "./OpDetSim/digi_pmt_sbnd_data_OV6.root"
 SBNDOpDeconvolutionPMT_data.OpDecoAlg.Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))" #Gauss filter, remove DC component F(0)=0
 SBNDOpDeconvolutionPMT_data.OpDecoAlg.DecoWaveformPrecision: 0.005
-SBNDOpDeconvolutionPMT_data.OpDecoAlg.SkipChannelList: [39, 66, 67, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302]
 
 ###### PMT REALISTIC MC ######
 
@@ -46,7 +45,6 @@ SBNDOpDeconvolutionPMT_realisticMC.Electronics: [""]
 SBNDOpDeconvolutionPMT_realisticMC.OpDecoAlg.OpDetDataFile: "./OpDetSim/digi_pmt_sbnd_data_OV6.root"
 SBNDOpDeconvolutionPMT_realisticMC.OpDecoAlg.Filter: "(x>0)*exp(-0.5*pow(x/[0],[1]))" #Gauss filter, remove DC component F(0)=0
 SBNDOpDeconvolutionPMT_realisticMC.OpDecoAlg.DecoWaveformPrecision: 0.005
-SBNDOpDeconvolutionPMT_realisticMC.OpDecoAlg.SkipChannelList: [39, 66, 67, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302]
 
 
 ###### XA IDEAL MC ######

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -41,7 +41,6 @@ SBNDDecoSimpleFlashTPC1_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.DataCalibration: true
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2_tpc1.root"
-SBNDDecoSimpleFlashTPC1_data.CorrectLightPropagation: true
 SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1Data
 
 

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -28,57 +28,36 @@ SBNDDecoSimpleFlashTPC1.CorrectLightPropagation: true
 
 ###### PMT DATA ######
 ###TPC0
-SBNDDecoSimpleFlashTPC0_data: @local::SBNDSimpleFlashTPC0
+SBNDDecoSimpleFlashTPC0_data: @local::SBNDDecoSimpleFlashTPC0
+SBNDDecoSimpleFlashTPC0_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC0_data.PECalib.SPEAreaGain: 200
-SBNDDecoSimpleFlashTPC0_data.OpHitProducers: ["ophitpmt"]
-SBNDDecoSimpleFlashTPC0_data.OpHitInputTime: "RiseTime"
-SBNDDecoSimpleFlashTPC0_data.UseT0Tool: true
-SBNDDecoSimpleFlashTPC0_data.ReadoutDelay: 0 //cable time delay in us
-SBNDDecoSimpleFlashTPC0_data.CorrectLightPropagation: true
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
+SBNDDecoSimpleFlashTPC0_data.FlashGeoConfig: @local::FlashGeoThresholdTPC0
 
 #TPC1
-SBNDDecoSimpleFlashTPC1_data: @local::SBNDSimpleFlashTPC1
+SBNDDecoSimpleFlashTPC1_data: @local::SBNDDecoSimpleFlashTPC1
+SBNDDecoSimpleFlashTPC1_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC1_data.PECalib.SPEAreaGain: 200
-SBNDDecoSimpleFlashTPC1_data.OpHitProducers: ["ophitpmt"]
-SBNDDecoSimpleFlashTPC1_data.OpHitInputTime: "RiseTime"
-SBNDDecoSimpleFlashTPC1_data.UseT0Tool: true
-SBNDDecoSimpleFlashTPC1_data.ReadoutDelay: 0 //cable time delay in us
+SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
 SBNDDecoSimpleFlashTPC1_data.CorrectLightPropagation: true
+SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1
 
 
 ###### PMT REALISTIC MC ######
 ###TPC0
-SBNDDecoSimpleFlashTPC0_realisticMC: @local::SBNDSimpleFlashTPC0
-SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
-SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC0_realisticMC.PECalib.SPEAreaGain: 200
-SBNDDecoSimpleFlashTPC0_realisticMC.OpHitProducers: ["ophitpmt"]
-SBNDDecoSimpleFlashTPC0_realisticMC.OpHitInputTime: "RiseTime"
-SBNDDecoSimpleFlashTPC0_realisticMC.UseT0Tool: true
-SBNDDecoSimpleFlashTPC0_realisticMC.ReadoutDelay: 0 //cable time delay in us
-SBNDDecoSimpleFlashTPC0_realisticMC.CorrectLightPropagation: true
-SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC2.root"
+SBNDDecoSimpleFlashTPC0_realisticMC: @local::SBNDDecoSimpleFlashTPC0_data
+SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC3.root"
+SBNDDecoSimpleFlashTPC0_realisticMC.ReadoutDelay: 0. //cable time delay in us
 
 #TPC1
-SBNDDecoSimpleFlashTPC1_realisticMC: @local::SBNDSimpleFlashTPC1
-SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
-SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC1_realisticMC.PECalib.SPEAreaGain: 200
-SBNDDecoSimpleFlashTPC1_realisticMC.OpHitProducers: ["ophitpmt"]
-SBNDDecoSimpleFlashTPC1_realisticMC.OpHitInputTime: "RiseTime"
-SBNDDecoSimpleFlashTPC1_realisticMC.UseT0Tool: true
-SBNDDecoSimpleFlashTPC1_realisticMC.ReadoutDelay: 0 //cable time delay in us
-SBNDDecoSimpleFlashTPC1_realisticMC.CorrectLightPropagation: true
-SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC2.root"
+SBNDDecoSimpleFlashTPC1_realisticMC: @local::SBNDDecoSimpleFlashTPC1_data
+SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC3.root"
+SBNDDecoSimpleFlashTPC1_realisticMC.ReadoutDelay: 0. //cable time delay in us
 
 
 ###### XA IDEAL MC ######
-
 ####OpFlash finder for XArapucas deconvolved waveforms#####
 ###TPC0
 SBNDDecoSimpleFlashTPC0Arapuca: @local::SBNDSimpleFlashTPC0

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -32,7 +32,7 @@ SBNDDecoSimpleFlashTPC0_data: @local::SBNDDecoSimpleFlashTPC0
 SBNDDecoSimpleFlashTPC0_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
+SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2_tpc0.root"
 SBNDDecoSimpleFlashTPC0_data.FlashGeoConfig: @local::FlashGeoThresholdTPC0Data
 
 #TPC1
@@ -40,7 +40,7 @@ SBNDDecoSimpleFlashTPC1_data: @local::SBNDDecoSimpleFlashTPC1
 SBNDDecoSimpleFlashTPC1_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.DataCalibration: true
-SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
+SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2_tpc1.root"
 SBNDDecoSimpleFlashTPC1_data.CorrectLightPropagation: true
 SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1Data
 

--- a/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
+++ b/sbndcode/OpDetReco/OpDeconvolution/job/sbnd_flashfinder_deco.fcl
@@ -33,7 +33,7 @@ SBNDDecoSimpleFlashTPC0_data.ReadoutDelay: 0 //cable time delay in us
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTRatio"
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.DataCalibration: true
 SBNDDecoSimpleFlashTPC0_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
-SBNDDecoSimpleFlashTPC0_data.FlashGeoConfig: @local::FlashGeoThresholdTPC0
+SBNDDecoSimpleFlashTPC0_data.FlashGeoConfig: @local::FlashGeoThresholdTPC0Data
 
 #TPC1
 SBNDDecoSimpleFlashTPC1_data: @local::SBNDDecoSimpleFlashTPC1
@@ -42,7 +42,7 @@ SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.tool_type: "DriftEstimatorPMTR
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.DataCalibration: true
 SBNDDecoSimpleFlashTPC1_data.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_data_v2.root"
 SBNDDecoSimpleFlashTPC1_data.CorrectLightPropagation: true
-SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1
+SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1Data
 
 
 ###### PMT REALISTIC MC ######
@@ -50,11 +50,13 @@ SBNDDecoSimpleFlashTPC1_data.FlashGeoConfig: @local::FlashGeoThresholdTPC1
 SBNDDecoSimpleFlashTPC0_realisticMC: @local::SBNDDecoSimpleFlashTPC0_data
 SBNDDecoSimpleFlashTPC0_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC3.root"
 SBNDDecoSimpleFlashTPC0_realisticMC.ReadoutDelay: 0. //cable time delay in us
+SBNDDecoSimpleFlashTPC0_realisticMC.FlashGeoConfig: @local::FlashGeoThresholdTPC0_realisticMC
 
 #TPC1
 SBNDDecoSimpleFlashTPC1_realisticMC: @local::SBNDDecoSimpleFlashTPC1_data
 SBNDDecoSimpleFlashTPC1_realisticMC.DriftEstimatorConfig.CalibrationFile: "OpDetReco/PMTRatioCalibration_MC3.root"
 SBNDDecoSimpleFlashTPC1_realisticMC.ReadoutDelay: 0. //cable time delay in us
+SBNDDecoSimpleFlashTPC1_realisticMC.FlashGeoConfig: @local::FlashGeoThresholdTPC1_realisticMC
 
 
 ###### XA IDEAL MC ######

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_driftestimatoralgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_driftestimatoralgo.fcl
@@ -5,7 +5,7 @@ BEGIN_PROLOG
 DriftEstimatorPMTRatio:
 {
   tool_type: "DriftEstimatorPMTRatio"
-  CalibrationFile: "OpDetReco/PMTRatioCalibration_MC2.root"
+  CalibrationFile: "OpDetReco/PMTRatioCalibration_MC3.root"
   VGroupVUV: @local::sbnd_vuv_timing_parameterization.vuv_vgroup_mean
   VGroupVIS: @local::sbnd_vis_timing_parameterization.vis_vmean
   DataCalibration: true

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
@@ -1,17 +1,51 @@
 BEGIN_PROLOG
 
-FlashGeoBarycenter:
-{
+FlashGeoBarycenter:{
   tool_type: "FlashGeoBarycenter"
   WeightExp: 2
 }
 
-FlashGeoThreshold:
-{
+FlashGeoThreshold:{
   tool_type: "FlashGeoThreshold"
   PDTypes: ["pmt_coated", "pmt_uncoated"]
-  ThresholdY: 0.75
-  ThresholdZ: 0.45
+  ThresholdY: 0.8
+  ThresholdZ: 0.8
+  NormalizeByPDType: true
+  WeightExp: 2
+}
+
+FlashGeoThresholdTPC0Data:{
+  tool_type: "FlashGeoThreshold"
+  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  ThresholdY: 0.5
+  ThresholdZ: 0.5
+  NormalizeByPDType: true
+  WeightExp: 2
+}
+
+FlashGeoThresholdTPC1Data:{
+  tool_type: "FlashGeoThreshold"
+  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  ThresholdY: 0.5
+  ThresholdZ: 0.5
+  NormalizeByPDType: true
+  WeightExp: 2
+}
+
+FlashGeoThresholdTPC0_realisticMC:{
+  tool_type: "FlashGeoThreshold"
+  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  ThresholdY: 0.7
+  ThresholdZ: 0.7
+  NormalizeByPDType: true
+  WeightExp: 2
+}
+
+FlashGeoThresholdTPC0_realisticMC:{
+  tool_type: "FlashGeoThreshold"
+  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  ThresholdY: 0.6
+  ThresholdZ: 0.6
   NormalizeByPDType: true
   WeightExp: 2
 }

--- a/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
+++ b/sbndcode/OpDetReco/OpFlash/job/sbnd_flashgeoalgo.fcl
@@ -16,7 +16,7 @@ FlashGeoThreshold:{
 
 FlashGeoThresholdTPC0Data:{
   tool_type: "FlashGeoThreshold"
-  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  PDTypes: ["pmt_coated"]
   ThresholdY: 0.5
   ThresholdZ: 0.5
   NormalizeByPDType: true
@@ -25,7 +25,7 @@ FlashGeoThresholdTPC0Data:{
 
 FlashGeoThresholdTPC1Data:{
   tool_type: "FlashGeoThreshold"
-  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  PDTypes: ["pmt_coated"]
   ThresholdY: 0.5
   ThresholdZ: 0.5
   NormalizeByPDType: true
@@ -34,16 +34,16 @@ FlashGeoThresholdTPC1Data:{
 
 FlashGeoThresholdTPC0_realisticMC:{
   tool_type: "FlashGeoThreshold"
-  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  PDTypes: ["pmt_coated"]
   ThresholdY: 0.7
   ThresholdZ: 0.7
   NormalizeByPDType: true
   WeightExp: 2
 }
 
-FlashGeoThresholdTPC0_realisticMC:{
+FlashGeoThresholdTPC1_realisticMC:{
   tool_type: "FlashGeoThreshold"
-  PDTypes: ["pmt_coated", "pmt_uncoated"]
+  PDTypes: ["pmt_coated"]
   ThresholdY: 0.6
   ThresholdZ: 0.6
   NormalizeByPDType: true

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.hh
@@ -81,8 +81,6 @@ namespace opdet {
       bool MakeGainFluctuations; //Fluctuate PMT gain
       fhicl::ParameterSet GainFluctuationsParams;
       bool SimulateNonLinearity; //Fluctuate PMT gain
-      bool PositivePolarity;
-      bool OscillateAfterPulse;
       bool UseDataNoise;
       fhicl::ParameterSet NonLinearityParams;
       
@@ -134,8 +132,6 @@ namespace opdet {
       {
         return fParams.PMTBaseline;
       }
-
-    void AddOscillationAfterPulse( std::vector<double>& wave);
 
   private:
 

--- a/sbndcode/TPCPMTBarycenterMatching/TPCPMTBarycenterMatching_module.cc
+++ b/sbndcode/TPCPMTBarycenterMatching/TPCPMTBarycenterMatching_module.cc
@@ -232,8 +232,9 @@ private:
   double                    fDistanceCandidateFlashes; ///< Maximum distance between candidate flashes to be considered for matching (cm)
   std::vector<double>       fCalAreaConst;         /// Calibration area constants for wire plane
   std::vector<int>          fSkipChannelList;
-  double                    fOpDetVUVEff;           // Efficiencies for PMT detection
-  double                    fOpDetVISEff;           // Efficiencies for PMT detection
+  double                    fOpDetCoVUVEff;           // Efficiencies for PMT detection (Coated PMT VUV)
+  double                    fOpDetCoVISEff;           // Efficiencies for PMT detection (Coated PMT VIS)
+  double                    fOpDetUncoVISEff;           // Efficiencies for PMT detection (Uncoated PMT VIS)
   bool                      fVerbose;              ///< Print extra info
   bool                      fFillMatchTree;        ///< Fill an output TTree in the supplemental file
   bool                      fDo3DMatching;         ///< Wether to perform the matching in 3D or 2D
@@ -304,8 +305,9 @@ TPCPMTBarycenterMatchProducer::TPCPMTBarycenterMatchProducer(fhicl::ParameterSet
   fCollectionOnly(p.get<bool>("CollectionOnly", true)),
   fDistanceCandidateFlashes(p.get<double>("DistanceCandidateFlashes")), // cm
   fCalAreaConst(p.get<std::vector<double>>("CalAreaConst")),
-  fOpDetVUVEff (p.get<double>("OpDetVUVEff")),
-  fOpDetVISEff (p.get<double>("OpDetVISEff")),
+  fOpDetCoVUVEff (p.get<double>("OpDetCoVUVEff")),
+  fOpDetCoVISEff (p.get<double>("OpDetCoVISEff")),
+  fOpDetUncoVISEff (p.get<double>("OpDetUncoVISEff")),
   fVerbose(p.get<bool>("Verbose")),
   fFillMatchTree(p.get<bool>("FillMatchTree")),
   fDo3DMatching(p.get<bool>("Do3DMatching")),
@@ -891,11 +893,10 @@ double TPCPMTBarycenterMatchProducer::GetFlashLight(double flash_pe, std::vector
 
   for(size_t ch=0; ch<dir_visibility.size(); ch++){
     if (std::find(fSkipChannelList.begin(), fSkipChannelList.end(), ch) != fSkipChannelList.end()) continue;
-    if(fOpDetType[ch]==0) tot_visibility += fOpDetVUVEff*dir_visibility[ch] + fOpDetVISEff*ref_visibility[ch];
-    else if(fOpDetType[ch]==1) tot_visibility += fOpDetVISEff*ref_visibility[ch];
+    if(fOpDetType[ch]==0) tot_visibility += fOpDetCoVUVEff*dir_visibility[ch] + fOpDetCoVISEff*ref_visibility[ch];
+    else if(fOpDetType[ch]==1) tot_visibility += fOpDetUncoVISEff*ref_visibility[ch];
     else continue; // skip other types
   }
-  //std::cout << " The number of PEs in the flash is " << flash_pe << " the total direct visibility is " << total_dir_visibility << " the total reflected visibility is " << total_ref_visibility << " with a VUV QE " << fOpDetVUVEff << " and a vis QE " << fOpDetVISEff << " so the total visibility is " << tot_visibility << std::endl;
   if((flash_pe == 0) || std::isinf(1/tot_visibility))
     return 0.0;
   // deposited light is inverse of visibility * PE count

--- a/sbndcode/TPCPMTBarycenterMatching/job/sbnd_tpcpmt3dbarycentermatching_config.fcl
+++ b/sbndcode/TPCPMTBarycenterMatching/job/sbnd_tpcpmt3dbarycentermatching_config.fcl
@@ -16,21 +16,27 @@ TPCPMTBarycenterMatchProducer:
     DistanceCandidateFlashes: 100
     VUVHits: @local::sbnd_vuv_RS100cm_hits_parameterization
     VIVHits: @local::sbnd_vis_RS100cm_hits_parameterization
-    OpDetVUVEff: @local::sbnd_digipmt_alg.PMTCoatedVUVEff_tpc1
-    OpDetVISEff:  @local::sbnd_digipmt_alg.PMTUncoatedEff_tpc1
+    OpDetCoVUVEff: @local::sbnd_digipmt_alg.PMTCoatedVUVEff_tpc1
+    OpDetCoVISEff: @local::sbnd_digipmt_alg.PMTCoatedVISEff_tpc1
+    OpDetUncoVISEff:  @local::sbnd_digipmt_alg.PMTUncoatedEff_tpc1
     CalAreaConst: @local::sbnd_calorimetryalgdata.CalAreaConstants
     LightChargeRatioBounds: [0.25, 3]
-    XError: 12 // cm
-    YError: 23 // cm
-    ZError: 23 // cm
+    XError: 11 // cm
+    YError: 21 // cm
+    ZError: 25 // cm
     AngleError: 27 // deg
     FlashVetoWindow: [-5,5] // ns
     OpticalPathTool:  @local::SBNDOpticalPath
     module_type: "TPCPMTBarycenterMatchProducer"
 }
 
+TPCPMTBarycenterMatchProducerMC: @local::TPCPMTBarycenterMatchProducer 
+TPCPMTBarycenterMatchProducerMC.XError: 9
+
+TPCPMTBarycenterMatchProducerSCEMC: @local::TPCPMTBarycenterMatchProducerMC
+TPCPMTBarycenterMatchProducerSCEMC.PandoraLabel: "pandoraSCE"
+
 TPCPMTBarycenterMatchProducerSCE: @local::TPCPMTBarycenterMatchProducer 
 TPCPMTBarycenterMatchProducerSCE.PandoraLabel: "pandoraSCE"
-
 
 END_PROLOG

--- a/sbndcode/Trigger/PMTSoftware/fcls/pmtmcmetricproducer.fcl
+++ b/sbndcode/Trigger/PMTSoftware/fcls/pmtmcmetricproducer.fcl
@@ -3,9 +3,12 @@ BEGIN_PROLOG
 sbnd_pmtmcmetricproducer: {
     module_type: "PMTMCMetricProducer"
     PDTypes: ["pmt_coated","pmt_uncoated"]
-    OpDetWaveformsLabel: "opdaq"
+    OpDetWaveformsLabel: "pmtpulseoscillation"
     StartTime: -1
     ADCtoPE: 12.5 # don't change this without good reason, needs to be kept consistent with DAQ version
+
+    ## the "off" PMT channels are properly accounted for in realistic PMT detsim
+    ## this fcl parameter is kept for legacy reasons, can be used for debugging
     #ChannelsToIgnore: [39, 66, 67, 71, 85, 86, 87, 92, 115, 138, 141, 170, 197, 217, 218, 221, 222, 223, 226, 245, 248, 249, 302]
 }
 END_PROLOG


### PR DESCRIPTION
## Description 
This PR does: 
- Updates the flash barycenter to use only coated PMTs, as it has been shown to improve the performance both in data and mc.
- Introduces new threshold for barycenter algorithm (optimised independently for each TPC) both in data and mc. 
- Updates the value of `ScintPreScale` to reflect the updated value of the PMT detection efficiencies.
- Introduces the new $\eta_{PMT}$ calibration curve for MC after updating PMT detection efficiencies in previous PRs. 
- Introduces an independent $\eta_{PMT}$ calibration curve for each TPC in data, as it improved the performance of the drift distance reconstruction. 
- Fixes a bug found by @lynnt20 related to readout cable delay simulation. Readout delay is removed to reconcile the timing scheme with the the one used in the previous version of the PTM MC. 
- Fixes a bug found by @lynnt20 related to PMT detsim simulation. Channel 249 was being erroneously simulated. It has been fixed by updating the `pds_calibration.db` file. 
- Updates the PMT deconvolution module to make use of the calibration database to decide wether tor reconstruct a channel or not instead of using a fcl-configurable list.


Please provide a detailed description of the changes this pull request introduces. 

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
This PR is to be merged with https://github.com/SBNSoftware/sbnd_data/pull/8
### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
