### PR TITLE
Adding hyperon filter for Gen2 production

### DIFF
--- a/sbndcode/Filters/fcls/run_sbnd_gen2_rare_signal_filter.fcl
+++ b/sbndcode/Filters/fcls/run_sbnd_gen2_rare_signal_filter.fcl
@@ -23,6 +23,7 @@ physics: {
         etafilter: @local::sbnd_eta_nopi0_filter
         nueccfilter: @local::sbnd_ccnue_filter
         kaonfilter: @local::sbnd_kaon_filter
+	hyperonfilter: @local::sbnd_hyperon_filter
         CCDeltaRadFilter: {
             module_type: "CCDeltaRadiative"
         }
@@ -38,8 +39,9 @@ physics: {
     kaon: [ "kaonfilter" ]
     ccdeltarad: [ "CCDeltaRadFilter" ]
     ncdeltarad: [ "NCDeltaRadFilter" ]
+    hyperon: [ "hyperonfilter" ]
 
-    trigger_paths: [ "ccpi0", "ncpi0", "eta", "nuecc", "kaon", "ccdeltarad", "ncdeltarad" ]
+    trigger_paths: [ "ccpi0", "ncpi0", "eta", "nuecc", "kaon", "ccdeltarad", "ncdeltarad", "hyperon" ]
 
     streamccpi0: [ outccpi0 ]
     streamncpi0: [ outncpi0 ]
@@ -48,7 +50,9 @@ physics: {
     streamkaon: [ outkaon ]
     streamccdeltarad: [ outccdeltarad ]
     streamncdeltarad: [ outncdeltarad ]
-    end_paths: [ streamccpi0, streamncpi0, streameta, streamnuecc, streamkaon, streamccdeltarad, streamncdeltarad ]
+    streamhyperon: [ outhyperon ]
+    end_paths: [ streamccpi0, streamncpi0, streameta, streamnuecc, streamkaon, streamhyperon, streamccdeltarad, streamncdeltarad ]
+
 }
 
 
@@ -93,5 +97,11 @@ outputs: {
     module_type: "RootOutput"
     fileName: "output_ncdeltarad.root"
     SelectEvents: [ "ncdeltarad" ]
+  }
+
+  outhyperon: {
+    module_type: "RootOutput"
+    fileName: "output_hyperon.root"
+    SelectEvents: [ "hyperon" ]
   }
 }

--- a/sbndcode/Filters/fcls/signal_filters_sbnd.fcl
+++ b/sbndcode/Filters/fcls/signal_filters_sbnd.fcl
@@ -162,4 +162,30 @@ sbnd_kaon_filter:
     ]
 }
 
+# Any hyperon (Lambda or Sigma) + anything
+sbnd_hyperon_filter:
+{
+    module_type: TrueSignalFilter
+    GENIELabel: "generator"
+    Filters: [
+        {
+            RequiredPDGs: [ 3122 ]
+            InTPC: true
+        },
+        {
+            RequiredPDGs: [ 3212 ]
+            InTPC: true
+        },
+	{
+            RequiredPDGs: [ 3112 ]
+            InTPC: true
+        },
+        {
+            RequiredPDGs: [ 3222 ]
+            InTPC: true
+        }
+    ]
+}
+
+
 END_PROLOG


### PR DESCRIPTION
## Description 
Please provide a detailed description of the changes this pull request introduces. 

Adds the `sbnd_hyperon_filter` block to `signal_filters_sbnd.fcl` and wires it up in `run_sbnd_gen2_rare_signal_filter.fcl` to enable Gen2 exclusive hyperon filtering. 

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{blue}\bf{\textrm{IMPORTANT UPDATE Feb 2nd 2026:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production for gen 2 SBND analyses, you must make two PRs: one for develop and one for the production/sbnd-gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?
No

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
N/A

~~Assigning as draft as I am still extracting neccesary filter info~~

I have confirmed that after the running the filter on a generated sample of beam + corsika + rockbox, that there are events in my output file. Below are the relevant metrics. I have also attached a file that shows the end of the art log file wth the summaries. -> [filter_end_log.txt](https://github.com/user-attachments/files/31033189/filter_end_log.txt)


**Filter Performance Metrics (Based on 11,794 generated events):**

* **Filter Efficiency:** 14 / 11,794 events (**~0.12%** retention for the hyperon stream)
* **Average CPU Time (hyperon filter module):** **~0.026** seconds / event
* **Output File Size:** 525 MB total (**~37.5 MB** / saved event)