### PR TITLE
Channels 3048 and 4405 shorted together on May 13, 2026.  Mark them bad

### DIFF
--- a/sbndcode/Utilities/badchannels_sbnd.fcl
+++ b/sbndcode/Utilities/badchannels_sbnd.fcl
@@ -30,6 +30,8 @@ sbnd_data_badchannels_east_dead_femb: [
 #Shorted channels                                      
 sbnd_data_badchannels_west_plane0_shorted: [ 7169 ]
 sbnd_data_badchannels_west_plane1_shorted: [ 8378 ]
+sbnd_data_badchannels_east_plane1_shorted: [ 3048 ]
+sbnd_data_badchannels_east_plane2_shorted: [ 4405 ]
 
 #No response from channels
 sbnd_data_badchannels_no_response: [ 546, 607, 2781, 7166, 7167, 8574, 8395, 11147 ]

--- a/sbndcode/Utilities/channelstatus_sbnd.fcl
+++ b/sbndcode/Utilities/channelstatus_sbnd.fcl
@@ -14,6 +14,8 @@ sbnd_channelstatus: {
     @sequence::sbnd_data_badchannels_east_dead_femb,
     @sequence::sbnd_data_badchannels_west_plane0_shorted,
     @sequence::sbnd_data_badchannels_west_plane1_shorted,
+    @sequence::sbnd_data_badchannels_east_plane1_shorted,
+    @sequence::sbnd_data_badchannels_east_plane2_shorted,
     @sequence::sbnd_data_badchannels_no_response,
     @sequence::sbnd_data_badchannels_east_plane2_missing_combs,
     @sequence::sbnd_data_badchannels_west_plane2_missing_combs,

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/chndb-base.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/chndb-base.jsonnet
@@ -53,14 +53,15 @@ function(params, anode, field, n, rms_cuts=[])
     // Dead channels: 3232:3263 (inclusive) (East V).   4160:4191 (East Y)
     // Jumpered region: 4800:4805 (inclusive, East Y), 10438:10443 (inclusive, West Y)
     // No response: 546, 607, 8574
-    // Shorted channels:  7169 (West U), 8378 (West V).
+    // Channels shorted since commissioning:  7169 (West U), 8378 (West V).
+    // On May 13, 2026, these became shorted: 3048 (East V), 4405 (East Y).
     // Unresponsive channels: 546, 607, 2781, 7167, 8574, 8395, 11147
     // There are four physically missing wires ( = bad channels) due to combs, in the center of each 1/2 APA.
     // They are 4374 and 5231 (East Y), 10012 and 10869 (West Y).
     // So in total, there are 76 bad channels + 12 from jumpered region + 4 missing 
     // 
     //bad: [],
-    bad: [546, 607, 2781] + std.range(3232, 3263) + std.range(4160, 4191) + [4374, 4800, 4801, 4802, 4803, 4804, 4805, 5060, 5231, 5636, 5637, 7167, 7169, 8378, 8395, 8574, 10012, 10869, 10438, 10439, 10440, 10441, 10442, 10443, 11147],
+    bad: [546, 607, 2781, 3048] + std.range(3232, 3263) + std.range(4160, 4191) + [4374, 4405, 4800, 4801, 4802, 4803, 4804, 4805, 5060, 5231, 5636, 5637, 7167, 7169, 8378, 8395, 8574, 10012, 10869, 10438, 10439, 10440, 10441, 10442, 10443, 11147],
 
     // Overide defaults for specific channels.  If an info is
     // mentioned for a particular channel in multiple objects in this

--- a/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/chndb-perfect.jsonnet
+++ b/sbndcode/WireCell/cfg/pgrapher/experiment/sbnd/chndb-perfect.jsonnet
@@ -38,14 +38,15 @@ function(params, anode, field, n, rms_cuts=[])
     // Dead channels: 3232:3263 (inclusive) (East V).   4160:4191 (East Y)
     // Jumpered region: 4800:4805 (inclusive, East Y), 10438:10443 (inclusive, West Y)
     // No response: 546, 607, 8574
-    // Shorted channels:  7169 (West U), 8378 (West V).
+    // Channels shorted since commissioning:  7169 (West U), 8378 (West V).
+    // On May 13, 2026, these became shorted: 3048 (East V), 4405 (East Y).
     // Unresponsive channels: 546, 607, 2781, 7167, 8574, 8395, 11147
     // There are four physically missing wires ( = bad channels) due to combs, in the center of each 1/2 APA.
     // They are 4374 and 5231 (East Y), 10012 and 10869 (West Y).
     // So in total, there are 76 bad channels + 12 from jumpered region + 4 missing 
     // 
     //bad: [],
-    bad: [546, 607, 2781] + std.range(3232, 3263) + std.range(4160, 4191) + [4374, 4800, 4801, 4802, 4803, 4804, 4805, 5060, 5231, 5636, 5637, 7167, 7169, 8378, 8395, 8574, 10012, 10869, 10438, 10439, 10440, 10441, 10442, 10443, 11147],
+    bad: [546, 607, 2781, 3048] + std.range(3232, 3263) + std.range(4160, 4191) + [4374, 4405, 4800, 4801, 4802, 4803, 4804, 4805, 5060, 5231, 5636, 5637, 7167, 7169, 8378, 8395, 8574, 10012, 10869, 10438, 10439, 10440, 10441, 10442, 10443, 11147],
 
     // Overide defaults for specific channels.  If an info is
     // mentioned for a particular channel in multiple objects in this


### PR DESCRIPTION
## Description 

This is a second PR for production/sbnd-gen2.  It contains the commits of PR #931 but the branch is now based off of production/sbnd-gen2

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
PR #931 contains the same changes, but is meant to be merged into develop.

I need to make one more commit because I forgot one file.  
