### PR TITLE
PDS Detector Variation Module fix

### DIFF
--- a/sbndcode/Calibration/PDSDatabaseInterface/PMTCalibrationDatabaseProvider.cxx
+++ b/sbndcode/Calibration/PDSDatabaseInterface/PMTCalibrationDatabaseProvider.cxx
@@ -323,30 +323,20 @@ void sbndDB::PMTCalibrationDatabaseProvider::readPMTCalibrationDatabase(const ar
 sbndDB::PMTCalibrationDatabaseProvider::PMTCalibrationDB sbndDB::PMTCalibrationDatabaseProvider::scalePMTCalibrationData(
         const PMTCalibrationDB& db, const PMTCalibrationDBScales& scales) const
 {
-    PMTCalibrationDB result;
+    PMTCalibrationDB result = db;
 
-    // copy IDs, no modification
-    result.breakoutBox = db.breakoutBox;
-    result.caenDigitizer = db.caenDigitizer;
-    result.caenDigitizerChannel = db.caenDigitizerChannel;
-
-    // copy and scale calibrations
-    // bools: change value if set
     if (scales.onPMT) result.onPMT = scales.onPMT.value();
     if (scales.reconstructChannel) result.reconstructChannel = scales.reconstructChannel.value();
 
     // otherwise multiply
-    result.totalTransitTime = db.totalTransitTime * scales.totalTransitTime.value_or(1.0);
-    result.cosmicTimeCorrection = db.cosmicTimeCorrection * scales.cosmicTimeCorrection.value_or(1.0);
-    result.spe_amplitude = db.spe_amplitude * scales.spe_amplitude.value_or(1.0);
-    result.spe_amplitude_std = db.spe_amplitude_std * scales.spe_amplitude_std.value_or(1.0);
-    result.gauss_wc_power = db.gauss_wc_power * scales.gauss_wc_power.value_or(1.0);
-    result.gauss_wc = db.gauss_wc * scales.gauss_wc.value_or(1.0);
-    result.nonlinearity_pesat = db.nonlinearity_pesat * scales.nonlinearity_pesat.value_or(1.0);
-    result.nonlinearity_alpha = db.nonlinearity_alpha * scales.nonlinearity_alpha.value_or(1.0);
-
-    // TODO not implemented
-    result.ser = db.ser;
+    result.totalTransitTime *= scales.totalTransitTime.value_or(1.0);
+    result.cosmicTimeCorrection *= scales.cosmicTimeCorrection.value_or(1.0);
+    result.spe_amplitude *= scales.spe_amplitude.value_or(1.0);
+    result.spe_amplitude_std *= scales.spe_amplitude_std.value_or(1.0);
+    result.gauss_wc_power *= scales.gauss_wc_power.value_or(1.0);
+    result.gauss_wc *= scales.gauss_wc.value_or(1.0);
+    result.nonlinearity_pesat *= scales.nonlinearity_pesat.value_or(1.0);
+    result.nonlinearity_alpha *= scales.nonlinearity_alpha.value_or(1.0);
 
     return result;
 }

--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/pmt_variations/standard_detsim_sbnd_PMTSPEDecrease.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/pmt_variations/standard_detsim_sbnd_PMTSPEDecrease.fcl
@@ -1,9 +1,7 @@
-#include "pmtcalibrationdatabase_sbnd.fcl"
 #include "detsim_detvar_PDSonly_sbnd.fcl"
 
-services.PMTCalibrationDatabase: @local::sbnd_pmtcalibrationdatabaseservice
-services.PMTCalibrationDatabase.ApplyScales: true
-services.PMTCalibrationDatabase.Scales: [
+services.IPMTCalibrationDatabaseService.ApplyScales: true
+services.IPMTCalibrationDatabaseService.Scales: [
     {
         Channel: -1
         SPEAmplitude: 0.94

--- a/sbndcode/JobConfigurations/standard/detsim/detector_variations/pmt_variations/standard_detsim_sbnd_PMTSPEDecrease.fcl
+++ b/sbndcode/JobConfigurations/standard/detsim/detector_variations/pmt_variations/standard_detsim_sbnd_PMTSPEDecrease.fcl
@@ -1,8 +1,9 @@
+#include "pmtcalibrationdatabase_sbnd.fcl"
 #include "detsim_detvar_PDSonly_sbnd.fcl"
 
 services.PMTCalibrationDatabase: @local::sbnd_pmtcalibrationdatabaseservice
-services.PMTCalibrationDatabaseService.ApplyScales: true
-services.PMTCalibrationDatabaseService.Scales: [
+services.PMTCalibrationDatabase.ApplyScales: true
+services.PMTCalibrationDatabase.Scales: [
     {
         Channel: -1
         SPEAmplitude: 0.94

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
@@ -90,13 +90,17 @@ namespace opdet {
     }
     else if (fParams.PMTSinglePEmodel=="data"){
       //Build the average data PMT waveform for channels with uncalibrated SER
-      int dataSERSize;
+      int dataSERSize = -1;
       // Retrieve the data SER vector size from the first calibrated channel in the database
       for(size_t i=0; i<fSinglePEWave_HD.size(); i++){
         if(fPMTCalibrationDatabaseService->getReconstructChannel(i)){
           dataSERSize = fPMTCalibrationDatabaseService->getSER(i).size();
           break;
         }
+      }
+      if (dataSERSize <= 0) {
+          throw cet:exception("DigiPMTSBNDAlg")
+              << "No channel with calibrated SER found in the calibration database\n";
       }
       fAverageDataSER.resize(dataSERSize);
       fAverageDataSPEAmplitude = 0;

--- a/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
+++ b/sbndcode/OpDetSim/DigiPMTSBNDAlg.cc
@@ -99,7 +99,7 @@ namespace opdet {
         }
       }
       if (dataSERSize <= 0) {
-          throw cet:exception("DigiPMTSBNDAlg")
+          throw cet::exception("DigiPMTSBNDAlg")
               << "No channel with calibrated SER found in the calibration database\n";
       }
       fAverageDataSER.resize(dataSERSize);


### PR DESCRIPTION
## Description 

Two fixes: PMT variations explicitly copy the existing DB struct instead of applying modifications to a default struct, and we initialize a size to prevent nonsensical error messages.

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`

### Relevant PR links (optional)

The error PR#950 attempted to fix was ultimately a red herring. The real issue was an unfortunate interaction between the module code resetting all the modified PMTs and an uninitialized variable.