### PR TITLE
Use ups version string with leading v and underscores

### DIFF
--- a/test/ci/CMakeLists.txt
+++ b/test/ci/CMakeLists.txt
@@ -51,4 +51,4 @@ install_scripts(AS_TEST)
 
 install_fhicl()
 
-install(FILES fcl_file_checks.list DESTINATION "${CMAKE_INSTALL_PREFIX}/${PROJECT_NAME}/${PROJECT_VERSION}/test")
+install(FILES fcl_file_checks.list DESTINATION "${PROJECT_NAME}/v${PROJECT_VERSION_MAJOR}_${PROJECT_VERSION_MINOR}_${PROJECT_VERSION_PATCH}}/test")


### PR DESCRIPTION
@aantonakis This should set the ups style version string for the install path of the test/ci files.