### PR TITLE
Bugfix/blips on empty events

### DIFF
--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -357,31 +357,32 @@ namespace blip {
     if (evt.getByLabel(fGeantProducer,pHandle))
       art::fill_ptr_vector(plist, pHandle);
  
-    // -- SimEnergyDeposits (usually dropped in reco
-    //art::Handle<std::vector<sim::EnergyDeposit> > sedHandle;
-    std::vector<sim::IDE > sedlist;
-    //if (evt.getByLabel(fSimDepProducer,sedHandle)){
-    //  art::fill_ptr_vector(sedlist, sedHandle);
-    // }
-    // -- SimChannels (usually dropped in reco)
+    // -- SimEnergyDeposits 
+    art::Handle<std::vector<sim::EnergyDeposit> > sedHandle;
+    std::vector<art::Ptr<sim::SimEnergyDeposit> > sedlist;
+    if (evt.getByLabel(fSimDepProducer,sedHandle)){
+      art::fill_ptr_vector(sedlist, sedHandle);
+     }
+    std::vector<sim::IDE > sIDElist;
+    // -- SimChannels 
     art::Handle<std::vector<sim::SimChannel> > simchanHandle;
     std::vector<art::Ptr<sim::SimChannel> > simchanlist;
     if (evt.getByLabel(fSimChanProducer,simchanHandle))
     { 
       art::fill_ptr_vector(simchanlist, simchanHandle);
-      //Loop over channels to get full sedlist
+      //Loop over channels to get full sIDElist
       for(int chIndex=0; chIndex<int(simchanlist.size()); chIndex++)
 	    {
       std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
-      std::cout << " Got my wire for chIndex " << chIndex << " it has size " << wids.size() << " first entry string is " << wids[0].toString() << std::endl;
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
-      std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, 999999999);
+      std::cout << " Got my wire for chIndex " << chIndex << " it has size " << wids.size() << " first entry string is " << wids[0].toString() << std::endl;
+      unsigned int MaxTDCTick = 3401;
+      std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, MaxTDCTick);
       std::cout << " this channel has " << TempChIDE.size() << " IDEs" << std::endl;
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {
-	        //art::fill_ptr_vector(sedlist, simchanHandle.TrackIDsAndEnergies(0, 99999999));
-	        sedlist.push_back( TempChIDE[ideIndex] ); //may need to add a &
+	        sIDElist.push_back( TempChIDE[ideIndex] ); //may need to add a &
 	       }
 	    }
     }
@@ -535,7 +536,15 @@ namespace blip {
     if( plist.size() ) {
       pinfo.resize(plist.size());
       for(size_t i = 0; i<plist.size(); i++){
-        BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sedlist, fCaloPlane);
+        //use sim::EnergyDeposits by default. This is heavy and may be dropped
+        if(evt.getByLabel(fSimDepProducer,sedHandle))
+        {
+          BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sedlist, fCaloPlane);
+        }
+        else //use sim::Channel -> IDE otherwise. This is usually kept but results in strange bugs.
+        {
+          BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sIDElist, fCaloPlane);
+        }
         if( map_g4trkid_charge[pinfo[i].trackId] ) pinfo[i].numElectrons = (int)map_g4trkid_charge[pinfo[i].trackId];
         pinfo[i].index = i;
       }

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -32,7 +32,6 @@ namespace blip {
       
 
     // Loop over cryostats
-    std::cout<<"NCryostats: "<<fGeom.Ncryostats()<<"\n";
     for(size_t cstat=0; cstat<fGeom.Ncryostats(); cstat++){
       auto const& cryoid = geo::CryostatID(cstat);
 
@@ -49,8 +48,6 @@ namespace blip {
           kNumChannels += planegeo.Nwires();
             
           float offset = detProp.GetXTicksOffset(pl,tpc,cstat);
-          std::cout<<"CRYOSTAT "<<cstat<<" / TPC "<<tpc<<" / PLANE "<<pl<<":  "<<planegeo.Nwires()<<" wires\n";
-          std::cout<<"  XTicksOffset (from detProp): "<<offset<<"\n";
          
           kXTicksOffsets[cstat][tpc][pl] = 0;
 
@@ -68,10 +65,7 @@ namespace blip {
             const double dir((tpcgeom.DriftSign() == geo::DriftSign::Negative) ? +1.0 : -1.0);
 	    float x_ticks_coefficient = kDriftVelocity*kTickPeriod;
             float goofy_offset = -xyz.X() / (dir * x_ticks_coefficient);
-	    std::cout<<"  After geometric correction: "<<offset - goofy_offset<<"\n";
-
             kXTicksOffsets[cstat][tpc][pl] = offset - goofy_offset;
-
 	  } else {
           
             // for the case of 2D wirecell workflow, the plane-to-plane
@@ -85,9 +79,7 @@ namespace blip {
           }
           
           // additional ad-hoc corrections supplied by user
-          //kXTicksOffsets[cstat][tpc][pl] += fTimeOffset[pl];
-          std::cout << " offsetting plane " << pl << " by " << fTimeOffset[pl] << " ticks " << std::endl;
-          
+          //kXTicksOffsets[cstat][tpc][pl] += fTimeOffset[pl];          
         }
       }
     }
@@ -361,7 +353,6 @@ namespace blip {
     art::Handle<std::vector<sim::SimEnergyDeposit> > sedHandle;
     std::vector<art::Ptr<sim::SimEnergyDeposit> > sedlist;
     if (evt.getByLabel(fSimDepProducer,sedHandle)){
-      std::cout << " in the sedlist filler " << std::endl;
       art::fill_ptr_vector(sedlist, sedHandle);
      }
     std::vector<sim::IDE > sIDElist;
@@ -385,8 +376,6 @@ namespace blip {
 	       }
 	    }
     }
-    std::cout << "sed list " << sedlist.size() << " IDElist " << sIDElist.size() << std::endl;
-
     // -- hits (from input module, usually track-masked subset of gaushit)
     art::Handle< std::vector<recob::Hit> > hitHandle;
     std::vector<art::Ptr<recob::Hit> > hitlist;
@@ -449,9 +438,7 @@ namespace blip {
     //===============================================================
     std::map< int, int > map_gh;
     // if input collection is already gaushit, this is trivial
-    std::cout << " About to fill in map with hitProducer " << fHitProducer << std::endl;
     if( fHitProducer == "gaushit" ||  fHitProducer == "specialblipgaushit") {
-      std::cout << " in special branch" << std::endl;
       for(auto& h : hitlist ) map_gh[h.key()] = h.key(); 
     // ... but if not, find the matching gaushit. There's no convenient
     // hit ID, so we must loop through and compare channel/time (ugh)
@@ -465,9 +452,7 @@ namespace blip {
           break;
         }
       }
-    }
-    std::cout << "done with map" << std::endl;
-   
+    }   
     //=====================================================
     // Record PDG for every G4 Track ID
     //=====================================================
@@ -539,7 +524,6 @@ namespace blip {
         //use sim::EnergyDeposits by default. This is heavy and may be dropped
         if(sedlist.size()>0)
         {
-          std::cout << " filling particle info with sedlist" << std::endl;
           BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sedlist, fCaloPlane);
         }
         else //use sim::Channel -> IDE otherwise. This is usually kept but results in strange bugs.
@@ -552,8 +536,6 @@ namespace blip {
       BlipUtils::MakeTrueBlips(pinfo, trueblips);
       BlipUtils::MergeTrueBlips(trueblips, fTrueBlipMergeDist);
     }
-    std::cout << "end of true blips" << std::endl;
-
 
     //=======================================
     // Map track IDs to the index in the vector
@@ -684,9 +666,7 @@ namespace blip {
       if( hitinfo[i].trkid < 0 ) nhits_untracked++;
       //printf("  %lu   plane: %i,  wire: %i, time: %i\n",i,hitinfo[i].plane,hitinfo[i].wire,int(hitinfo[i].driftTime));
 
-    }//endloop over hits
-    std::cout << " Hit info filled in " << std::endl;
-    
+    }//endloop over hits    
     //for(auto& a : tpc_plane_hitsMap ) {
       //for(auto& b : a.second ) 
         //std::cout<<"TPC "<<a.first<<", plane "<<b.first<<": "<<b.second.size()<<" hits\n";
@@ -752,7 +732,6 @@ namespace blip {
     // Hit clustering
     // ---------------------------------------------------
     std::map<int,std::map<int,std::vector<int>>> tpc_planeclustsMap;
-   std::cout << "Hit clustering processing" << std::endl;
     for(auto const& tpc_plane_hitsMap : cryo_tpc_plane_hitsMap ) {
     
     for(auto const& plane_hitsMap : tpc_plane_hitsMap.second ) {
@@ -895,7 +874,6 @@ namespace blip {
       }//loop over planes
     }//loop over TPCs
     }//loop over cryostats
-    std::cout << "Done Hit clustering processing" << std::endl;
     //std::cout<<"All done with clustering\n";
     
 
@@ -914,7 +892,6 @@ namespace blip {
     
     float _matchQDiffLimit= (fMatchQDiffLimit <= 0 ) ? std::numeric_limits<float>::max() : fMatchQDiffLimit;
     float _matchMaxQRatio = (fMatchMaxQRatio  <= 0 ) ? std::numeric_limits<float>::max() : fMatchMaxQRatio;
-     std::cout << "Plane matching " << std::endl;
     for(auto& tpcMap : tpc_planeclustsMap ) { // loop on TPCs
       
       //std::cout
@@ -1121,9 +1098,14 @@ namespace blip {
               hitclust[hc.ID].BlipID = newBlip.ID;
               for( auto& h : hc.HitIDs ) hitinfo[h].blipid = newBlip.ID;
             }
+            //BLIPS HAVE A COPY OF HITCLUSTERS NOT A POINTER
+            //UPDATE THE HITCLUSTER VARS THAT HAVE CHANGED SINCE CONSTRUCTION
             for(int iclust=0; iclust<int(sizeof(newBlip.clusters)/sizeof(newBlip.clusters[0])); iclust++)
             {
-              if(newBlip.clusters[iclust].ID>-1) newBlip.clusters[iclust].BlipID = newBlip.ID;
+              if(newBlip.clusters[iclust].ID>-1){
+                newBlip.clusters[iclust].BlipID = newBlip.ID;
+                newBlip.clusters[iclust].isMatched = true;
+              }
             }
             blips.push_back(newBlip);
 
@@ -1132,8 +1114,6 @@ namespace blip {
         }//endloop over caloplane ("Plane A") clusters
       }//endif calo plane has clusters
     }//endloop over TPCs
-    std::cout << " done planematching " << std::endl;
-
     // Re-index the clusters after removing unmatched
     if( !keepAllClusts ) {
       std::vector<blip::HitClust> hitclust_filt;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -655,7 +655,7 @@ namespace blip {
       
 
       // find associated track
-      if( fHitProducer == "gaushit" && fmtrk.isValid() ) {
+      if( fHitProducer == "specialblipgaushit" && fmtrk.isValid() ) {
         if(fmtrk.at(i).size()) hitinfo[i].trkid = fmtrk.at(i)[0]->ID();
       
       // if the hit collection didn't have associations made

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -40,8 +40,8 @@ namespace blip {
         auto const& tpcid = geo::TPCID(cryoid,tpc);
 
         // Loop planes in TPC 'tpc'
-	auto const& plane0id = geo::PlaneID(cstat,tpc,0);
-	auto const& plane0geo = wireReadoutGeom->Get().Plane(plane0id);
+        auto const& plane0id = geo::PlaneID(cstat,tpc,0);
+        auto const& plane0geo = wireReadoutGeom->Get().Plane(plane0id);
         for(size_t pl=0; pl<wireReadoutGeom->Get().Nplanes(tpcid); pl++){
           auto const& planeid = geo::PlaneID(cstat,tpc,pl);
           auto const& planegeo = wireReadoutGeom->Get().Plane(planeid);
@@ -63,7 +63,7 @@ namespace blip {
             auto const& tpcgeom   = cryostat.TPC(tpc);
             auto const xyz        = plane0geo.GetCenter();
             const double dir((tpcgeom.DriftSign() == geo::DriftSign::Negative) ? +1.0 : -1.0);
-	    float x_ticks_coefficient = kDriftVelocity*kTickPeriod;
+            float x_ticks_coefficient = kDriftVelocity*kTickPeriod;
             float goofy_offset = -xyz.X() / (dir * x_ticks_coefficient);
             kXTicksOffsets[cstat][tpc][pl] = offset - goofy_offset;
 	  } else {
@@ -156,18 +156,18 @@ namespace blip {
       for(int i=0; i<kNplanes; i++) {
         if( i == fCaloPlane ) continue;
         h_clust_overlap[iTPC][i]           = hdir.make<TH1D>(Form("t%i_p%i_clust_overlap",iTPC,i),   Form("TPC %i, Plane %i clusters;Overlap fraction",iTPC,i),101,0,1.01);
-	h_clust_dt[iTPC][i]                = hdir.make<TH1D>(Form("t%i_p%i_clust_dt",iTPC,i),        Form("TPC %i, Plane %i clusters;dT [ticks]",iTPC,i),200,-10,10);
+        h_clust_dt[iTPC][i]                = hdir.make<TH1D>(Form("t%i_p%i_clust_dt",iTPC,i),        Form("TPC %i, Plane %i clusters;dT [ticks]",iTPC,i),200,-10,10);
         h_clust_dtfrac[iTPC][i]            = hdir.make<TH1D>(Form("t%i_p%i_clust_dtfrac",iTPC,i),    Form("TPC %i, Plane %i clusters;Charge-weighted mean dT/RMS",iTPC,i),150,-1.5,1.5);
         
         h_clust_q[iTPC][i]     = hdir.make<TH2D>(Form("t%i_p%i_clust_charge",iTPC,i),  
 						 Form("Pre-cut, TPC %i;Plane %i cluster charge [#times10^{3} e-];Plane %i cluster charge [#times10^{3} e-]",iTPC,fCaloPlane,i),
 						 qbins,0,qmax,qbins,0,qmax);
-	h_clust_q[iTPC][i]->SetOption("colz");
+        h_clust_q[iTPC][i]->SetOption("colz");
         
         h_clust_q_cut[iTPC][i]     = hdir.make<TH2D>(Form("t%i_p%i_clust_charge_cut",iTPC,i),  
 						     Form("Post-cut, TPC %i;Plane %i cluster charge [#times10^{3} e-];Plane %i cluster charge [#times10^{3}]",iTPC,fCaloPlane,i),
 						     qbins,0,qmax,qbins,0,qmax);
-	h_clust_q_cut[iTPC][i]->SetOption("colz");
+        h_clust_q_cut[iTPC][i]->SetOption("colz");
       
         h_clust_score[iTPC][i]    = hdir.make<TH1D>(Form("t%i_p%i_clust_matchscore",iTPC,i),   Form("TPC %i, Plane %i clusters;Match score",iTPC,i),101,0,1.01);
        
@@ -181,7 +181,7 @@ namespace blip {
         h_clust_truematch_q[iTPC][i]     = hdir.make<TH2D>(Form("t%i_p%i_clust_truematch_charge",iTPC,i),  
           Form("Pre-cut, TPC %i;Plane %i cluster charge [#times10^{3} e-];Plane %i cluster charge [#times10^{3} e-]",iTPC,fCaloPlane,i),
           qbins,0,qmax,qbins,0,qmax);
-          h_clust_truematch_q[iTPC][i]->SetOption("colz");
+        h_clust_truematch_q[iTPC][i]->SetOption("colz");
         
         h_clust_truematch_score[iTPC][i]    = hdir.make<TH1D>(Form("t%i_p%i_clust_truematch_matchscore",iTPC,i),   Form("TPC %i, Plane %i clusters;Match score",iTPC,i),101,0,1.01);
 
@@ -932,15 +932,15 @@ namespace blip {
               // Check that the two central wires intersect
               // *******************************************
               double y, z;
-	      geo::Point_t intsec_p;
-	      std::vector<geo::WireID> A_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcA.CenterChan);
-	      std::vector<geo::WireID> B_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcB.CenterChan);
+	            geo::Point_t intsec_p;
+	            std::vector<geo::WireID> A_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcA.CenterChan);
+	            std::vector<geo::WireID> B_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcB.CenterChan);
 
-	      if( !wireReadoutGeom->Get().WireIDsIntersect(A_wireids.at(0),B_wireids.at(0),intsec_p)) continue;
-	      // Save intersect location, so we don't have to
+	            if( !wireReadoutGeom->Get().WireIDsIntersect(A_wireids.at(0),B_wireids.at(0),intsec_p)) continue;
+	            // Save intersect location, so we don't have to
               // make another call to the Geometry service later
-	      y = intsec_p.Y();
-	      z = intsec_p.Z();
+	            y = intsec_p.Y();
+	            z = intsec_p.Z();
               TVector3 xloc(0,y,z);
               hcA.IntersectLocations[hcB.ID] = xloc;
               hcB.IntersectLocations[hcA.ID] = xloc;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -1121,9 +1121,9 @@ namespace blip {
               hitclust[hc.ID].BlipID = newBlip.ID;
               for( auto& h : hc.HitIDs ) hitinfo[h].blipid = newBlip.ID;
             }
-            for(auto hc : newBlip.clusters)
+            for(int iclust=0; iclust<int(sizeof(newBlip.clusters)/sizeof(newBlip.clusters[0])); iclust++)
             {
-              hc.BlipID = newBlip.ID;
+              newBlip.clusters[iclust].BlipID = newBlip.ID;
             }
             blips.push_back(newBlip);
 

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -397,7 +397,7 @@ namespace blip {
     // -- associations
     art::FindManyP<recob::Track> fmtrk(hitHandle,evt,fTrkProducer);
     art::FindManyP<recob::Track> fmtrkGH(hitHandleGH,evt,fTrkProducer);
-    art::FindMany<simb::MCParticle,recob::Hit, anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
+    art::FindMany<simb::MCParticle, anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
     /*
     //====================================================
     // Update map of bad channels for this event
@@ -611,7 +611,7 @@ namespace blip {
         if( fmhh.at(igh).size() ) {
           std::vector<simb::MCParticle const*> pvec;
           std::vector<anab::BackTrackerHitMatchingData const*> btvec;
-          fmhh.get(igh,pvec,btvec);
+          fmhh.get(pvec,igh,btvec);
           hitinfo[i].g4energy = 0;
           hitinfo[i].g4charge = 0;
           float maxQ = -9;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -442,7 +442,9 @@ namespace blip {
     //===============================================================
     std::map< int, int > map_gh;
     // if input collection is already gaushit, this is trivial
+    std::cout << " About to fill in map with hitProducer " << fHitProducer << std::endl;
     if( fHitProducer == "gaushit" ||  fHitProducer == "specialblipgaushit") {
+      std::cout << " in special branch" << std::endl;
       for(auto& h : hitlist ) map_gh[h.key()] = h.key(); 
     // ... but if not, find the matching gaushit. There's no convenient
     // hit ID, so we must loop through and compare channel/time (ugh)
@@ -457,6 +459,7 @@ namespace blip {
         }
       }
     }
+    std::cout << "done with map" << std::endl;
    
     //=====================================================
     // Record PDG for every G4 Track ID

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -386,7 +386,7 @@ namespace blip {
     art::Handle< std::vector<recob::Hit> > hitHandleGH;
     std::vector<art::Ptr<recob::Hit> > hitlistGH;
     if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
-    else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
+    //else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
 
     // -- tracks
     art::Handle< std::vector<recob::Track> > tracklistHandle;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -376,6 +376,7 @@ namespace blip {
 	       }
 	    }
     }
+    std::cout <<"IDE SIZE " << sIDElist.size() << "  vs EDEP SIZE " << sedlist.size() << std::endl;
     // -- hits (from input module, usually track-masked subset of gaushit)
     art::Handle< std::vector<recob::Hit> > hitHandle;
     std::vector<art::Ptr<recob::Hit> > hitlist;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -1068,7 +1068,6 @@ namespace blip {
             for(auto& hc : hcGroup ) {
               hitclust[hc.ID].isMatched = true;
               for(auto hit : hitclust[hc.ID].HitIDs) hitinfo[hit].ismatch = true;
-              hitclust[hc.ID].BlipID = newBlip.ID;
               // Diagnostic plots for successful 3-plane matches
               //if( picky && hc.Plane != fCaloPlane ) {
                 //float q1 = (float)newBlip.clusters[fCaloPlane].Charge;
@@ -1122,6 +1121,10 @@ namespace blip {
             for(auto& hc : hcGroup ) {
               hitclust[hc.ID].BlipID = newBlip.ID;
               for( auto& h : hc.HitIDs ) hitinfo[h].blipid = newBlip.ID;
+            }
+            for(auto hc : newBlip.clusters)
+            {
+              hc.BlipID = newBlip.ID;
             }
 
   

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -393,7 +393,11 @@ namespace blip {
     // -- hits (from gaushit), these are used in truth-matching of hits
     art::Handle< std::vector<recob::Hit> > hitHandleGH;
     std::vector<art::Ptr<recob::Hit> > hitlistGH;
-    if (evt.getByLabel("gaushit",hitHandleGH))
+    if(fHitProducer == "specialblipgaushit")
+    {
+      if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
+    }
+    else if(evt.getByLabel("gaushit",hitHandleGH))
       art::fill_ptr_vector(hitlistGH, hitHandleGH);
 
     // -- tracks

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -622,6 +622,8 @@ namespace blip {
               {
                 std::cout << " on hit " << igh << std::endl;
                 std::cout << " its got pvec size " << pvec.size() << std::endl;
+                std::cout << "hit is on wire " << hitinfo[i].wire <<" in tpc " << hitinfo[i].tpc << " on plane " << hitinfo[i].plane << 
+                " at time " << hitinfo[i].peakTime << std::endl;
               }
               std::cout << "pvec " << j << " has code " << pvec.at(j)->PdgCode() << " and contribtues " << btvec.at(j)->numElectrons << std::endl;
             }

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -386,6 +386,7 @@ namespace blip {
 	       }
 	    }
     }
+    std::cout << "sed list " << sedlist.size() << " IDElist " << sIDElist.size() << std::endl;
 
     // -- hits (from input module, usually track-masked subset of gaushit)
     art::Handle< std::vector<recob::Hit> > hitHandle;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -536,6 +536,7 @@ namespace blip {
       BlipUtils::MakeTrueBlips(pinfo, trueblips);
       BlipUtils::MergeTrueBlips(trueblips, fTrueBlipMergeDist);
     }
+    std::cout << "end of true blips" << std::endl;
 
 
     //=======================================
@@ -668,6 +669,7 @@ namespace blip {
       //printf("  %lu   plane: %i,  wire: %i, time: %i\n",i,hitinfo[i].plane,hitinfo[i].wire,int(hitinfo[i].driftTime));
 
     }//endloop over hits
+    std::cout << " Hit info filled in " << std::endl;
     
     //for(auto& a : tpc_plane_hitsMap ) {
       //for(auto& b : a.second ) 
@@ -734,7 +736,7 @@ namespace blip {
     // Hit clustering
     // ---------------------------------------------------
     std::map<int,std::map<int,std::vector<int>>> tpc_planeclustsMap;
-   
+   std::cout << "Hit clustering processing" << std::endl;
     for(auto const& tpc_plane_hitsMap : cryo_tpc_plane_hitsMap ) {
     
     for(auto const& plane_hitsMap : tpc_plane_hitsMap.second ) {
@@ -877,6 +879,7 @@ namespace blip {
       }//loop over planes
     }//loop over TPCs
     }//loop over cryostats
+    std::cout << "Done Hit clustering processing" << std::endl;
     //std::cout<<"All done with clustering\n";
     
 
@@ -895,7 +898,7 @@ namespace blip {
     
     float _matchQDiffLimit= (fMatchQDiffLimit <= 0 ) ? std::numeric_limits<float>::max() : fMatchQDiffLimit;
     float _matchMaxQRatio = (fMatchMaxQRatio  <= 0 ) ? std::numeric_limits<float>::max() : fMatchMaxQRatio;
-     
+     std::cout << "Plane matching " << std::endl;
     for(auto& tpcMap : tpc_planeclustsMap ) { // loop on TPCs
       
       //std::cout
@@ -1110,6 +1113,7 @@ namespace blip {
         }//endloop over caloplane ("Plane A") clusters
       }//endif calo plane has clusters
     }//endloop over TPCs
+    std::cout << " done planematching " << std::endl;
 
     // Re-index the clusters after removing unmatched
     if( !keepAllClusts ) {

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -386,7 +386,7 @@ namespace blip {
     art::Handle< std::vector<recob::Hit> > hitHandleGH;
     std::vector<art::Ptr<recob::Hit> > hitlistGH;
     if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
-    //else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
+    else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
 
     // -- tracks
     art::Handle< std::vector<recob::Track> > tracklistHandle;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -616,6 +616,15 @@ namespace blip {
           hitinfo[i].g4charge = 0;
           float maxQ = -9;
           for(size_t j=0; j<pvec.size(); j++){
+            if(igh==10235 || igh==10237)
+            {
+              if(j==0)
+              {
+                std::cout << " on hit " << igh << std::endl;
+                std::cout << " its got pvec size " << pvec.size() << std::endl;
+              }
+              std::cout << "pvec " << j << " has code " << pvec.at(j)->PdgCode() << " and contribtues " << btvec.at(j)->numElectrons << std::endl;
+            }
             hitinfo[i].g4energy += btvec.at(j)->energy;
             hitinfo[i].g4charge += btvec.at(j)->numElectrons;
             if( btvec.at(j)->numElectrons <= maxQ ) continue;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -1068,7 +1068,7 @@ namespace blip {
             for(auto& hc : hcGroup ) {
               hitclust[hc.ID].isMatched = true;
               for(auto hit : hitclust[hc.ID].HitIDs) hitinfo[hit].ismatch = true;
-             
+              hitclust[hc.ID].BlipID = newBlip.ID;
               // Diagnostic plots for successful 3-plane matches
               //if( picky && hc.Plane != fCaloPlane ) {
                 //float q1 = (float)newBlip.clusters[fCaloPlane].Charge;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -1123,7 +1123,7 @@ namespace blip {
             }
             for(int iclust=0; iclust<int(sizeof(newBlip.clusters)/sizeof(newBlip.clusters[0])); iclust++)
             {
-              newBlip.clusters[iclust].BlipID = newBlip.ID;
+              if(newBlip.clusters[iclust].ID>-1) newBlip.clusters[iclust].BlipID = newBlip.ID;
             }
             blips.push_back(newBlip);
 

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -397,7 +397,7 @@ namespace blip {
     // -- associations
     art::FindManyP<recob::Track> fmtrk(hitHandle,evt,fTrkProducer);
     art::FindManyP<recob::Track> fmtrkGH(hitHandleGH,evt,fTrkProducer);
-    art::FindMany<simb::MCParticle,anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
+    art::FindMany<simb::MCParticle,recob::Hit, anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
     /*
     //====================================================
     // Update map of bad channels for this event

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -693,6 +693,7 @@ namespace blip {
     
     
     // Basic track inclusion cut: exclude hits that were tracked
+    int Tracked=0;
     for(size_t i=0; i<hitlist.size(); i++){
       if( hitinfo[i].trkid < 0 ) continue;
       auto it = map_trkid_index.find(hitinfo[i].trkid);
@@ -701,8 +702,10 @@ namespace blip {
       if( tracklist[trkindex]->Length() > fMaxHitTrkLength ) {
         hitIsTracked[i] = true;
         hitIsGood[i] = false;
+        Tracked++;
       }
     }
+    std::cout << Tracked << " hits were in tracks from pandora " << std::endl;
         
 
     // Filter based on hit properties. For hits that are a part of

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -76,10 +76,7 @@ namespace blip {
             // we still want to correct for global trigger offset though:
             kXTicksOffsets[cstat][tpc][pl] = clockData.TriggerTime()/kTickPeriod;
 
-          }
-          
-          // additional ad-hoc corrections supplied by user
-          //kXTicksOffsets[cstat][tpc][pl] += fTimeOffset[pl];          
+          }          
         }
       }
     }
@@ -231,6 +228,7 @@ namespace blip {
   void BlipRecoAlg::reconfigure( fhicl::ParameterSet const& pset ){
     
     fHitProducer        = pset.get<std::string>   ("HitProducer",       "gaushit");
+    fHitTruthMatcher    = pset.get<std::string>   ("HitTruthMatcher",   "blipgaushitTruthMatch");
     fTrkProducer        = pset.get<std::string>   ("TrkProducer",       "pandora");
     fGeantProducer      = pset.get<std::string>   ("GeantProducer",     "largeant");
     fSimDepProducer     = pset.get<std::string>   ("SimEDepProducer",   "ionandscint");
@@ -368,7 +366,7 @@ namespace blip {
       std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
-      unsigned int MaxTDCTick = 4294967294; // 1 under 32 bit unsigned int max
+      unsigned int MaxTDCTick = UINT_MAX;
       std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, MaxTDCTick);
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {
@@ -382,12 +380,6 @@ namespace blip {
     if (evt.getByLabel(fHitProducer,hitHandle))
       art::fill_ptr_vector(hitlist, hitHandle);
 
-    // -- hits (from gaushit), these are used in truth-matching of hits
-    art::Handle< std::vector<recob::Hit> > hitHandleGH;
-    std::vector<art::Ptr<recob::Hit> > hitlistGH;
-    if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
-    else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
-
     // -- tracks
     art::Handle< std::vector<recob::Track> > tracklistHandle;
     std::vector<art::Ptr<recob::Track> > tracklist;
@@ -396,8 +388,8 @@ namespace blip {
   
     // -- associations
     art::FindManyP<recob::Track> fmtrk(hitHandle,evt,fTrkProducer);
-    art::FindManyP<recob::Track> fmtrkGH(hitHandleGH,evt,fTrkProducer);
-    art::FindMany<simb::MCParticle, anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
+    art::FindManyP<recob::Track> fmtrkGH(hitHandle,evt,fTrkProducer);
+    art::FindMany<simb::MCParticle, anab::BackTrackerHitMatchingData> fmhh(hitHandle,evt,fHitTruthMatcher);
     /*
     //====================================================
     // Update map of bad channels for this event
@@ -433,22 +425,7 @@ namespace blip {
     // use gaushitTruthMatch later on)
     //===============================================================
     std::map< int, int > map_gh;
-    // if input collection is already gaushit, this is trivial
-    if( fHitProducer == "gaushit" ||  fHitProducer == "specialblipgaushit") {
-      for(auto& h : hitlist ) map_gh[h.key()] = h.key(); 
-    // ... but if not, find the matching gaushit. There's no convenient
-    // hit ID, so we must loop through and compare channel/time (ugh)
-    } else {
-      std::map<int,std::vector<int>> map_chan_ghid;
-      for(auto& gh : hitlistGH ) map_chan_ghid[gh->Channel()].push_back(gh.key());
-      for(auto& h : hitlist ) {
-        for(auto& igh : map_chan_ghid[h->Channel()]){
-          if( hitlistGH[igh]->PeakTime() != h->PeakTime() ) continue;
-          map_gh[h.key()] = igh;
-          break;
-        }
-      }
-    }   
+    for(auto& h : hitlist ) map_gh[h.key()] = h.key(); 
     //=====================================================
     // Record PDG for every G4 Track ID
     //=====================================================
@@ -646,14 +623,8 @@ namespace blip {
       
 
       // find associated track
-      if( fHitProducer == "specialblipgaushit" && fmtrk.isValid() ) {
+      if( fmtrk.isValid() ) {
         if(fmtrk.at(i).size()) hitinfo[i].trkid = fmtrk.at(i)[0]->ID();
-      
-      // if the hit collection didn't have associations made
-      // to the tracks, try gaushit instead
-      } else if ( fmtrkGH.isValid() && map_gh.size() ) {
-        int gi = map_gh[i];
-        if (fmtrkGH.at(gi).size()) hitinfo[i].trkid= fmtrkGH.at(gi)[0]->ID(); 
       }
 
       // add to the map

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -531,9 +531,7 @@ namespace blip {
         pinfo[i].index = i;
       }
       BlipUtils::MakeTrueBlips(pinfo, trueblips);
-      std::cout << "True blip size after make " << trueblips.size() << std::endl; 
       BlipUtils::MergeTrueBlips(trueblips, fTrueBlipMergeDist);
-      std::cout << "True blip size after merge " << trueblips.size() << std::endl; 
     }
 
     //=======================================
@@ -616,17 +614,6 @@ namespace blip {
           hitinfo[i].g4charge = 0;
           float maxQ = -9;
           for(size_t j=0; j<pvec.size(); j++){
-            if(igh==10235 || igh==10237)
-            {
-              if(j==0)
-              {
-                std::cout << " on hit " << igh << std::endl;
-                std::cout << " its got pvec size " << pvec.size() << " and btvec size " << btvec.size() << std::endl;
-                std::cout << "hit is on wire " << hitinfo[i].wire <<" in tpc " << hitinfo[i].tpc << " on plane " << hitinfo[i].plane << 
-                " at time " << hitinfo[i].peakTime << std::endl;
-              }
-              std::cout << "pvec " << j << " has code " << pvec.at(j)->PdgCode() << " and contribtues " << btvec.at(j)->numElectrons << std::endl;
-            }
             hitinfo[i].g4energy += btvec.at(j)->energy;
             hitinfo[i].g4charge += btvec.at(j)->numElectrons;
             if( btvec.at(j)->numElectrons <= maxQ ) continue;
@@ -712,9 +699,7 @@ namespace blip {
         hitIsGood[i] = false;
         Tracked++;
       }
-    }
-    std::cout << Tracked << " hits were in tracks from pandora " << std::endl;
-        
+    }        
 
     // Filter based on hit properties. For hits that are a part of
     // multi-gaussian fits (multiplicity > 1), need to re-think this.

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -377,7 +377,7 @@ namespace blip {
       std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
-      unsigned int MaxTDCTick = 3401;
+      unsigned int MaxTDCTick = 4294967294; // 1 under 32 bit unsigned int max
       std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, MaxTDCTick);
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -373,9 +373,11 @@ namespace blip {
       for(int chIndex=0; chIndex<int(simchanlist.size()); chIndex++)
 	    {
       std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
+      std::cout << " Got my wire for chIndex " << chIndex << " it has size " << wids.size() << " first entry string is " << wids[0].toString() << std::endl;
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
       std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, 999999999);
+      std::cout << " this channel has " << TempChIDE.size() << " IDEs"
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {
 	        //art::fill_ptr_vector(sedlist, simchanHandle.TrackIDsAndEnergies(0, 99999999));

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -534,7 +534,9 @@ namespace blip {
         pinfo[i].index = i;
       }
       BlipUtils::MakeTrueBlips(pinfo, trueblips);
+      std::cout << "True blip size after make " << trueblips.size() << std::endl; 
       BlipUtils::MergeTrueBlips(trueblips, fTrueBlipMergeDist);
+      std::cout << "True blip size after merge " << trueblips.size() << std::endl; 
     }
 
     //=======================================

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -621,7 +621,7 @@ namespace blip {
               if(j==0)
               {
                 std::cout << " on hit " << igh << std::endl;
-                std::cout << " its got pvec size " << pvec.size() << std::endl;
+                std::cout << " its got pvec size " << pvec.size() << " and btvec size " << btvec.size() << std::endl;
                 std::cout << "hit is on wire " << hitinfo[i].wire <<" in tpc " << hitinfo[i].tpc << " on plane " << hitinfo[i].plane << 
                 " at time " << hitinfo[i].peakTime << std::endl;
               }

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -376,7 +376,6 @@ namespace blip {
 	       }
 	    }
     }
-    std::cout <<"IDE SIZE " << sIDElist.size() << "  vs EDEP SIZE " << sedlist.size() << std::endl;
     // -- hits (from input module, usually track-masked subset of gaushit)
     art::Handle< std::vector<recob::Hit> > hitHandle;
     std::vector<art::Ptr<recob::Hit> > hitlist;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -367,22 +367,22 @@ namespace blip {
     art::Handle<std::vector<sim::SimChannel> > simchanHandle;
     std::vector<art::Ptr<sim::SimChannel> > simchanlist;
     if (evt.getByLabel(fSimChanProducer,simchanHandle))
-      { 
+    { 
       art::fill_ptr_vector(simchanlist, simchanHandle);
       //Loop over channels to get full sedlist
       for(int chIndex=0; chIndex<int(simchanlist.size()); chIndex++)
-	{
-	  std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
-	  const geo::PlaneID&      planeID = wids[0].planeID();
-	  if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
-	  std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, 999999999);
-	  for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	    {
-	      //art::fill_ptr_vector(sedlist, simchanHandle.TrackIDsAndEnergies(0, 99999999));
-	      sedlist.push_back( TempChIDE[ideIndex] ); //may need to add a &
+      std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
+      const geo::PlaneID&      planeID = wids[0].planeID();
+      if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
+      std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, 999999999);
+      for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
+	        {
+	        //art::fill_ptr_vector(sedlist, simchanHandle.TrackIDsAndEnergies(0, 99999999));
+	        sedlist.push_back( TempChIDE[ideIndex] ); //may need to add a &
+	       }
 	    }
-	}
-      }
+    }
 
     // -- hits (from input module, usually track-masked subset of gaushit)
     art::Handle< std::vector<recob::Hit> > hitHandle;
@@ -442,7 +442,7 @@ namespace blip {
     //===============================================================
     std::map< int, int > map_gh;
     // if input collection is already gaushit, this is trivial
-    if( fHitProducer == "gaushit" ) {
+    if( fHitProducer == "gaushit" ||  fHitProducer == "specialblipgaushit") {
       for(auto& h : hitlist ) map_gh[h.key()] = h.key(); 
     // ... but if not, find the matching gaushit. There's no convenient
     // hit ID, so we must loop through and compare channel/time (ugh)

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -409,7 +409,7 @@ namespace blip {
     // -- associations
     art::FindManyP<recob::Track> fmtrk(hitHandle,evt,fTrkProducer);
     art::FindManyP<recob::Track> fmtrkGH(hitHandleGH,evt,fTrkProducer);
-    art::FindMany<simb::MCParticle,anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"gaushitTruthMatch");
+    art::FindMany<simb::MCParticle,anab::BackTrackerHitMatchingData> fmhh(hitHandleGH,evt,"blipgaushitTruthMatch");
     /*
     //====================================================
     // Update map of bad channels for this event

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -611,7 +611,7 @@ namespace blip {
         if( fmhh.at(igh).size() ) {
           std::vector<simb::MCParticle const*> pvec;
           std::vector<anab::BackTrackerHitMatchingData const*> btvec;
-          fmhh.get(pvec,igh,btvec);
+          fmhh.get(igh,btvec,pvec);
           hitinfo[i].g4energy = 0;
           hitinfo[i].g4charge = 0;
           float maxQ = -9;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -385,12 +385,8 @@ namespace blip {
     // -- hits (from gaushit), these are used in truth-matching of hits
     art::Handle< std::vector<recob::Hit> > hitHandleGH;
     std::vector<art::Ptr<recob::Hit> > hitlistGH;
-    if(fHitProducer == "specialblipgaushit")
-    {
-      if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
-    }
-    else if(evt.getByLabel("gaushit",hitHandleGH))
-      art::fill_ptr_vector(hitlistGH, hitHandleGH);
+    if(evt.getByLabel("specialblipgaushit",hitHandleGH)) art::fill_ptr_vector(hitlistGH, hitHandleGH);
+    else if(evt.getByLabel("gaushit",hitHandleGH))       art::fill_ptr_vector(hitlistGH, hitHandleGH);
 
     // -- tracks
     art::Handle< std::vector<recob::Track> > tracklistHandle;
@@ -531,6 +527,7 @@ namespace blip {
           BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sIDElist, fCaloPlane);
         }
         if( map_g4trkid_charge[pinfo[i].trackId] ) pinfo[i].numElectrons = (int)map_g4trkid_charge[pinfo[i].trackId];
+        else pinfo[i].numElectrons = pinfo[i].depElectrons; // JACOB ADDITION Jan22, 2026 for strange channel IDE results
         pinfo[i].index = i;
       }
       BlipUtils::MakeTrueBlips(pinfo, trueblips);

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -611,7 +611,7 @@ namespace blip {
         if( fmhh.at(igh).size() ) {
           std::vector<simb::MCParticle const*> pvec;
           std::vector<anab::BackTrackerHitMatchingData const*> btvec;
-          fmhh.get(igh,btvec,pvec);
+          fmhh.get(igh,pvec,btvec);
           hitinfo[i].g4energy = 0;
           hitinfo[i].g4charge = 0;
           float maxQ = -9;

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -358,7 +358,7 @@ namespace blip {
       art::fill_ptr_vector(plist, pHandle);
  
     // -- SimEnergyDeposits 
-    art::Handle<std::vector<sim::EnergyDeposit> > sedHandle;
+    art::Handle<std::vector<sim::SimEnergyDeposit> > sedHandle;
     std::vector<art::Ptr<sim::SimEnergyDeposit> > sedlist;
     if (evt.getByLabel(fSimDepProducer,sedHandle)){
       art::fill_ptr_vector(sedlist, sedHandle);

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -361,6 +361,7 @@ namespace blip {
     art::Handle<std::vector<sim::SimEnergyDeposit> > sedHandle;
     std::vector<art::Ptr<sim::SimEnergyDeposit> > sedlist;
     if (evt.getByLabel(fSimDepProducer,sedHandle)){
+      std::cout << " in the sedlist filler " << std::endl;
       art::fill_ptr_vector(sedlist, sedHandle);
      }
     std::vector<sim::IDE > sIDElist;
@@ -376,10 +377,8 @@ namespace blip {
       std::vector<geo::WireID> wids    = wireReadoutGeom->Get().ChannelToWire( (*(simchanlist[chIndex])).Channel() ); //Not sure why this is a vector, but it should have len 1
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
-      std::cout << " Got my wire for chIndex " << chIndex << " it has size " << wids.size() << " first entry string is " << wids[0].toString() << std::endl;
       unsigned int MaxTDCTick = 3401;
       std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, MaxTDCTick);
-      std::cout << " this channel has " << TempChIDE.size() << " IDEs" << std::endl;
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {
 	        sIDElist.push_back( TempChIDE[ideIndex] ); //may need to add a &
@@ -538,8 +537,9 @@ namespace blip {
       pinfo.resize(plist.size());
       for(size_t i = 0; i<plist.size(); i++){
         //use sim::EnergyDeposits by default. This is heavy and may be dropped
-        if(evt.getByLabel(fSimDepProducer,sedHandle))
+        if(sedlist.size()>0)
         {
+          std::cout << " filling particle info with sedlist" << std::endl;
           BlipUtils::FillParticleInfo( *plist[i], pinfo[i], sedlist, fCaloPlane);
         }
         else //use sim::Channel -> IDE otherwise. This is usually kept but results in strange bugs.

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -377,7 +377,7 @@ namespace blip {
       const geo::PlaneID&      planeID = wids[0].planeID();
       if(int(planeID.Plane) != fCaloPlane) continue; //only take calorimetry plane IDE values 
       std::vector< sim::IDE > TempChIDE = (*simchanlist[chIndex]).TrackIDsAndEnergies(0, 999999999);
-      std::cout << " this channel has " << TempChIDE.size() << " IDEs"
+      std::cout << " this channel has " << TempChIDE.size() << " IDEs" << std::endl;
       for(int ideIndex=0; ideIndex<int(TempChIDE.size()); ideIndex++)
 	        {
 	        //art::fill_ptr_vector(sedlist, simchanHandle.TrackIDsAndEnergies(0, 99999999));

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.cc
@@ -1117,7 +1117,6 @@ namespace blip {
             // if we made it this far, the blip is good!
             // associate this blip with the hits and clusters within it
             newBlip.ID = blips.size();
-            blips.push_back(newBlip);
             for(auto& hc : hcGroup ) {
               hitclust[hc.ID].BlipID = newBlip.ID;
               for( auto& h : hc.HitIDs ) hitinfo[h].blipid = newBlip.ID;
@@ -1126,6 +1125,7 @@ namespace blip {
             {
               hc.BlipID = newBlip.ID;
             }
+            blips.push_back(newBlip);
 
   
           }//endif ncands > 0

--- a/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.h
+++ b/sbndcode/BlipRecoSBND/Alg/BlipRecoAlg.h
@@ -129,6 +129,7 @@ namespace blip {
 
     // --- FCL configs ---
     std::string         fHitProducer;
+    std::string         fHitTruthMatcher;
     std::string         fTrkProducer;
     std::string         fGeantProducer;
     std::string         fSimDepProducer;

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -456,10 +456,10 @@ class BlipAnaTreeDataStruct
       evtTree->Branch("hit_ismatch",hit_ismatch,"hit_ismatch[nhits]/I");
       evtTree->Branch("hit_trkid",hit_trkid,"hit_trkid[nhits]/I"); 
       if( saveTruthInfo ) {
-      evtTree->Branch("hit_g4trkid",hit_g4trkid,"hit_g4trkid[nhits]/I");
-      evtTree->Branch("hit_g4frac",hit_g4frac,"hit_g4frac[nhits]/F"); 
-      evtTree->Branch("hit_g4energy",hit_g4energy,"hit_g4energy[nhits]/F"); 
-      evtTree->Branch("hit_g4charge",hit_g4charge,"hit_g4charge[nhits]/F"); 
+        evtTree->Branch("hit_g4trkid",hit_g4trkid,"hit_g4trkid[nhits]/I");
+        evtTree->Branch("hit_g4frac",hit_g4frac,"hit_g4frac[nhits]/F"); 
+        evtTree->Branch("hit_g4energy",hit_g4energy,"hit_g4energy[nhits]/F"); 
+        evtTree->Branch("hit_g4charge",hit_g4charge,"hit_g4charge[nhits]/F"); 
       }
       evtTree->Branch("hit_clustid",hit_clustid,"hit_clustid[nhits]/I"); 
       evtTree->Branch("hit_blipid",hit_blipid,"hit_blipid[nhits]/I");
@@ -745,22 +745,22 @@ class BlipAna : public art::EDAnalyzer
     
     h_part_process    = dir_truth.make<TH1D>("part_process","MCParticle->Process()",5,0,5);
     auto xa = h_part_process->GetXaxis();
-      xa->SetBinLabel(1,"primary");
-      xa->SetBinLabel(2,"compt");
-      xa->SetBinLabel(3,"phot");
-      xa->SetBinLabel(4,"conv");
-      xa->SetBinLabel(5,"other");
+    xa->SetBinLabel(1,"primary");
+    xa->SetBinLabel(2,"compt");
+    xa->SetBinLabel(3,"phot");
+    xa->SetBinLabel(4,"conv");
+    xa->SetBinLabel(5,"other");
     
     h_nblips_tm    = dir_truth.make<TH1D>("nblips_tm","Truth-matched 3D blips per event",blipBins,0,blipMax);
     h_blip_qcomp   = dir_truth.make<TH1D>("blip_qcomp","Fraction of true charge (at anode) reconstructed into 3D blips",202,0,1.01);
     h_blip_reszy   = dir_truth.make<TH2D>("blip_res_zy","Blip position resolution;Z_{reco} - Z_{true} [cm];Y_{reco} - Y_{true} [cm]",150,-15,15,150,-15,15);
-      h_blip_reszy ->SetOption("colz");
+    h_blip_reszy ->SetOption("colz");
     h_blip_resx    = dir_truth.make<TH1D>("blip_res_x","Blip position resolution;X_{reco} - X_{true} [cm]",200,-10,10);
     h_blip_resE   = dir_truth.make<TH1D>("blip_res_E","Blip energy resolution;(E_{reco} - E_{true})/E_{true} [cm]",200,-1.,1.);
     h_blip_E_vs_resE    = dir_truth.make<TH2D>("blip_res_energy","Energy resolution of 3D blips;Energy [MeV];#deltaE/E_{true}",100,0,5,200,-1.,1.);
-        h_blip_E_vs_resE ->SetOption("colz");
+    h_blip_E_vs_resE ->SetOption("colz");
     h_clust_qres_vs_q       = dir_truth.make<TH2D>("qres_vs_q","Clusters on collection plane;True charge deposited [ #times 10^{3} e- ];Reco resolution",160,0,80,200,-1,1);
-      h_clust_qres_vs_q     ->SetOption("colz");
+    h_clust_qres_vs_q     ->SetOption("colz");
     h_clust_qres_anode      = dir_truth.make<TH1D>("qres_anode","Reco charge vs true charge collected;( reco-true ) / true;Area-normalized entries",200,-1.,1.);
     h_clust_qres_dep        = dir_truth.make<TH1D>("qres_dep","Reco charge vs true charge deposited;( reco-true ) / true;Area-normalized entries",200,-1.,1.);
     h_qratio_vs_time_sim  = dir_truth.make<TH2D>("qratio_vs_time_sim",";Drift time [#mus]; Q_{anode} / Q_{dep}",44,100,2300, 1000,0.50,1.50);
@@ -801,10 +801,10 @@ class BlipAna : public art::EDAnalyzer
       h_hitqres[i]      = dir_truth.make<TH1D>(Form("pl%i_hit_q_res",i),     Form("Plane %i hits;charge resolution: (reco-true)/true",i),    400,-1,1);
       h_hitqres_scatter[i] = dir_truth.make<TH2D>( Form("pl%i_hit_qres_scatter",i), 
         Form("Plane %i;true hit charge [#times 10^{3} e-];Reconstructed hit charge [#times 10^{3} e-]",i),qBins,0,qMax/1e3,qBins,0,qMax/1e3);
-        h_hitqres_scatter[i]  ->SetOption("colz");
+      h_hitqres_scatter[i]  ->SetOption("colz");
       h_hitqres_vs_q[i] = dir_truth.make<TH2D>( Form("pl%i_hit_qres_vs_q",i),
         Form("Plane %i;true hit charge [#times 10^{3} e-];hit charge resolution: (reco-true)/true",i),qBins,0,qMax/1e3, 400,-2,2);
-        h_hitqres_vs_q[i]     ->SetOption("colz");
+      h_hitqres_vs_q[i]     ->SetOption("colz");
     
       h_chargecomp[i] = dir_truth.make<TH1D>(Form("pl%i_hit_charge_completeness",i),Form("charge completness, plane %i",i),101,0,1.01);
       h_hitpur[i]     = dir_truth.make<TH1D>(Form("pl%i_hit_purity",i),Form("hit purity, plane %i",i),101,0,1.01);
@@ -1385,7 +1385,7 @@ void BlipAna::analyze(const art::Event& evt)
       nblips_picky++;
       fNum3DBlipsPicky++;
       h_blip_charge_picky ->Fill(blp.clusters[fCaloPlane].Charge);
-       h_blip_zy_picky     ->Fill(blp.Position.Z(), blp.Position.Y());
+      h_blip_zy_picky     ->Fill(blp.Position.Z(), blp.Position.Y());
       h_blip_charge_YU_picky->Fill( 0.001*blp.clusters[2].Charge, 0.001*blp.clusters[0].Charge );
       h_blip_charge_YV_picky->Fill( 0.001*blp.clusters[2].Charge, 0.001*blp.clusters[1].Charge );
       h_blip_charge_UV_picky->Fill( 0.001*blp.clusters[0].Charge, 0.001*blp.clusters[1].Charge );
@@ -1488,27 +1488,27 @@ void BlipAna::endJob(){
   //printf("                 picky frac   : %5.3f\n",     fNum3DBlipsPicky/float(fNum3DBlips));
   
   if(fIsMC){
-  printf("  MC-matched blips per evt    : %.3f\n",       fNum3DBlipsTrue/nEvents);
-  printf("  MC blip purity              : %.3f\n",       fNum3DBlipsTrue/float(fNum3DBlips));
-  printf("  MC blip purity, 3 planes    : %.3f\n",      fNum3DBlipsTrue3P/float(fNum3DBlips3Plane));
-  if( h_blip_qcomp->GetMean() > 0 ) 
-  printf("  Charge completeness, total  : %.4f +/- %.4f\n", h_blip_qcomp->GetMean(), h_blip_qcomp->GetStdDev()/sqrt(fNumEvents));
-  //printf("                       < 2MeV : %.4f +/- %.4f\n", h_blip_qcomp_2MeV->GetMean(), h_blip_qcomp_2MeV->GetStdDev()/sqrt(fNumEvents));
-  //printf("  Blip purity                 : %.4f\n",       h_blip_pur->GetMean());
+    printf("  MC-matched blips per evt    : %.3f\n",       fNum3DBlipsTrue/nEvents);
+    printf("  MC blip purity              : %.3f\n",       fNum3DBlipsTrue/float(fNum3DBlips));
+    printf("  MC blip purity, 3 planes    : %.3f\n",      fNum3DBlipsTrue3P/float(fNum3DBlips3Plane));
+    if( h_blip_qcomp->GetMean() > 0 ) 
+    printf("  Charge completeness, total  : %.4f +/- %.4f\n", h_blip_qcomp->GetMean(), h_blip_qcomp->GetStdDev()/sqrt(fNumEvents));
+    //printf("                       < 2MeV : %.4f +/- %.4f\n", h_blip_qcomp_2MeV->GetMean(), h_blip_qcomp_2MeV->GetStdDev()/sqrt(fNumEvents));
+    //printf("  Blip purity                 : %.4f\n",       h_blip_pur->GetMean());
   }
   printf("  Mean blip charge            : %.0f e-\n",      h_blip_charge->GetMean());
   printf("\n");
   for(size_t i=0; i<kNplanes; i++){
-  printf("  Plane %lu -------------------------\n",i);
-  printf("   * total hits/evt           : %.2f\n",fNumHits[i]/(float)fNumEvents);
-  printf("   * untracked hits/evt       : %.2f (%.2f plane-matched)\n",fNumHitsUntracked[i]/(float)fNumEvents, fNumHitsMatched[i]/(float)fNumEvents);
-  //printf("   * plane-matched hits/evt   : %.2f\n",fNumHitsMatched[i]/(float)fNumEvents);
-  if(fIsMC) {
-  printf("   * true-matched hits/evt    : %.2f (%.2f plane-matched)\n",fNumHitsTrue[i]/(float)fNumEvents, fNumHitsMatchedTrue[i]/(float)fNumEvents);
-  if( h_chargecomp[i]->GetMean() > 0 ) 
-  printf("   * charge completeness      : %.4f\n",h_chargecomp[i]->GetMean());
-  printf("   * hit purity               : %.4f\n",h_hitpur[i]->GetMean());
-  }
+    printf("  Plane %lu -------------------------\n",i);
+    printf("   * total hits/evt           : %.2f\n",fNumHits[i]/(float)fNumEvents);
+    printf("   * untracked hits/evt       : %.2f (%.2f plane-matched)\n",fNumHitsUntracked[i]/(float)fNumEvents, fNumHitsMatched[i]/(float)fNumEvents);
+    //printf("   * plane-matched hits/evt   : %.2f\n",fNumHitsMatched[i]/(float)fNumEvents);
+    if(fIsMC) {
+      printf("   * true-matched hits/evt    : %.2f (%.2f plane-matched)\n",fNumHitsTrue[i]/(float)fNumEvents, fNumHitsMatchedTrue[i]/(float)fNumEvents);
+      if( h_chargecomp[i]->GetMean() > 0 ) 
+      printf("   * charge completeness      : %.4f\n",h_chargecomp[i]->GetMean());
+      printf("   * hit purity               : %.4f\n",h_hitpur[i]->GetMean());
+    }
   } 
   printf("\n***********************************************\n");
 

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -1583,7 +1583,7 @@ void BlipAna::PrintClusterInfo(const blip::HitClust& hc){
     hc.isMatched
   );
   printf("G4 IDs contib");
-  for(g4ID : hc.G4IDs) printf("%i", g4ID);
+  for(int g4ID : hc.G4IDs) printf("%i", g4ID);
 }
 
 void BlipAna::PrintBlipInfo(const blip::Blip& bl){

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -1582,8 +1582,9 @@ void BlipAna::PrintClusterInfo(const blip::HitClust& hc){
     hc.EdepID,
     hc.isMatched
   );
-  printf("G4 IDs contib");
-  for(int g4ID : hc.G4IDs) printf("%i", g4ID);
+  printf("G4 IDs contib \n");
+  for(int g4ID : hc.G4IDs) printf(" %i ", g4ID);
+  printf("\n");
 }
 
 void BlipAna::PrintBlipInfo(const blip::Blip& bl){

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -1326,7 +1326,6 @@ void BlipAna::analyze(const art::Event& evt)
       }
     
     }
-      
     if( fDebugMode ) PrintClusterInfo(clust);
     
   }//endloop over 2D hit clusters

--- a/sbndcode/BlipRecoSBND/BlipAna_module.cc
+++ b/sbndcode/BlipRecoSBND/BlipAna_module.cc
@@ -1582,6 +1582,8 @@ void BlipAna::PrintClusterInfo(const blip::HitClust& hc){
     hc.EdepID,
     hc.isMatched
   );
+  printf("G4 IDs contib");
+  for(g4ID : hc.G4IDs) printf("%i", g4ID);
 }
 
 void BlipAna::PrintBlipInfo(const blip::Blip& bl){

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -113,7 +113,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
         for(size_t j=0; j<pinfo.size(); j++){
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
-          if( p.PdgCode() != 2112 && p.PdgCode()!=22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
+          if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ) GrowTrueBlip(pinfo[j],tb);
           }
         }
@@ -161,7 +161,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     // .. otherwise, check that the new particle
     // creation time is comparable to existing blip.
     // then calculate new energy-weighted position.
-    } else if ( fabs(tblip.Time-pinfo.time) < 3 ) {
+    } else if ( fabs(tblip.Time-pinfo.time) < 3) {
       float totE = tblip.Energy + pinfo.depEnergy;
       float w1 = tblip.Energy/totE;
       float w2 = pinfo.depEnergy/totE;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -32,9 +32,8 @@ namespace BlipUtils {
   //===========================================================================
   // Provided a MCParticle, calculate everything we'll need for later calculations
   // and save into ParticleInfo object
-  void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
-    
-    // Get important info and do conversions
+void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
+  // Get important info and do conversions
     pinfo.particle    = part;
     pinfo.trackId     = part.TrackId();
     pinfo.isPrimary   = (int)(part.Process() == "primary");
@@ -50,17 +49,29 @@ namespace BlipUtils {
     pinfo.time        = /*ns ->mus*/1e-3 * part.T();
     pinfo.endtime     = /*ns ->mus*/1e-3 * part.EndT();
     pinfo.numTrajPts  = part.NumberTrajectoryPoints();
-
     // Pathlength (in AV) and start/end point
     pinfo.pathLength  = PathLength( part, pinfo.startPoint, pinfo.endPoint);
-
     // Central position of trajectory
     pinfo.position    = 0.5*(pinfo.startPoint+pinfo.endPoint);
-
     // Energy/charge deposited by this particle, found using SimEnergyDeposits 
     pinfo.depEnergy     = 0;
     pinfo.depElectrons  = 0;
+    return;
+}
+void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
+    FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
+      if( sed->TrackID() == part.TrackId() ) {
+        pinfo.depEnergy     += sed->Energy();
+        pinfo.depElectrons  += sed->NumElectrons();
+      }
+    }
+    return;
+  }
+  void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SIDEVec_t& sIDEvec, int caloPlane){
+    
+    FillParticleInfo( part, pinfo);
+    for(auto& sed : sIDEvec ) {
       if( -1*sed.trackID == part.TrackId() || sed.trackID == part.TrackId() ) {
         pinfo.depEnergy     += sed.energy;
         pinfo.depElectrons  += sed.numElectrons;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -95,7 +95,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       //std::cout<<"Making true blip for "<<part.TrackId()<<" (PDG "<<part.PdgCode()<<", which deposited "<<pinfo[i].depEnergy<<"\n";
 
       // If this is a photon or neutron, don't even bother!
-      //if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) continue;
+      if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) continue;
 
       // If this is an electron that came from another electron, it would 
       // have already been grouped as part of the contiguous "blip" previously.
@@ -148,7 +148,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     simb::MCParticle& part = pinfo.particle;
 
     // Skip neutrons, photons
-    // if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
+     if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
     
     // Check that path length isn't zero
     if( !pinfo.pathLength ) return;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,7 +105,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
-      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << 
+      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << " and daughters " 
+      << pinfo[i].particle.NumberDaughters() << 
       " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl;
       if( !tb.Energy ) continue;  
 
@@ -119,7 +120,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
               GrowTrueBlip(pinfo[j],tb);
               std::cout << " \t growing it with " << pinfo[j].particle.TrackId() << " with code " << pinfo[j].particle.PdgCode()<< 
-              " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl;
+              " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl; //literally never seems to be called?
             }
           }
         }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,9 +105,6 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
-      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << " and daughters " 
-      << pinfo[i].particle.NumberDaughters() << 
-      " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl;
       if( !tb.Energy ) continue;  
 
       // We want to loop through any contiguous electrons (produced
@@ -120,13 +117,10 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
               GrowTrueBlip(pinfo[j],tb);
-              std::cout << " \t growing it with " << pinfo[j].particle.TrackId() << " with code " << pinfo[j].particle.PdgCode()<< 
-              " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl; //literally never seems to be called?
             }
           }
           else if(IsAncestorOf(p.TrackId(),part.TrackId(),true,true)) excludedDaughters++; 
         }
-        std::cout << " \t " << excludedDaughters << " were of the special types" << std::endl;
       }
       
       // Final check -- ensure there was non-negligible number 

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -115,7 +115,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
           if( p.PdgCode() != 2112 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){
-            if( IsAncestorOf(p.TrackId(),part.TrackId(),true) ) GrowTrueBlip(pinfo[j],tb);
+            if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ) GrowTrueBlip(pinfo[j],tb);
           }
         }
       }
@@ -485,7 +485,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
   //====================================================================
   // Function to determine if a particle descended from another particle.
   // Allows option to break lineage at photons for contiguous parentage.
-  bool IsAncestorOf(int particleID, int ancestorID, bool breakAtPhots = false){
+  bool IsAncestorOf(int particleID, int ancestorID, bool breakAtPhots = false, bool breakAtNeutrons = false){
     art::ServiceHandle<cheat::ParticleInventoryService> pi_serv;
     const sim::ParticleList& plist = pi_serv->ParticleList();
     if( particleID == ancestorID  )       return true;
@@ -499,6 +499,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       simb::MCParticle pM = pi_serv->TrackIdToParticle(p.Mother());
       if      ( pM.TrackId() == ancestorID )                      { return true;  }
       else if ( breakAtPhots == true && pM.PdgCode() == 22 )      { return false; }
+      else if ( breakAtNeutrons && pM.PdgCode() == 2112 )           { return false; }
       else if ( pM.Process() == "primary" || pM.TrackId() == 1 )  { return false; }
       else if ( pM.Mother() == 0 )                                { return false; }
       else    { particleID = pM.TrackId(); }              

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -95,7 +95,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       //std::cout<<"Making true blip for "<<part.TrackId()<<" (PDG "<<part.PdgCode()<<", which deposited "<<pinfo[i].depEnergy<<"\n";
 
       // If this is a photon or neutron, don't even bother!
-      if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) continue;
+      //if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) continue;
 
       // If this is an electron that came from another electron, it would 
       // have already been grouped as part of the contiguous "blip" previously.
@@ -148,7 +148,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     simb::MCParticle& part = pinfo.particle;
 
     // Skip neutrons, photons
-     if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
+    // if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
     
     // Check that path length isn't zero
     if( !pinfo.pathLength ) return;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -124,7 +124,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
               " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl; //literally never seems to be called?
             }
           }
-          else if(IsAncestorOf(p.TrackId(),part.TrackId(),true,true)) excludedDaughters++;
+          else if(IsAncestorOf(p.TrackId(),part.TrackId(),true,true)) excludedDaughters++; 
         }
         std::cout << " \t " << excludedDaughters << " were of the special types" << std::endl;
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,6 +61,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
+      std::cout << sed->TrackID()  << " vs " << part.TrackId() << std::endl;
       if( -1*sed->TrackID() == part.TrackId() || sed->TrackID() == part.TrackId() ) {
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
@@ -69,7 +70,6 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     return;
   }
   void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SIDEVec_t& sIDEvec, int caloPlane){
-    
     FillParticleInfo( part, pinfo);
     for(auto& sed : sIDEvec ) {
       if( -1*sed.trackID == part.TrackId() || sed.trackID == part.TrackId() ) {

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -112,7 +112,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
 
       // We want to loop through any contiguous electrons (produced
       // with process "eIoni") and add the energy they deposit into this blip.
-      if( part.NumberDaughters() ) {
+      if( part.NumberDaughters() ) { //particles have daughters but they must all be neutron, gamma, or one of the special processes?
+        int excludedDaughters=0;
         for(size_t j=0; j<pinfo.size(); j++){
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
@@ -123,7 +124,9 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
               " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl; //literally never seems to be called?
             }
           }
+          else if(IsAncestorOf(p.TrackId(),part.TrackId(),true,true)) excludedDaughters++;
         }
+        std::cout << " \t " << excludedDaughters << " were of the special types" << std::endl;
       }
       
       // Final check -- ensure there was non-negligible number 

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,7 +105,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
-      std::cout << "Made a true blip out of " << pinfo[i].TrackID() << " with code " << pinfo[i].PdgCode() << std::endl;
+      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackID() << " with code " << pinfo[i].particle.PdgCode() << std::endl;
       if( !tb.Energy ) continue;  
 
       // We want to loop through any contiguous electrons (produced

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,7 +61,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
-      if( -1*sed.trackID() == part.TrackId() || sed.trackID() == part.TrackId() ) {
+      if( -1*sed.TrackID() == part.TrackId() || sed.TrackID() == part.TrackId() ) {
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -117,7 +117,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
               GrowTrueBlip(pinfo[j],tb);
-              std::cout << " \t growing it with " << pinfo[j].TrackID() << " with code " << pinfo[j].PdgCode() << std::endl;
+              std::cout << " \t growing it with " << pinfo[j].particle.TrackID() << " with code " << pinfo[j].particle.PdgCode() << std::endl;
             }
           }
         }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -149,7 +149,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     simb::MCParticle& part = pinfo.particle;
 
     // Skip neutrons, photons
-     if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
+    // if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
     
     // Check that path length isn't zero
     if( !pinfo.pathLength ) return;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,7 +61,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
-      if( sed->TrackID() == part.TrackId() ) {
+      if( -1*sed.trackID == part.TrackId() || sed.trackID == part.TrackId() ) {
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,7 +61,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
-      if( -1*sed.TrackID() == part.TrackId() || sed.TrackID() == part.TrackId() ) {
+      if( -1*sed->TrackID() == part.TrackId() || sed->TrackID() == part.TrackId() ) {
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -110,7 +110,6 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // We want to loop through any contiguous electrons (produced
       // with process "eIoni") and add the energy they deposit into this blip.
       if( part.NumberDaughters() ) { //particles have daughters but they must all be neutron, gamma, or one of the special processes?
-        int excludedDaughters=0;
         for(size_t j=0; j<pinfo.size(); j++){
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
@@ -119,7 +118,6 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
               GrowTrueBlip(pinfo[j],tb);
             }
           }
-          else if(IsAncestorOf(p.TrackId(),part.TrackId(),true,true)) excludedDaughters++; 
         }
       }
       

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,6 +105,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
+      std::cout << "Made a true blip out of " << pinfo[i].TrackID() << " with code " << pinfo[i].PdgCode() << std::endl;
       if( !tb.Energy ) continue;  
 
       // We want to loop through any contiguous electrons (produced
@@ -114,7 +115,10 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
           if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
-            if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ) GrowTrueBlip(pinfo[j],tb);
+            if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
+              GrowTrueBlip(pinfo[j],tb);
+              std::cout << " \t growing it with " << pinfo[j].TrackID() << " with code " << pinfo[j].PdgCode() << std::endl;
+            }
           }
         }
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,8 +61,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
-      std::cout << sed->TrackID()  << " vs " << part.TrackId() << std::endl;
       if( -1*sed->TrackID() == part.TrackId() || sed->TrackID() == part.TrackId() ) {
+        std::cout << " recording some edep information" << std::endl;
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -61,7 +61,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo){
 void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, SEDVec_t& sedvec, int caloPlane){
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
-      if( -1*sed.trackID == part.TrackId() || sed.trackID == part.TrackId() ) {
+      if( -1*sed.trackID() == part.TrackId() || sed.trackID() == part.TrackId() ) {
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,7 +105,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
-      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << std::endl;
+      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << 
+      " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl;
       if( !tb.Energy ) continue;  
 
       // We want to loop through any contiguous electrons (produced
@@ -117,7 +118,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
               GrowTrueBlip(pinfo[j],tb);
-              std::cout << " \t growing it with " << pinfo[j].particle.TrackId() << " with code " << pinfo[j].particle.PdgCode() << std::endl;
+              std::cout << " \t growing it with " << pinfo[j].particle.TrackId() << " with code " << pinfo[j].particle.PdgCode()<< 
+              " total electrons " << tb.DepElectrons << " total energy " << tb.Energy << std::endl;
             }
           }
         }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -62,7 +62,6 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     FillParticleInfo( part, pinfo);
     for(auto& sed : sedvec ) {
       if( -1*sed->TrackID() == part.TrackId() || sed->TrackID() == part.TrackId() ) {
-        std::cout << " recording some edep information" << std::endl;
         pinfo.depEnergy     += sed->Energy();
         pinfo.depElectrons  += sed->NumElectrons();
       }
@@ -114,7 +113,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
         for(size_t j=0; j<pinfo.size(); j++){
           simb::MCParticle& p = pinfo[j].particle;
           std::string pr = p.Process();
-          if( p.PdgCode() != 2112 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){
+          if( p.PdgCode() != 2112 && p.PdgCode()!=22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ) GrowTrueBlip(pinfo[j],tb);
           }
         }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -105,7 +105,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // Create the new blip
       blip::TrueBlip tb;
       GrowTrueBlip(pinfo[i],tb);
-      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackID() << " with code " << pinfo[i].particle.PdgCode() << std::endl;
+      std::cout << "Made a true blip out of " << pinfo[i].particle.TrackId() << " with code " << pinfo[i].particle.PdgCode() << std::endl;
       if( !tb.Energy ) continue;  
 
       // We want to loop through any contiguous electrons (produced
@@ -117,7 +117,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           if( p.PdgCode() != 2112 && p.PdgCode() != 22 && (pr == "eIoni" || pr == "muIoni" || pr == "hIoni") ){ //neutron and photons leave track
             if( IsAncestorOf(p.TrackId(),part.TrackId(),true,true) ){
               GrowTrueBlip(pinfo[j],tb);
-              std::cout << " \t growing it with " << pinfo[j].particle.TrackID() << " with code " << pinfo[j].particle.PdgCode() << std::endl;
+              std::cout << " \t growing it with " << pinfo[j].particle.TrackId() << " with code " << pinfo[j].particle.PdgCode() << std::endl;
             }
           }
         }

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -149,7 +149,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
     simb::MCParticle& part = pinfo.particle;
 
     // Skip neutrons, photons
-    // if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
+     if( part.PdgCode() == 2112 || part.PdgCode() == 22 ) return;
     
     // Check that path length isn't zero
     if( !pinfo.pathLength ) return;

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.cc
@@ -395,7 +395,7 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
       // use view with the maximal wire extent to calculate transverse (YZ) length
       if( hcs[i].NWires > newblip.MaxWireSpan ) {
         newblip.MaxWireSpan = hcs[i].NWires;
-	newblip.dYZ         = hcs[i].NWires * wirepitch;
+	      newblip.dYZ         = hcs[i].NWires * wirepitch;
       }
   
       for(size_t j=i+1; j<hcs.size(); j++){
@@ -409,9 +409,8 @@ void FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo, 
           intsec_p.SetY(hcs[i].IntersectLocations.find(hcs[j].ID)->second.Y());
           intsec_p.SetZ(hcs[i].IntersectLocations.find(hcs[j].ID)->second.Z());
         } else {
-	  std::vector<geo::WireID> i_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcs[i].CenterChan);
-	  std::vector<geo::WireID> j_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcs[j].CenterChan);
-
+	        std::vector<geo::WireID> i_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcs[i].CenterChan);
+	        std::vector<geo::WireID> j_wireids = wireReadoutGeom->Get().ChannelToWire((unsigned int)hcs[j].CenterChan);
           match3d = wireReadoutGeom->Get().WireIDsIntersect(i_wireids.at(0), j_wireids.at(0), intsec_p);
         }
 

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
@@ -80,7 +80,7 @@ namespace BlipUtils {
   //bool    G4IdToMCTruth( int const, art::Ptr<simb::MCTruth>&);
   double  PathLength(const simb::MCParticle&, TVector3&, TVector3&);
   double  PathLength(const simb::MCParticle&);
-  bool    IsAncestorOf(int, int, bool);
+  bool    IsAncestorOf(int, int, bool, bool);
   double  DistToBoundary(const recob::Track::Point_t&);
   double  DistToLine(TVector3&, TVector3&, TVector3&);
   double  DistToLine2D(TVector2&, TVector2&, TVector2&);

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
@@ -48,8 +48,8 @@ namespace BlipUtils {
   // Functions related to blip reconstruction
   //###################################################
   //void      InitializeDetProps();
-  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane=2);
-  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane=2);
+  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane);
+  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane);
   void      FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo);
   //void      CalcPartDrift(blip::ParticleInfo&, int);
   //void      CalcTotalDep(float&,int&,float&, SEDVec_t&);

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
@@ -49,7 +49,7 @@ namespace BlipUtils {
   //###################################################
   //void      InitializeDetProps();
   void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane);
-  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane);
+  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SIDEVec_t&, int plane);
   void      FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo);
   //void      CalcPartDrift(blip::ParticleInfo&, int);
   //void      CalcTotalDep(float&,int&,float&, SEDVec_t&);

--- a/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
+++ b/sbndcode/BlipRecoSBND/Utils/BlipUtils.h
@@ -37,8 +37,8 @@
 #include "sbndcode/BlipRecoSBND/Utils/DataTypes.h"
 #include "TH1D.h"
 
-
-typedef std::vector<sim::IDE> SEDVec_t;
+typedef std::vector<art::Ptr<sim::SimEnergyDeposit>> SEDVec_t;
+typedef std::vector<sim::IDE> SIDEVec_t;
 
 geo::View_t kViews[3]={geo::kU, geo::kV, geo::kW};
 
@@ -49,6 +49,8 @@ namespace BlipUtils {
   //###################################################
   //void      InitializeDetProps();
   void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane=2);
+  void      FillParticleInfo(simb::MCParticle const&, blip::ParticleInfo&, SEDVec_t&, int plane=2);
+  void      FillParticleInfo( const simb::MCParticle& part, blip::ParticleInfo& pinfo);
   //void      CalcPartDrift(blip::ParticleInfo&, int);
   //void      CalcTotalDep(float&,int&,float&, SEDVec_t&);
   void      MakeTrueBlips(std::vector<blip::ParticleInfo>&, std::vector<blip::TrueBlip>&); 

--- a/sbndcode/BlipRecoSBND/blipreco_configs.fcl
+++ b/sbndcode/BlipRecoSBND/blipreco_configs.fcl
@@ -8,7 +8,7 @@ sbnd_blipalg:
   HitProducer:          "specialblipgaushit"       #// input recob::Hits to use for blip reconstruction
   TrkProducer:          "blipPandoraTrackCopy"       #// input recob::Tracks to use for blip reconstruction
   GeantProducer:        "largeant"      #// input sim::MCParticles (getting true particle info)
-  SimEDepProducer:      "ionandscint"   #// input sim::SimEnergyDeposits (getting energy/electrons deposited)
+  SimEDepProducer:      "ionandscint:priorSCE:G4"   #// input sim::SimEnergyDeposits (getting energy/electrons deposited)
   SimChanProducer:      "simtpc2d:simpleSC:DetSim"      #// label for sim::SimChannels (getting drifted charge; optional)
   MaxHitTrkLength:      5.0             #// hits in trks > this length will be vetoed [cm]
   DoHitFiltering:       false           #// filter hits based on amp, width, RMS

--- a/sbndcode/BlipRecoSBND/blipreco_configs.fcl
+++ b/sbndcode/BlipRecoSBND/blipreco_configs.fcl
@@ -6,6 +6,7 @@ BEGIN_PROLOG
 sbnd_blipalg:
 {
   HitProducer:          "specialblipgaushit"       #// input recob::Hits to use for blip reconstruction
+  HitTruthMatcher:      "blipgaushitTruthMatch"    #// Truth info corresponding to the above hit collection
   TrkProducer:          "blipPandoraTrackCopy"       #// input recob::Tracks to use for blip reconstruction
   GeantProducer:        "largeant"      #// input sim::MCParticles (getting true particle info)
   SimEDepProducer:      "ionandscint:priorSCE:G4"   #// input sim::SimEnergyDeposits (getting energy/electrons deposited)


### PR DESCRIPTION
A few bugs existed in old versions of blip reco

1. Running blipreco on mostly empty event displays (somewhat common in simple MC productions of single neutrino events) would lead to empty hit collections being accessed and a subsequent memory issue/crash (Not specifically a segfault though). 
2. A few blip-related hitcluster variables were not copying quite correctly. Effected variables are blip.clusters[i].blipID, and blip.clusters[i].isMatched, which both had default values. The independently saved clusters objects were correctly updated. 
3. The MC truth PDG values for blip-energy deposits have puzzling labels and need their evaluation looked into. 

The first bug was related to a hardcoded hitHandleGH label, which looked at gaushit rather than specialBlipGausHit. On ~emtpy events the lower threshold (specialBlipGausHit) will have a few entries, but the code uses hitHandleGH for truth matching, and that higher threshold hit collection can be empty. That leads to crashes. 
For now the hardcoded label is just updated to accommodate specialBlipGausHit. 

The second bug is not critical, as access hitclusters this way is done through a blip, so the ID is the same as the blip you are looking at and the clusters included must be matched (into this blip). The hitcluster collection values are updated after the struct assignment (copy constructor), so I updated the blip alg to also update the blip.Cluster[i].blipID, and isMatched. 

The third bug I am still digging into. I was worried that the switch from sim::energy_deposition to sim::channel->IDE was causing issues, but in the new arrangement (with an optional interface to use either) gives consistent results between them. 

I have some notes I can build into slides for the first two but would like to spend a little more time on the third bug. 