### PR TITLE
Update dCache door used by CI regression tests

### DIFF
--- a/test/ci/ci_tests.cfg
+++ b/test/ci/ci_tests.cfg
@@ -181,7 +181,7 @@ BASEFILERELPATH_SBNDCODE=sbnd/persistent/stash/ContinuousIntegration
 BASEFILEDIR_SBNDCODE=/pnfs/%(BASEFILERELPATH_SBNDCODE)s
 # - absolute path with XRootD access to dCache
 # - use XRootD port 1095 that allows unauthenticated XRootD access
-XROOTD_BASEFILEDIR_SBNDCODE=xroot://fndca1.fnal.gov:1095/pnfs/fnal.gov/usr/%(BASEFILERELPATH_SBNDCODE)s
+XROOTD_BASEFILEDIR_SBNDCODE=xroot://fndcadoor.fnal.gov:1095/pnfs/fnal.gov/usr/%(BASEFILERELPATH_SBNDCODE)s
 # - the subdirectory hosting the selected input and reference, and the full paths (both POSIX and XRootD)
 # NOTE: the configuration value 'INPUTFILEDIR_SBNDCODE' is also used in the C.I. test workflow:
 #       its name must not be changed!


### PR DESCRIPTION
## Description 
Update dCache door used by CI regression tests to access input/references from dCache.
fndca1 door is being decommissioned in favor of fndcadoor that has been in use since a while now.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

$${\color{blue}\bf{\textrm{IMPORTANT UPDATE Feb 2nd 2026:}}}$$  If you are making a PR which is intended as a patch for the CURRENT production for gen 2 SBND analyses, you must make two PRs: one for develop and one for the production/sbnd-gen2 branch.

$${\color{blue}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!}$$

## Checklist
- [x] Added at least 1 label from [available labels](https://github.com/SBNSoftware/sbndcode/issues/labels?sort=name-asc).
- [x] Assigned at least 1 reviewer under `Reviewers`,
- [x] Assigned all contributers including yourself under `Assignees`
- [ ] Linked any relevant issues under `Developement`
- [ ] Does this PR affect CAF data format? If so, please assign a CAF maintainer ([PetrilloAtWork](https://github.com/PetrilloAtWork) or [tjones79](https://github.com/tjones79)) as additional reviewer.
- [ ] Does this affect the standard workflow? 
- [ ] Is this PR a patch for the ongoing production? If so, separate PR must also be made for production/v10_06_00 branch! 

### Relevant PR links (optional)
Does this PR require merging another PR in a different repository (such as sbnanobj/sbnobj etc.)?

### Link(s) to docdb describing changes (optional)
Is there a docdb describing the issue this solves or the feature added?
