### PR TITLE
Set CableTime to 0 ns for readout cable delay

### DIFF
--- a/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
+++ b/sbndcode/OpDetSim/digi_pmt_sbnd.fcl
@@ -20,7 +20,7 @@ sbnd_digipmt_alg:
   
   # Time delays
   TTS:                   2.4        #Transit Time Spread in ns
-  CableTime:             135        #time delay of the 30 m long readout cable in ns
+  CableTime:             0        #time delay of the 30 m long readout cable in ns (not simulated not corrected)
 
   # Digitizer simulation
   PMTADCDynamicRange:    14250      #in ADC values


### PR DESCRIPTION
## Description 
PMT cable delay was being simulated but not corrected downstream, producing a time shift in the reconstructed timing objects. This PR removes the cable delay simulation.


$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{blue}\bf{\textrm{IMPORTANT UPDATE Feb 2nd 2026:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production for gen 2 SBND analyses, you must make two PRs: one for develop and one for the production/sbnd-gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [x] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [x] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
