### PR TITLE
Update target dependency on sbncode PDMapAlg.

### DIFF
--- a/sbndcode/OpDetSim/CMakeLists.txt
+++ b/sbndcode/OpDetSim/CMakeLists.txt
@@ -9,7 +9,7 @@ cet_build_plugin( sbndPDMapAlg art::tool
                     lardataobj::RawData
                     lardata::DetectorInfoServices_DetectorClocksServiceStandard_service
                     larpandora::LArPandoraInterface
-                    sbncode::OpDet_PDMapAlgSimple_tool
+                    sbncode::OpDet_PDMapAlg
                     sbndcode_Utilities_SignalShapingServiceSBND_service
                     nurandom::RandomUtils_NuRandomService_service
                     art::Framework_Services_Optional_RandomNumberGenerator_service


### PR DESCRIPTION
## Description 
This PR is a companion to sbncode#651.

It changes the dependence of tool sbndPDMapAlg in directory OpDetSim to only depend on the relevant header, and not on the corresponding link library, which library wants to be private.


## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
https://github.com/sbnSoftware/sbncode/pull/651

