### PR TITLE
Fix bug for opdettype in light propagation time

### DIFF
--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -36,6 +36,11 @@ sbnd::LightPropagationCorrection::LightPropagationCorrection(fhicl::ParameterSet
         fOpDetX.push_back(pdCenter.X());
         fOpDetY.push_back(pdCenter.Y());
         fOpDetZ.push_back(pdCenter.Z());
+        if(fPDSMap.pdType(opch)=="pmt_coated") fOpDetType.push_back(0);
+        else if(fPDSMap.pdType(opch)=="pmt_uncoated") fOpDetType.push_back(1);
+        else if(fPDSMap.pdType(opch)=="xarapuca_vuv") fOpDetType.push_back(2);
+        else if(fPDSMap.pdType(opch)=="xarapuca_vis") fOpDetType.push_back(3);
+        else fOpDetType.push_back(-1);
     }
 
     auto const& tpc = art::ServiceHandle<geo::Geometry>()->TPC();
@@ -442,16 +447,18 @@ void sbnd::LightPropagationCorrection::GetPropagationTimeCorrectionPerChannel()
             double dy = fSpacePointY[sp] - _opDetY;
             double dz = fSpacePointZ[sp] - _opDetZ;
             double distanceToOpDet = std::sqrt(dx*dx + dy*dy + dz*dz);
-            //double spToCathode = abs(fSpacePointX[sp]); // Distance from space point to cathode in mm
-            //double cathodeToOpDet = std::sqrt(_opDetX*_opDetX + dy*dy + dz*dz); // Distance from cathode to OpDet in mm
-            //float lightPropTimeVIS = spToCathode/fVGroupVUV + cathodeToOpDet/fVGroupVIS; // Speed
-
             double cathodeToOpDet = std::sqrt(_opDetX*_opDetX + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from cathode to OpDet in mm
             double spToCathode = std::sqrt( fSpacePointX[sp]*fSpacePointX[sp] + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from space point to cathode in mm
 
             float lightPropTimeVIS = spToCathode/fVGroupVUV + cathodeToOpDet/fVGroupVIS; // Speed
             float lightPropTimeVUV = distanceToOpDet / fVGroupVUV; // Speed of light in mm/ns for VUV
-            float lightPropTime = std::min(lightPropTimeVIS, lightPropTimeVUV);
+            float lightPropTime = 0;
+            if(fOpDetType[opdet]==0)
+                lightPropTime = std::min(lightPropTimeVIS, lightPropTimeVUV);
+            else if(fOpDetType[opdet]==1)
+                lightPropTime = lightPropTimeVIS;
+            else
+                throw art::Exception(art::errors::LogicError) << " OpDet Type " <<  fOpDetType[opdet] << " not supported ." << std::endl;
             float partPropTime = std::sqrt((fSpacePointX[sp]-fRecoVx)*(fSpacePointX[sp]-fRecoVx) + (fSpacePointY[sp]-fRecoVy)*(fSpacePointY[sp]-fRecoVy) + (fSpacePointZ[sp]-fRecoVz)*(fSpacePointZ[sp]-fRecoVz))/fSpeedOfLight;
             float PropTime = lightPropTime + partPropTime;
             if(PropTime < minPropTime) minPropTime = PropTime;

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -449,7 +449,6 @@ void sbnd::LightPropagationCorrection::GetPropagationTimeCorrectionPerChannel()
             double distanceToOpDet = std::sqrt(dx*dx + dy*dy + dz*dz);
             double cathodeToOpDet = std::sqrt(_opDetX*_opDetX + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from cathode to OpDet in mm
             double spToCathode = std::sqrt( fSpacePointX[sp]*fSpacePointX[sp] + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from space point to cathode in mm
-
             float lightPropTimeVIS = spToCathode/fVGroupVUV + cathodeToOpDet/fVGroupVIS; // Speed
             float lightPropTimeVUV = distanceToOpDet / fVGroupVUV; // Speed of light in mm/ns for VUV
             float lightPropTime = 0;
@@ -458,7 +457,7 @@ void sbnd::LightPropagationCorrection::GetPropagationTimeCorrectionPerChannel()
             else if(fOpDetType[opdet]==1)
                 lightPropTime = lightPropTimeVIS;
             else
-                throw art::Exception(art::errors::LogicError) << " OpDet Type " <<  fOpDetType[opdet] << " not supported ." << std::endl;
+                continue;    
             float partPropTime = std::sqrt((fSpacePointX[sp]-fRecoVx)*(fSpacePointX[sp]-fRecoVx) + (fSpacePointY[sp]-fRecoVy)*(fSpacePointY[sp]-fRecoVy) + (fSpacePointZ[sp]-fRecoVz)*(fSpacePointZ[sp]-fRecoVz))/fSpeedOfLight;
             float PropTime = lightPropTime + partPropTime;
             if(PropTime < minPropTime) minPropTime = PropTime;

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -448,9 +448,9 @@ void sbnd::LightPropagationCorrection::GetPropagationTimeCorrectionPerChannel()
             float lightPropTimeVIS = spToCathode/fVGroupVUV + cathodeToOpDet/fVGroupVIS; // Speed
             float lightPropTimeVUV = distanceToOpDet / fVGroupVUV; // Speed of light in mm/ns for VUV
             float lightPropTime = 0;
-            if(fPDSMap.pdType(opch)=="pmt_coated" || fPDSMap.pdType(opch)=="xarapuca_vuv")
+            if(fPDSMap.pdType(opdet)=="pmt_coated" || fPDSMap.pdType(opdet)=="xarapuca_vuv")
                 lightPropTime = std::min(lightPropTimeVIS, lightPropTimeVUV);
-            else if(fPDSMap.pdType(opch)=="pmt_uncoated" || fPDSMap.pdType(opch)=="xarapuca_vis")
+            else if(fPDSMap.pdType(opdet)=="pmt_uncoated" || fPDSMap.pdType(opdet)=="xarapuca_vis")
                 lightPropTime = lightPropTimeVIS;
             float partPropTime = std::sqrt((fSpacePointX[sp]-fRecoVx)*(fSpacePointX[sp]-fRecoVx) + (fSpacePointY[sp]-fRecoVy)*(fSpacePointY[sp]-fRecoVy) + (fSpacePointZ[sp]-fRecoVz)*(fSpacePointZ[sp]-fRecoVz))/fSpeedOfLight;
             float PropTime = lightPropTime + partPropTime;

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.cc
@@ -36,11 +36,6 @@ sbnd::LightPropagationCorrection::LightPropagationCorrection(fhicl::ParameterSet
         fOpDetX.push_back(pdCenter.X());
         fOpDetY.push_back(pdCenter.Y());
         fOpDetZ.push_back(pdCenter.Z());
-        if(fPDSMap.pdType(opch)=="pmt_coated") fOpDetType.push_back(0);
-        else if(fPDSMap.pdType(opch)=="pmt_uncoated") fOpDetType.push_back(1);
-        else if(fPDSMap.pdType(opch)=="xarapuca_vuv") fOpDetType.push_back(2);
-        else if(fPDSMap.pdType(opch)=="xarapuca_vis") fOpDetType.push_back(3);
-        else fOpDetType.push_back(-1);
     }
 
     auto const& tpc = art::ServiceHandle<geo::Geometry>()->TPC();
@@ -449,15 +444,14 @@ void sbnd::LightPropagationCorrection::GetPropagationTimeCorrectionPerChannel()
             double distanceToOpDet = std::sqrt(dx*dx + dy*dy + dz*dz);
             double cathodeToOpDet = std::sqrt(_opDetX*_opDetX + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from cathode to OpDet in mm
             double spToCathode = std::sqrt( fSpacePointX[sp]*fSpacePointX[sp] + (dy/2)*(dy/2) + (dz/2)*(dz/2)); // Distance from space point to cathode in mm
+
             float lightPropTimeVIS = spToCathode/fVGroupVUV + cathodeToOpDet/fVGroupVIS; // Speed
             float lightPropTimeVUV = distanceToOpDet / fVGroupVUV; // Speed of light in mm/ns for VUV
             float lightPropTime = 0;
-            if(fOpDetType[opdet]==0)
+            if(fPDSMap.pdType(opch)=="pmt_coated" || fPDSMap.pdType(opch)=="xarapuca_vuv")
                 lightPropTime = std::min(lightPropTimeVIS, lightPropTimeVUV);
-            else if(fOpDetType[opdet]==1)
+            else if(fPDSMap.pdType(opch)=="pmt_uncoated" || fPDSMap.pdType(opch)=="xarapuca_vis")
                 lightPropTime = lightPropTimeVIS;
-            else
-                continue;    
             float partPropTime = std::sqrt((fSpacePointX[sp]-fRecoVx)*(fSpacePointX[sp]-fRecoVx) + (fSpacePointY[sp]-fRecoVy)*(fSpacePointY[sp]-fRecoVy) + (fSpacePointZ[sp]-fRecoVz)*(fSpacePointZ[sp]-fRecoVz))/fSpeedOfLight;
             float PropTime = lightPropTime + partPropTime;
             if(PropTime < minPropTime) minPropTime = PropTime;

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.hh
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.hh
@@ -145,7 +145,7 @@ private:
 
 
     geo::WireReadoutGeom const& fWireReadout = art::ServiceHandle<geo::WireReadout>()->Get();
-
+    opdet::sbndPDMapAlg fPDSMap;
     //Flash finder manager
     ::lightana::FlashFinderManager _mgr;
     ::lightana::FlashFinderManager _mgr_tpc0;
@@ -162,6 +162,7 @@ private:
     std::vector<double> fOpDetX;
     std::vector<double> fOpDetY;
     std::vector<double> fOpDetZ;
+    std::vector<int> fOpDetType;
 
     std::string fReco2Label;
     std::string fOpT0FinderModuleLabel;

--- a/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.hh
+++ b/sbndcode/LightPropagationCorrection/LightPropagationCorrection_module.hh
@@ -162,7 +162,6 @@ private:
     std::vector<double> fOpDetX;
     std::vector<double> fOpDetY;
     std::vector<double> fOpDetZ;
-    std::vector<int> fOpDetType;
 
     std::string fReco2Label;
     std::string fOpT0FinderModuleLabel;


### PR DESCRIPTION
## Description 
This PR fixes a minor bug on the light propagation correction module spotted by @henrylay97. Previously, the minimum of VIS and VUV light propagation time was assigned to both coated and uncoated channels. Now uncoated channels always receive the VIS light propagation time. The impact of the bug was expected to be minimal since uncoated channels hardly every contribute to the OpFlash timing estimation. 


$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{red}\bf{\textrm{IMPORTANT UPDATE June 22nd 2025:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production (which started in Spring 2025), you must make two PRs: one for develop and one for the production/v10_06_00 branch.

$${\color{red}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
