### PR TITLE
Change CAF maintainer reviewer in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ $${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 - [ ] Assigned at least 1 reviewer under `Reviewers`,
 - [ ] Assigned all contributers including yourself under `Assignees`
 - [ ] Linked any relevant issues under `Developement`
-- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
+- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [tjones79](https://github.com/tjones79)) as additional reviewer.
 - [ ] Does this affect the standard workflow? 
 - [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 
 


### PR DESCRIPTION
Updated the CAF maintainer reviewer assignment in the PR template.

## Description 
Please provide a detailed description of the changes this pull request introduces. 

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{blue}\bf{\textrm{IMPORTANT UPDATE Feb 2nd 2026:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production for gen 2 SBND analyses, you must make two PRs: one for develop and one for the production/sbnd-gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [yes] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [yes] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [JosiePaton](https://github.com/JosiePaton)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
