### PR TITLE
updating TPC calibration tag to v4r1

### DIFF
--- a/sbndcode/Calibration/configurations/calibration_database_GlobalTags_sbnd.fcl
+++ b/sbndcode/Calibration/configurations/calibration_database_GlobalTags_sbnd.fcl
@@ -4,7 +4,7 @@
 BEGIN_PROLOG
 
 SBND_Calibration_GlobalTags: {
-  @table::TPC_CalibrationTags_Nov2025
+  @table::TPC_CalibrationTags_Jan2026
   @table::PDS_CalibrationTags_Nov2025
 }
 

--- a/sbndcode/Calibration/configurations/calibration_database_TPC_TagSets_sbnd.fcl
+++ b/sbndcode/Calibration/configurations/calibration_database_TPC_TagSets_sbnd.fcl
@@ -7,6 +7,12 @@ BEGIN_PROLOG
 ## r1: SBND Full Run 1 with light trigger, run number 18250-18618
 
 ## First one for 2025 Fall, only with etau tag
+TPC_CalibrationTags_Jan2026: {
+
+  tpc_elifetime_data: "v3r1"
+
+}
+
 TPC_CalibrationTags_Nov2025: {
 
   tpc_elifetime_data: "v2r1"

--- a/sbndcode/Calibration/configurations/calibration_database_TPC_TagSets_sbnd.fcl
+++ b/sbndcode/Calibration/configurations/calibration_database_TPC_TagSets_sbnd.fcl
@@ -9,7 +9,7 @@ BEGIN_PROLOG
 ## First one for 2025 Fall, only with etau tag
 TPC_CalibrationTags_Jan2026: {
 
-  tpc_elifetime_data: "v3r1"
+  tpc_elifetime_data: "v4r1"
 
 }
 


### PR DESCRIPTION
## Description 

Updating SBND TPC calibration tag for electron lifetime to v4r1.
[PR#10](https://github.com/SBNSoftware/sbnd_data/pull/10) in sbnd_data should be merged first for this PR.


## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

Yes, [PR#10](https://github.com/SBNSoftware/sbnd_data/pull/10) in sbnd_data.

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?

[SBN-doc-44848](https://sbn-docdb.fnal.gov/cgi-bin/sso/ShowDocument?docid=44848), page 20.