### PR TITLE
PTB exposure accounting filter for Run2A (Gen2)

### DIFF
--- a/sbndcode/Decoders/PTB/CMakeLists.txt
+++ b/sbndcode/Decoders/PTB/CMakeLists.txt
@@ -16,6 +16,17 @@ cet_build_plugin( SBNDPTBDecoder art::module
   ROOT::Core
 )
 
+cet_build_plugin( SBNDPTBGateCountFilter art::module
+  SOURCE SBNDPTBGateCountFilter_module.cc
+  LIBRARIES
+  artdaq_core::artdaq-core_Utilities
+  art::Utilities
+  fhiclcpp::fhiclcpp
+  messagefacility::MF_MessageLogger
+  art::Framework_Core
+  ROOT::Core
+)
+
 cet_make_library(SOURCE
   SBNDPTBRawUtils.cxx
   LIBRARIES

--- a/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_config.fcl
+++ b/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_config.fcl
@@ -1,0 +1,10 @@
+BEGIN_PROLOG
+
+SBNDPTBGateCountFilterConfig: {
+      module_type: SBNDPTBGateCountFilter
+      PTBInputLabel: "ptbdecoder"
+      Verbose: 0
+}
+
+END_PROLOG
+

--- a/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_module.cc
+++ b/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_module.cc
@@ -1,0 +1,115 @@
+////////////////////////////////////////////////////////////////////////
+// Class:       SBNDPTBGateCountFilter
+// Plugin Type: art::EDFilter
+// File:        SBNDPTBGateCountFilter_module.cc
+// Purpose:     Filter events from the BNBLight stream with
+//              corrupted POT normalization data
+////////////////////////////////////////////////////////////////////////
+
+// C++ includes
+#include <iostream>
+#include <string>
+#include <vector>
+
+// art includes
+//#include "canvas/Utilities/InputTag.h"
+#include "canvas/Persistency/Common/FindOneP.h"
+#include "canvas/Persistency/Common/FindManyP.h"
+#include "canvas/Persistency/Common/Ptr.h"
+#include "art/Framework/Core/EDFilter.h" 
+#include "art/Framework/Core/ModuleMacros.h"
+#include "art/Framework/Principal/Event.h"
+#include "art/Framework/Principal/Handle.h"
+#include "art/Framework/Principal/Run.h" 
+#include "art/Framework/Principal/SubRun.h" 
+#include "fhiclcpp/ParameterSet.h" 
+#include "messagefacility/MessageLogger/MessageLogger.h"  
+#include <bitset>
+
+
+#include "sbndcode/Decoders/PTB/sbndptb.h"
+
+
+
+class SBNDPTBGateCountFilter : public art::EDFilter {
+  public:
+
+    explicit SBNDPTBGateCountFilter(fhicl::ParameterSet const & pset);
+    virtual bool filter(art::Event& evt) override;
+
+  private:
+
+    // Fhicl parameters
+    std::string fPTBInputLabel;
+    int fVerbose;
+
+    const int bnbLightHLT_id = 2; // HLT2
+    const int bnbLowLightLLT_id = 6; // HLT6
+
+    int run;
+    int subrun;
+    int event;
+  
+};
+
+
+SBNDPTBGateCountFilter::SBNDPTBGateCountFilter(fhicl::ParameterSet const & pset)
+: EDFilter(pset),
+fPTBInputLabel(pset.get<std::string>("PTBInputLabel"))
+{
+  std::cout << "SBNDPTBGateCountFilter configured with PTBInputLabel: " << fPTBInputLabel << std::endl;
+}
+
+
+bool SBNDPTBGateCountFilter::filter(art::Event & evt){
+
+  run = evt.id().run();
+  subrun = evt.id().subRun();
+  event = evt.id().event();
+
+
+  std::cout << "SBNDPTBGateCountFilter::Processing event: " << run << ":" << subrun << ":" << event << std::endl;
+
+  // Get PTB decoded data
+  art::Handle<std::vector<raw::ptb::sbndptb>> ptbHandle;
+  evt.getByLabel(fPTBInputLabel, ptbHandle);
+  if(!ptbHandle.isValid()){
+    // If the handle is not valid, thow an exception
+    throw art::Exception(art::errors::ProductNotFound)
+      << "Could not find PTB data with label: " << fPTBInputLabel << std::endl;
+  }
+  std::vector<art::Ptr<raw::ptb::sbndptb>> ptbVec;
+  art::fill_ptr_vector(ptbVec, ptbHandle);
+
+  // Loop over PTB data and check for HLT2 and HLT6 triggers
+  for (auto const& ptb : ptbVec) {
+
+      // Loop over HLT trigger words in the PTB data
+      for (unsigned i = 0; i < ptb->GetNHLTriggers(); ++i) {
+          auto const& hlt = ptb->GetHLTrigger(i);
+          int hlt_word = hlt.trigger_word;
+          uint64_t timestamp = hlt.timestamp;
+
+          std::cout << "HLT word: " << std::bitset<32>(hlt_word)
+                    << ", timestamp: " << timestamp << std::endl;
+
+          // Look for the first HLT2 (BNBLight) instance in the event
+          if (hlt_word & (1 << bnbLightHLT_id)) {
+
+              // If first HLT2 instance in the event — decision point
+              // Check if HLT6 (BNBLowLight) is also present in the same trigger word
+              bool hasHLT6 = hlt_word & (1 << bnbLowLightLLT_id);
+              std::cout << "Event " << run << ":" << subrun << ":" << event
+                        << " - first HLT2 instance"
+                        << (hasHLT6 ? ", coincident with HLT6. Filtering out." : ".")
+                        << std::endl;
+              return !hasHLT6;  // false filters out, true keeps event
+          }
+      }
+  }
+
+  return true; // return true for other data streams (i.e. not BNBLight HLT2)
+  
+}
+
+DEFINE_ART_MODULE(SBNDPTBGateCountFilter)

--- a/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_module.cc
+++ b/sbndcode/Decoders/PTB/SBNDPTBGateCountFilter_module.cc
@@ -67,8 +67,9 @@ bool SBNDPTBGateCountFilter::filter(art::Event & evt){
   subrun = evt.id().subRun();
   event = evt.id().event();
 
-
-  std::cout << "SBNDPTBGateCountFilter::Processing event: " << run << ":" << subrun << ":" << event << std::endl;
+  if(fVerbose > 1){
+    std::cout << "SBNDPTBGateCountFilter::Processing event: " << run << ":" << subrun << ":" << event << std::endl;
+  }
 
   // Get PTB decoded data
   art::Handle<std::vector<raw::ptb::sbndptb>> ptbHandle;
@@ -90,8 +91,10 @@ bool SBNDPTBGateCountFilter::filter(art::Event & evt){
           int hlt_word = hlt.trigger_word;
           uint64_t timestamp = hlt.timestamp;
 
-          std::cout << "HLT word: " << std::bitset<32>(hlt_word)
+          if(fVerbose > 1){
+            std::cout << "  HLT word: " << std::bitset<32>(hlt_word)
                     << ", timestamp: " << timestamp << std::endl;
+          }
 
           // Look for the first HLT2 (BNBLight) instance in the event
           if (hlt_word & (1 << bnbLightHLT_id)) {
@@ -99,10 +102,12 @@ bool SBNDPTBGateCountFilter::filter(art::Event & evt){
               // If first HLT2 instance in the event — decision point
               // Check if HLT6 (BNBLowLight) is also present in the same trigger word
               bool hasHLT6 = hlt_word & (1 << bnbLowLightLLT_id);
-              std::cout << "Event " << run << ":" << subrun << ":" << event
-                        << " - first HLT2 instance"
-                        << (hasHLT6 ? ", coincident with HLT6. Filtering out." : ".")
-                        << std::endl;
+
+              if( fVerbose > 0 && hasHLT6){
+                std::cout << "  FILTERING OUT Event " << run << ":" << subrun << ":" << event
+                          << " - first HLT2 instance coincident with HLT6." << std::endl;
+              }
+              
               return !hasHLT6;  // false filters out, true keeps event
           }
       }

--- a/sbndcode/Decoders/run_decoders_job_run2abnblight.fcl
+++ b/sbndcode/Decoders/run_decoders_job_run2abnblight.fcl
@@ -1,0 +1,6 @@
+#include "SBNDPTBGateCountFilter_config.fcl"
+#include "run_decoders_job.fcl"
+
+physics.filters.filterPTBGateCount: @local::SBNDPTBGateCountFilterConfig
+
+physics.dropchoppy: [@sequence::physics.dropchoppy, filterPTBGateCount]

--- a/sbndcode/Decoders/run_decoders_job_run2abnblight_nochoppy.fcl
+++ b/sbndcode/Decoders/run_decoders_job_run2abnblight_nochoppy.fcl
@@ -1,0 +1,7 @@
+#include "run_decoders_job_run2abnblight.fcl"
+
+physics.end_paths: [ stream1 ]
+
+# Stops the output of the choppy decoded file, only outputs the filtered decoded file 
+outputs.out2: @erase
+physics.stream2: @erase

--- a/sbndcode/PTBAna/PTBAnalysis_module.cc
+++ b/sbndcode/PTBAna/PTBAnalysis_module.cc
@@ -61,15 +61,17 @@ private:
   int _subrun;
   int _event;
 
-
+	// HLTs
   std::vector<uint64_t> _ptb_hlt_trigger;
   std::vector<uint64_t> _ptb_hlt_timestamp;
+	std::vector<uint32_t> _ptb_hlt_gatecount;
+	std::vector<int> _ptb_hlt_trunmask;
   std::vector<uint64_t> _ptb_hlt_unmask_timestamp;
-  std::vector<uint64_t> _ptb_llt_unmask_timestamp;
-  std::vector<int> _ptb_hlt_trunmask;
+	// LLTs
   std::vector<uint64_t> _ptb_llt_trigger;
   std::vector<uint64_t> _ptb_llt_timestamp;
   std::vector<int> _ptb_llt_trunmask;
+	std::vector<uint64_t> _ptb_llt_unmask_timestamp;
 
   std::vector<uint64_t> _ptb_chStatus_timestamp;
   std::vector<uint64_t> _ptb_chStatus_beam;
@@ -123,6 +125,7 @@ sbnd::ptb::PTBAnalysis::PTBAnalysis(fhicl::ParameterSet const& p)
       fTree->Branch("ptb_hlt_trunmask", "std::vector<int>", &_ptb_hlt_trunmask);
       fTree->Branch("ptb_hlt_timestamp", "std::vector<uint64_t>", &_ptb_hlt_timestamp);
       fTree->Branch("ptb_hlt_unmask_timestamp", "std::vector<uint64_t>", &_ptb_hlt_unmask_timestamp);
+			fTree->Branch("ptb_hlt_gatecount", "std::vector<uint32_t>", &_ptb_hlt_gatecount);
       fTree->Branch("ptb_llt_unmask_timestamp", "std::vector<uint64_t>", &_ptb_llt_unmask_timestamp);
       fTree->Branch("ptb_llt_trigger", "std::vector<uint64_t>", &_ptb_llt_trigger);
       fTree->Branch("ptb_chStatus_timestamp", "std::vector<uint64_t>", &_ptb_chStatus_timestamp);
@@ -515,6 +518,7 @@ void sbnd::ptb::PTBAnalysis::AnalysePTBs(std::vector<art::Ptr<raw::ptb::sbndptb>
   
   _ptb_hlt_trigger.resize(nHLTs);
   _ptb_hlt_timestamp.resize(nHLTs);
+	_ptb_hlt_gatecount.resize(nHLTs);
   _ptb_hlt_trunmask.resize(nHLTs);
   _ptb_hlt_unmask_timestamp.resize(nHLTs);
   
@@ -527,6 +531,7 @@ void sbnd::ptb::PTBAnalysis::AnalysePTBs(std::vector<art::Ptr<raw::ptb::sbndptb>
         {
 	  _ptb_hlt_trigger[h_i] = ptb->GetHLTrigger(i).trigger_word;
 	  _ptb_hlt_timestamp[h_i] = ptb->GetHLTrigger(i).timestamp; //Units can be found in the Decoder Module 
+		_ptb_hlt_gatecount[h_i] = ptb->GetHLTrigger(i).gate_counter;	
 	  h_i++;
 
 	  int val = ptb->GetHLTrigger(i).trigger_word;


### PR DESCRIPTION
## Description 
Mirror of #955 for Gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{blue}\bf{\textrm{IMPORTANT UPDATE Feb 2nd 2026:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production for gen 2 SBND analyses, you must make two PRs: one for develop and one for the production/sbnd-gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [ ] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [ ] Assigned at least 1 reviewer under `Reviewers`,
- [ ] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
